### PR TITLE
Fix task quality: fault injection, pager, answer-giving hints, RHEL 10 refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+$ cat /home/user/rhcsa-simulator/CLAUDE.md
+
+# RHCSA Exam Simulator
+
+RHCSA EX200 v10 exam simulator for Red Hat Enterprise Linux. Generates tasks, validates system configuration, tracks progress.
+
+## Running the Simulator
+
+```bash
+# Must run as root (uses sudo internally)
+sudo python3 rhcsa_simulator.py
+
+# Common flags
+python3 rhcsa_simulator.py --quick          # 5 random tasks
+python3 rhcsa_simulator.py --exam           # Full exam (15-20 tasks)
+python3 rhcsa_simulator.py --practice       # Practice by category
+python3 rhcsa_simulator.py --learn          # Study mode
+```
+
+## Running Tests
+
+```bash
+pytest                          # Run all tests
+pytest tests/                   # Test suite
+pytest test_boot_tasks.py       # Boot/reboot task tests
+python3 -m pytest -v            # Verbose output
+```
+
+## Project Structure
+
+- `rhcsa_simulator.py` — Main entry point
+- `core/` — Engine: task manager, exam loop, SM-2 spaced repetition, ResultsDB
+- `tasks/` — Task definitions (198 tasks, 27 categories, 9 domains)
+- `validators/` — Safe read-only system validators for each task type
+- `utils/` — AI feedback, progress reports, device detection
+- `config/` — Settings and constants
+- `data/` — SQLite progress DB, bookmarks
+- `device/` — Loop device / practice disk setup
+
+## Key Facts
+
+- **Target OS**: RHEL 10 / Rocky Linux 9-10 / AlmaLinux 9-10
+- **Requires root** — many validators run real system commands
+- **No internet needed** — fully offline; optional Claude AI feedback via `ANTHROPIC_API_KEY`
+- **Loop devices** — LVM tasks can use virtual disks (option 13 in menu) when no spare disk exists
+
+## Testing on This VM
+
+This container may lack real systemd, SELinux enforcement, and firewalld. Tests that validate actual system state will fail here. For realistic testing:
+
+1. Use a RHEL/Rocky Linux 9+ VM
+2. Run as root
+3. Set up a loop device for LVM tasks: `python3 rhcsa_simulator.py` → option 13
+
+## AI Feedback Setup
+
+Set `ANTHROPIC_API_KEY` env var to enable line-by-line command analysis. See `AI_SETUP.md`.
+
+## Branch
+
+Active development: `claude/deploy-vm-rhel-exam-sk7q5b`

--- a/core/practice.py
+++ b/core/practice.py
@@ -54,7 +54,37 @@ class PracticeSession:
             return
 
         label = " [no-reboot mode]" if self.skip_reboot else ""
-        print(fmt.info(f"\nStarting {len(tasks)}-task practice session{label}"))
+
+        # Preview tasks before setting anything up — let user reshuffle if needed
+        while True:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                print(fmt.bold(f"\nTask Preview — {len(tasks)}-task session{label}"))
+                print("=" * 60)
+                for i, t in enumerate(tasks, 1):
+                    needs_setup = getattr(t, 'has_fault_injection', False)
+                    setup_tag = fmt.dim("  [auto-setup]") if needs_setup else ""
+                    print(f"  {i:2d}. {fmt.bold(t.description.splitlines()[0][:55])}"
+                          f"  ({t.points}pts){setup_tag}")
+                print()
+                print("S - Start session  R - Reshuffle tasks  Q - Back to menu")
+            fmt.page_output(buf.getvalue())
+
+            choice = input("Choice [S]: ").strip().lower() or 's'
+            if choice == 'q':
+                return
+            if choice == 'r':
+                tasks = TaskRegistry.get_practice_tasks(
+                    self.category, self.difficulty, self.task_count,
+                    skip_reboot=self.skip_reboot,
+                )
+                if not tasks:
+                    print(fmt.error("No tasks available."))
+                    return
+                continue
+            break  # 's' or Enter
+
+        print(fmt.info(f"\nStarting session…"))
 
         # Practice each task
         try:

--- a/core/practice.py
+++ b/core/practice.py
@@ -8,7 +8,9 @@ Features:
 - Retry with solution hints
 """
 
+import io
 import logging
+from contextlib import redirect_stdout
 from tasks.registry import TaskRegistry
 from core.validator import get_validator
 from core.results_db import get_results_db
@@ -157,33 +159,36 @@ class PracticeSession:
         stop_requested = False
         while True:
             fmt.clear_screen()
-            print(f"Practice Task {current}/{total}" + (f" (Attempt {attempt})" if attempt > 1 else ""))
-            print("=" * 60)
-            print()
 
-            # Display task with domain info
-            print(fmt.bold("Task:"))
-            print(task.description)
-            print()
-            print(fmt.bold(f"Category: {fmt.format_category_name(task.category)}"))
-            domain = getattr(task, 'exam_domain', 0)
-            domain_name = settings.EXAM_DOMAINS.get(domain, "")
-            if domain_name:
-                print(fmt.bold(f"Domain: {domain} - {domain_name}"))
-            print(fmt.bold(f"Points: {task.points}"))
-            print(fmt.bold(f"Difficulty: {fmt.format_difficulty(task.difficulty)}"))
-            persistence = getattr(task, 'requires_persistence', False)
-            if persistence:
-                print(fmt.info("  Requires persistence (survives reboot)"))
-            print()
+            # Build the task display into a buffer so we can page it
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                print(f"Practice Task {current}/{total}" + (f" (Attempt {attempt})" if attempt > 1 else ""))
+                print("=" * 60)
+                print()
 
-            # Show hints
-            if task.hints and confirm_action("Show hints?", default=False):
+                print(fmt.bold("Task:"))
+                print(task.description)
                 print()
-                print(fmt.bold("Hints:"))
-                for i, hint in enumerate(task.hints, 1):
-                    print(f"  {i}. {hint}")
+                print(fmt.bold(f"Category: {fmt.format_category_name(task.category)}"))
+                domain = getattr(task, 'exam_domain', 0)
+                domain_name = settings.EXAM_DOMAINS.get(domain, "")
+                if domain_name:
+                    print(fmt.bold(f"Domain: {domain} - {domain_name}"))
+                print(fmt.bold(f"Points: {task.points}"))
+                print(fmt.bold(f"Difficulty: {fmt.format_difficulty(task.difficulty)}"))
+                persistence = getattr(task, 'requires_persistence', False)
+                if persistence:
+                    print(fmt.info("  Requires persistence (survives reboot)"))
                 print()
+
+                if task.hints:
+                    print(fmt.bold("Hints:"))
+                    for i, hint in enumerate(task.hints, 1):
+                        print(f"  {i}. {hint}")
+                    print()
+
+            fmt.page_output(buf.getvalue())
 
             input("Complete this task on your system, then press Enter to validate...")
 
@@ -191,23 +196,33 @@ class PracticeSession:
             validator = get_validator()
             result = validator.validate_task(task)
 
-            # Display result
-            print()
-            print(fmt.bold("Validation Results:"))
-            print("=" * 60)
-            for check in result.checks:
-                fmt.print_check_result(
-                    check.name,
-                    check.passed,
-                    check.message,
-                    check.points,
-                    check.max_points
-                )
-                if not check.passed:
-                    self._show_fix_suggestion(check, task)
+            # Build result + exam tips into a buffer, then page it
+            rbuf = io.StringIO()
+            with redirect_stdout(rbuf):
+                print()
+                print(fmt.bold("Validation Results:"))
+                print("=" * 60)
+                for check in result.checks:
+                    fmt.print_check_result(
+                        check.name,
+                        check.passed,
+                        check.message,
+                        check.points,
+                        check.max_points
+                    )
+                    if not check.passed:
+                        self._show_fix_suggestion(check, task)
+                print("=" * 60)
+                fmt.print_result_summary(result.passed, result.score, result.max_score, result.percentage)
 
-            print("=" * 60)
-            fmt.print_result_summary(result.passed, result.score, result.max_score, result.percentage)
+                exam_tips = getattr(task, 'exam_tips', [])
+                if exam_tips:
+                    print()
+                    print(fmt.bold("Exam Tips:"))
+                    for tip in exam_tips:
+                        print(f"  * {tip}")
+
+            fmt.page_output(rbuf.getvalue())
 
             # Save to ResultsDB (triggers SM-2 update)
             db.save_practice_attempt(
@@ -220,14 +235,6 @@ class PracticeSession:
                 passed=result.passed,
                 mode='practice'
             )
-
-            # Show exam tips
-            exam_tips = getattr(task, 'exam_tips', [])
-            if exam_tips:
-                print()
-                print(fmt.bold("Exam Tips:"))
-                for tip in exam_tips:
-                    print(f"  * {tip}")
 
             if not result.passed:
                 print()

--- a/tasks/boot.py
+++ b/tasks/boot.py
@@ -434,7 +434,45 @@ class RemoveKernelParameterTask(BaseTask):
 # ---------------------------------------------------------------------------
 @TaskRegistry.register("boot")
 class BootTroubleshootingTask(BaseTask):
-    """Composite boot troubleshooting scenario combining target + GRUB + parameter fixes."""
+    """
+    Fault-injection: sets an incorrect default target, wrong GRUB timeout,
+    and removes/adds a kernel param so the system is misconfigured.
+    User must diagnose and fix all three issues.
+    """
+
+    has_fault_injection = True
+
+    # Maps scenario → what to INJECT (the broken state)
+    # target=what we set wrong, timeout=wrong value, param=wrong param state
+    _SCENARIOS = [
+        {
+            'symptom': 'System is configured to boot to text mode but the requirement is a GUI (graphical.target)',
+            'correct_target': 'graphical.target',
+            'inject_target': 'multi-user.target',
+            'correct_timeout': random.choice([5, 10]),
+            'inject_timeout': 0,
+            'add_param': 'rhgb',        # ensure this IS in cmdline
+            'remove_param': None,
+        },
+        {
+            'symptom': 'System is configured to boot to a full GUI but should run as a text-mode server (multi-user.target)',
+            'correct_target': 'multi-user.target',
+            'inject_target': 'graphical.target',
+            'correct_timeout': random.choice([3, 5]),
+            'inject_timeout': 10,
+            'add_param': None,
+            'remove_param': 'rhgb',     # ensure rhgb is NOT in cmdline
+        },
+        {
+            'symptom': 'Boot timeout is set to 0 (no menu) and audit logging is disabled',
+            'correct_target': 'multi-user.target',
+            'inject_target': 'multi-user.target',
+            'correct_timeout': random.choice([5, 10]),
+            'inject_timeout': 0,
+            'add_param': 'audit=1',
+            'remove_param': None,
+        },
+    ]
 
     def __init__(self):
         super().__init__(
@@ -444,63 +482,116 @@ class BootTroubleshootingTask(BaseTask):
             points=15
         )
         self.requires_persistence = True
-        self.tags = ["troubleshooting", "grub", "systemd", "exam-scenario"]
+        self.tags = ["troubleshooting", "grub", "systemd", "exam-scenario", "fault-injection"]
         self.exam_tips = [
-            "Always verify ALL changes: systemctl get-default, grep /etc/default/grub, grubby --info=DEFAULT.",
-            "If asked to regenerate GRUB config, remember BIOS vs UEFI paths differ.",
+            "Verify ALL changes: systemctl get-default, grep TIMEOUT /etc/default/grub, grubby --info=DEFAULT",
+            "grub2-mkconfig regenerates the GRUB binary config from /etc/default/grub.",
+            "BIOS path: /boot/grub2/grub.cfg   EFI path: /boot/efi/EFI/redhat/grub.cfg",
         ]
+        self._scenario = None
         self.target = None
         self.timeout = None
         self.extra_param = None
 
     def generate(self, **params):
-        """Generate boot troubleshooting task."""
-        scenarios = [
-            {
-                'desc': 'System boots to graphical target but must boot to text mode',
-                'target': 'multi-user.target',
-                'timeout': random.choice([3, 5, 8]),
-                'extra_param': 'quiet',
-            },
-            {
-                'desc': 'System boots to text mode but must provide a GUI',
-                'target': 'graphical.target',
-                'timeout': random.choice([5, 10, 15]),
-                'extra_param': 'rhgb',
-            },
-            {
-                'desc': 'System boots with no timeout and auditing disabled',
-                'target': 'multi-user.target',
-                'timeout': random.choice([5, 10]),
-                'extra_param': 'audit=1',
-            },
-        ]
-
-        scenario = params.get('scenario', random.choice(scenarios))
-        self.target = scenario['target']
-        self.timeout = scenario['timeout']
-        self.extra_param = scenario.get('extra_param', 'quiet')
+        self._scenario = params.get('scenario', random.choice(self._SCENARIOS))
+        self.target = self._scenario['correct_target']
+        self.timeout = self._scenario['correct_timeout']
+        self.extra_param = self._scenario.get('add_param') or self._scenario.get('remove_param')
 
         self.description = (
-            f"Boot Troubleshooting Scenario:\n"
-            f"  Problem: {scenario['desc']}\n"
-            f"\n"
-            f"  Required fixes:\n"
-            f"  1. Set default target to: {self.target}\n"
-            f"  2. Set GRUB timeout to: {self.timeout} seconds\n"
-            f"  3. Ensure '{self.extra_param}' is in the kernel command line\n"
-            f"  4. Regenerate the GRUB configuration\n"
+            f"Boot Configuration Problem:\n"
+            f"  Symptom: {self._scenario['symptom']}\n\n"
+            f"  The system has been misconfigured. Diagnose and fix the boot\n"
+            f"  settings so the system boots correctly.\n\n"
+            f"  Required end state:\n"
+            f"  - Default target: {self.target}\n"
+            f"  - GRUB timeout: {self.timeout} seconds\n"
             f"  - All changes must persist across reboots"
         )
-
         self.hints = [
-            f"systemctl set-default {self.target}",
-            f"Edit /etc/default/grub: GRUB_TIMEOUT={self.timeout}",
-            f"Ensure '{self.extra_param}' appears in GRUB_CMDLINE_LINUX",
-            "Run grub2-mkconfig -o /boot/grub2/grub.cfg",
+            "Check current default target: systemctl get-default",
+            "Check GRUB settings: cat /etc/default/grub",
+            "Check kernel parameters: grubby --info=DEFAULT | grep args",
+            "After editing /etc/default/grub: run grub2-mkconfig",
         ]
-
         return self
+
+    def inject_fault(self):
+        import subprocess as _sp
+        s = self._scenario
+
+        # Save current state
+        cur_target = _sp.run(['systemctl', 'get-default'], capture_output=True, text=True).stdout.strip()
+        r = _sp.run(['grep', 'GRUB_TIMEOUT=', '/etc/default/grub'], capture_output=True, text=True)
+        cur_timeout_line = r.stdout.strip() if r.returncode == 0 else ''
+
+        # Set wrong target
+        _sp.run(['systemctl', 'set-default', s['inject_target']], capture_output=True)
+
+        # Set wrong timeout in /etc/default/grub
+        with open('/etc/default/grub') as f:
+            grub_content = f.read()
+        import re
+        grub_content = re.sub(r'GRUB_TIMEOUT=\S+', f"GRUB_TIMEOUT={s['inject_timeout']}", grub_content)
+        with open('/etc/default/grub', 'w') as f:
+            f.write(grub_content)
+
+        # Manipulate kernel parameter
+        if s.get('add_param'):
+            _sp.run(['grubby', '--args', s['add_param'], '--update-kernel=ALL'], capture_output=True)
+        if s.get('remove_param'):
+            _sp.run(['grubby', '--remove-args', s['remove_param'], '--update-kernel=ALL'], capture_output=True)
+
+        # Regenerate GRUB so the injected state is applied
+        grub_cfg = '/boot/efi/EFI/redhat/grub.cfg'
+        if not os.path.exists(grub_cfg):
+            grub_cfg = '/boot/grub2/grub.cfg'
+        _sp.run(['grub2-mkconfig', '-o', grub_cfg], capture_output=True)
+
+        from tasks.troubleshooting import save_fault_state
+        save_fault_state(self.id, {
+            'orig_target': cur_target,
+            'orig_timeout_line': cur_timeout_line,
+            'added_param': s.get('add_param'),
+            'removed_param': s.get('remove_param'),
+            'grub_cfg': grub_cfg,
+        })
+        return True, (f"Set target→{s['inject_target']}, timeout→{s['inject_timeout']}, "
+                      f"kernel param changes applied")
+
+    def restore_fault(self):
+        import subprocess as _sp
+        import re
+        from tasks.troubleshooting import load_fault_state, clear_fault_state
+
+        state = load_fault_state()
+        info = state.get('restore_info', {}) if state else {}
+        orig_target = info.get('orig_target', 'multi-user.target')
+        orig_timeout_line = info.get('orig_timeout_line', 'GRUB_TIMEOUT=5')
+        added_param = info.get('added_param')
+        removed_param = info.get('removed_param')
+        grub_cfg = info.get('grub_cfg', '/boot/grub2/grub.cfg')
+
+        _sp.run(['systemctl', 'set-default', orig_target], capture_output=True)
+
+        with open('/etc/default/grub') as f:
+            content = f.read()
+        if orig_timeout_line:
+            content = re.sub(r'GRUB_TIMEOUT=\S+', orig_timeout_line.replace('GRUB_TIMEOUT=', 'GRUB_TIMEOUT=').split('=', 1)[1], content)
+            # simpler: just restore the whole line
+            content = re.sub(r'GRUB_TIMEOUT=\S+', orig_timeout_line, content)
+        with open('/etc/default/grub', 'w') as f:
+            f.write(content)
+
+        if added_param:
+            _sp.run(['grubby', '--remove-args', added_param, '--update-kernel=ALL'], capture_output=True)
+        if removed_param:
+            _sp.run(['grubby', '--args', removed_param, '--update-kernel=ALL'], capture_output=True)
+
+        _sp.run(['grub2-mkconfig', '-o', grub_cfg], capture_output=True)
+        clear_fault_state()
+        return True, "Restored original boot configuration"
 
     def validate(self):
         """Validate boot troubleshooting solution."""

--- a/tasks/boot.py
+++ b/tasks/boot.py
@@ -314,7 +314,17 @@ class AddKernelParameterTask(BaseTask):
 # ---------------------------------------------------------------------------
 @TaskRegistry.register("boot")
 class RemoveKernelParameterTask(BaseTask):
-    """Remove a kernel boot parameter from GRUB."""
+    """
+    Fault-injection: injects a kernel parameter via grubby so it is
+    guaranteed to be present; user must remove it.
+    Uses only params that are NOT on a clean RHEL 10 kernel cmdline
+    to avoid double-injecting parameters that are already there.
+    """
+
+    has_fault_injection = True
+
+    # These are NOT present on a default RHEL 10 kernel cmdline
+    _INJECTABLE_PARAMS = ['nofb', 'audit=0', 'biosdevname=0', 'nosplash']
 
     def __init__(self):
         super().__init__(
@@ -325,40 +335,51 @@ class RemoveKernelParameterTask(BaseTask):
         )
         self.requires_persistence = True
         self.requires_reboot = True
-        self.tags = ["grub", "kernel", "grubby", "boot-parameter"]
+        self.tags = ["grub", "kernel", "grubby", "boot-parameter", "fault-injection"]
         self.exam_tips = [
             "grubby --remove-args='<param>' --update-kernel=ALL is the fastest way.",
             "Be careful when editing GRUB_CMDLINE_LINUX not to break the quoting.",
+            "Verify removal: grubby --info=DEFAULT | grep args",
         ]
         self.parameter = None
 
     def generate(self, **params):
-        """Generate kernel parameter removal task."""
-        parameters = [
-            'quiet', 'rhgb', 'splash', 'nofb',
-            'audit=1', 'biosdevname=0',
-        ]
-        self.parameter = params.get('parameter', random.choice(parameters))
+        self.parameter = params.get('parameter', random.choice(self._INJECTABLE_PARAMS))
 
         self.description = (
             f"Configure kernel boot parameters:\n"
-            f"  - Remove '{self.parameter}' from the kernel command line\n"
+            f"  - The parameter '{self.parameter}' has been added to the kernel command line\n"
+            f"  - Remove it so it will not be present at next boot\n"
             f"  - You may use grubby --remove-args or edit /etc/default/grub\n"
-            f"  - If editing /etc/default/grub, regenerate the GRUB config\n"
-            f"  - Changes must persist across reboots"
+            f"  - If editing /etc/default/grub, regenerate the GRUB config afterwards"
         )
-
         self.hints = [
-            f"Method 1: grubby --remove-args='{self.parameter}' --update-kernel=ALL",
-            "Method 2: Edit /etc/default/grub and remove from GRUB_CMDLINE_LINUX",
-            "Run 'grub2-mkconfig -o /boot/grub2/grub.cfg' if using method 2",
+            f"Method 1 (faster): grubby --remove-args='{self.parameter}' --update-kernel=ALL",
+            "Method 2: Edit /etc/default/grub, remove from GRUB_CMDLINE_LINUX",
+            "  Then: grub2-mkconfig -o /boot/grub2/grub.cfg",
             "Verify: grubby --info=DEFAULT | grep args",
         ]
-
         return self
 
+    def inject_fault(self):
+        import subprocess as _sp
+        param = self.parameter
+        r = _sp.run(['grubby', '--args', param, '--update-kernel=ALL'], capture_output=True)
+        if r.returncode != 0:
+            return False, f"grubby failed: {r.stderr.decode().strip()}"
+        from tasks.troubleshooting import save_fault_state
+        save_fault_state(self.id, {'parameter': param})
+        return True, f"Added kernel parameter '{param}' via grubby"
+
+    def restore_fault(self):
+        import subprocess as _sp
+        param = self.parameter
+        _sp.run(['grubby', '--remove-args', param, '--update-kernel=ALL'], capture_output=True)
+        from tasks.troubleshooting import clear_fault_state
+        clear_fault_state()
+        return True, f"Removed kernel parameter '{param}'"
+
     def validate(self):
-        """Validate kernel parameter is removed."""
         checks = []
         total_points = 0
 
@@ -368,7 +389,7 @@ class RemoveKernelParameterTask(BaseTask):
         else:
             param_exists = validate_grub_parameter(self.parameter)
 
-        # Check 1: Parameter removed from GRUB_CMDLINE_LINUX (6 points)
+        # Check 1: Parameter removed (6 pts)
         if not param_exists:
             checks.append(ValidationCheck(
                 name="kernel_param_removed",
@@ -383,10 +404,10 @@ class RemoveKernelParameterTask(BaseTask):
                 passed=False,
                 points=0,
                 max_points=6,
-                message=f"Parameter '{self.parameter}' is still present in GRUB_CMDLINE_LINUX"
+                message=f"Parameter '{self.parameter}' is still in the kernel cmdline"
             ))
 
-        # Check 2: GRUB config regenerated (4 points)
+        # Check 2: GRUB config regenerated (4 pts)
         if is_grub_config_updated():
             checks.append(ValidationCheck(
                 name="grub_config_regenerated",
@@ -401,7 +422,7 @@ class RemoveKernelParameterTask(BaseTask):
                 passed=False,
                 points=0,
                 max_points=4,
-                message="GRUB configuration needs to be regenerated"
+                message="GRUB config not yet regenerated (run grub2-mkconfig or use grubby)"
             ))
 
         passed = total_points >= (self.points * 0.6)

--- a/tasks/boot.py
+++ b/tasks/boot.py
@@ -575,7 +575,19 @@ class BootTroubleshootingTask(BaseTask):
 # ---------------------------------------------------------------------------
 @TaskRegistry.register("boot")
 class ValidateFstabTask(BaseTask):
-    """Validate and correct /etc/fstab so the system boots cleanly."""
+    """
+    Fault-injection fstab task.
+
+    inject_fault() adds two broken entries:
+      1. A non-existent UUID — must be removed entirely.
+      2. A /backup entry missing 'nofail' — must have nofail added so a
+         missing device doesn't hang the boot sequence.
+    """
+
+    BAD_UUID_MARKER  = 'RHCSA-FAULT-FSTAB-BADUID'
+    NOFAIL_MARKER    = 'RHCSA-FAULT-FSTAB-NOFAIL'
+    NOFAIL_MOUNTPOINT = '/backup'
+    has_fault_injection = True
 
     def __init__(self):
         super().__init__(
@@ -585,160 +597,134 @@ class ValidateFstabTask(BaseTask):
             points=12
         )
         self.requires_persistence = True
-        self.tags = ["fstab", "boot", "troubleshooting", "exam-scenario"]
+        self.tags = ["fstab", "boot", "troubleshooting", "fault-injection"]
         self.exam_tips = [
             "A broken fstab WILL prevent boot and cost you the entire exam.",
             "Always run 'findmnt --verify' and 'mount -a' BEFORE rebooting.",
-            "Use 'nofail' mount option for non-critical filesystems.",
+            "'nofail' lets the system boot even when an optional device is absent.",
         ]
-        self.nofail_mount = None
 
     def generate(self, **params):
-        """Generate fstab validation task."""
-        mount_points = [
-            '/data', '/backup', '/shared', '/opt/appdata',
-            '/srv/content', '/mnt/external',
-        ]
-        self.nofail_mount = params.get('nofail_mount', random.choice(mount_points))
-
         self.description = (
-            f"Validate and ensure the /etc/fstab configuration is correct:\n"
-            f"\n"
-            f"  1. Run 'findmnt --verify' to check for fstab syntax errors\n"
-            f"  2. Ensure there are no invalid entries that would block boot\n"
-            f"  3. Run 'mount -a' to verify all entries can be mounted\n"
-            f"  4. If there is an entry for {self.nofail_mount}, ensure it uses\n"
-            f"     the 'nofail' mount option so a missing device won't block boot\n"
-            f"\n"
-            f"  IMPORTANT: A broken fstab can prevent system boot!"
+            "TROUBLESHOOTING: /etc/fstab Has Boot-Blocking Errors\n"
+            "=" * 50 + "\n\n"
+            "Two problems have been injected into /etc/fstab:\n\n"
+            "  Problem 1 — An entry references a UUID that does not exist.\n"
+            "    Symptom: 'mount -a' fails; system may drop to emergency shell.\n"
+            "    Fix: identify and remove the bad entry.\n\n"
+            f"  Problem 2 — {self.NOFAIL_MOUNTPOINT} is in fstab without 'nofail'.\n"
+            "    Symptom: if the device is absent at boot, boot hangs.\n"
+            "    Fix: add 'nofail' to its mount options.\n\n"
+            "Tasks:\n"
+            "  1. Run 'findmnt --verify' to identify the bad entries\n"
+            "  2. Remove the non-existent UUID entry\n"
+            f"  3. Add 'nofail' to the {self.NOFAIL_MOUNTPOINT} entry\n"
+            "  4. Verify 'mount -a' completes without errors"
         )
-
         self.hints = [
-            "'findmnt --verify' checks fstab syntax without mounting anything",
-            "'findmnt --verify --verbose' shows detailed validation output",
-            "'mount -a' attempts to mount all fstab entries",
-            "Add 'nofail' option to prevent boot failure from missing devices",
-            "Check that all device paths or UUIDs in fstab actually exist",
+            "'findmnt --verify' shows which entries are invalid",
+            "Remove the bad UUID line entirely — it references a device that doesn't exist",
+            f"Edit the {self.NOFAIL_MOUNTPOINT} line: change 'defaults' to 'defaults,nofail'",
+            "'mount -a' should return exit code 0 when fstab is clean",
         ]
-
         return self
 
-    def validate(self):
-        """Validate fstab is correct and bootable."""
-        checks = []
-        total_points = 0
+    def inject_fault(self):
+        import subprocess as _sp
+        os.makedirs(self.NOFAIL_MOUNTPOINT, exist_ok=True)
 
-        # Check 1: fstab file exists (2 points)
-        if os.path.exists('/etc/fstab'):
-            checks.append(ValidationCheck(
-                name="fstab_exists",
-                passed=True,
-                points=2,
-                message="/etc/fstab exists"
-            ))
-            total_points += 2
-        else:
-            checks.append(ValidationCheck(
-                name="fstab_exists",
-                passed=False,
-                points=0,
-                max_points=2,
-                message="/etc/fstab not found - critical error!"
-            ))
-            return ValidationResult(self.id, False, 0, self.points, checks)
+        entries = (
+            f"UUID=00000000-dead-beef-0000-badbadbad00 /mnt/nonexistent xfs defaults 0 2"
+            f"  # {self.BAD_UUID_MARKER}\n"
+            f"/dev/sdZ99 {self.NOFAIL_MOUNTPOINT} xfs defaults 0 0"
+            f"  # {self.NOFAIL_MARKER}\n"
+        )
+        with open('/etc/fstab', 'a') as f:
+            f.write(entries)
 
-        # Check 2: findmnt --verify passes (4 points)
-        result = execute_safe(['findmnt', '--verify'])
-        if result.success:
-            checks.append(ValidationCheck(
-                name="fstab_syntax_valid",
-                passed=True,
-                points=4,
-                message="fstab syntax is valid (findmnt --verify passed)"
-            ))
-            total_points += 4
-        else:
-            checks.append(ValidationCheck(
-                name="fstab_syntax_valid",
-                passed=False,
-                points=0,
-                max_points=4,
-                message=f"fstab has errors: {result.stderr or result.stdout}"
-            ))
+        from tasks.troubleshooting import save_fault_state
+        save_fault_state(self.id, {
+            'bad_uuid_marker': self.BAD_UUID_MARKER,
+            'nofail_marker': self.NOFAIL_MARKER,
+        })
+        return True, "Added bad UUID entry and nofail-missing /backup entry to /etc/fstab"
 
-        # Check 3: mount -a succeeds (4 points)
-        result = execute_safe(['mount', '-a'])
-        if result.success:
-            checks.append(ValidationCheck(
-                name="mount_all_succeeds",
-                passed=True,
-                points=4,
-                message="All fstab entries can be mounted (mount -a passed)"
-            ))
-            total_points += 4
-        else:
-            checks.append(ValidationCheck(
-                name="mount_all_succeeds",
-                passed=False,
-                points=0,
-                max_points=4,
-                message=f"mount -a failed: {result.stderr}"
-            ))
-
-        # Check 4: nofail option on non-critical mount (2 points)
+    def restore_fault(self):
         try:
-            with open('/etc/fstab', 'r') as f:
-                fstab_content = f.read()
-            # Look for the mount point line and check for nofail
-            nofail_ok = False
-            mount_found = False
-            for line in fstab_content.splitlines():
-                stripped = line.strip()
-                if stripped.startswith('#') or not stripped:
-                    continue
-                parts = stripped.split()
-                if len(parts) >= 4 and parts[1] == self.nofail_mount:
-                    mount_found = True
-                    if 'nofail' in parts[3]:
-                        nofail_ok = True
-                    break
-
-            if mount_found and nofail_ok:
-                checks.append(ValidationCheck(
-                    name="nofail_option",
-                    passed=True,
-                    points=2,
-                    message=f"'{self.nofail_mount}' has nofail option set"
-                ))
-                total_points += 2
-            elif mount_found:
-                checks.append(ValidationCheck(
-                    name="nofail_option",
-                    passed=False,
-                    points=0,
-                    max_points=2,
-                    message=f"'{self.nofail_mount}' is in fstab but lacks the 'nofail' option"
-                ))
-            else:
-                # Mount point not in fstab - award points (not blocking boot)
-                checks.append(ValidationCheck(
-                    name="nofail_option",
-                    passed=True,
-                    points=2,
-                    message=f"'{self.nofail_mount}' is not in fstab (no boot risk)"
-                ))
-                total_points += 2
+            with open('/etc/fstab') as f:
+                lines = f.readlines()
+            cleaned = [l for l in lines
+                       if self.BAD_UUID_MARKER not in l and self.NOFAIL_MARKER not in l]
+            with open('/etc/fstab', 'w') as f:
+                f.writelines(cleaned)
+            try:
+                os.rmdir(self.NOFAIL_MOUNTPOINT)
+            except OSError:
+                pass
+            from tasks.troubleshooting import clear_fault_state
+            clear_fault_state()
+            return True, "Removed injected fstab entries"
         except Exception as e:
-            checks.append(ValidationCheck(
-                name="nofail_option",
-                passed=False,
-                points=0,
-                max_points=2,
-                message=f"Could not read /etc/fstab: {e}"
-            ))
+            return False, f"Restore error: {e}"
 
-        passed = total_points >= (self.points * 0.6)
-        return ValidationResult(self.id, passed, total_points, self.points, checks)
+    def validate(self):
+        checks = []
+        score = 0
+
+        with open('/etc/fstab') as f:
+            fstab_lines = f.readlines()
+        fstab_text = ''.join(fstab_lines)
+
+        # Check 1: bad UUID entry removed (4 pts)
+        if self.BAD_UUID_MARKER not in fstab_text:
+            checks.append(ValidationCheck("bad_entry_removed", True, 4,
+                message="Non-existent UUID entry has been removed"))
+            score += 4
+        else:
+            checks.append(ValidationCheck("bad_entry_removed", False, 0, max_points=4,
+                message="Bad UUID entry still in /etc/fstab — will cause boot failure"))
+
+        # Check 2: findmnt --verify passes (2 pts)
+        r = execute_safe(['findmnt', '--verify'])
+        if r.returncode == 0:
+            checks.append(ValidationCheck("fstab_valid", True, 2,
+                message="findmnt --verify reports no errors"))
+            score += 2
+        else:
+            checks.append(ValidationCheck("fstab_valid", False, 0, max_points=2,
+                message=f"findmnt --verify still reports errors"))
+
+        # Check 3: mount -a succeeds (2 pts)
+        r = execute_safe(['mount', '-a'])
+        if r.returncode == 0:
+            checks.append(ValidationCheck("mount_a_clean", True, 2,
+                message="mount -a completes without errors"))
+            score += 2
+        else:
+            checks.append(ValidationCheck("mount_a_clean", False, 0, max_points=2,
+                message=f"mount -a still fails: {r.stderr.strip()[:80]}"))
+
+        # Check 4: /backup entry has nofail (4 pts)
+        nofail_line = next(
+            (l for l in fstab_lines if self.NOFAIL_MARKER in l), None
+        )
+        if nofail_line is None:
+            # User removed the line entirely — also acceptable, award partial
+            checks.append(ValidationCheck("nofail_added", False, 2, max_points=4,
+                message=f"{self.NOFAIL_MOUNTPOINT} entry was removed (ok) but adding nofail is the preferred fix"))
+            score += 2
+        else:
+            parts = nofail_line.split()
+            options = parts[3] if len(parts) >= 4 else ''
+            if 'nofail' in options:
+                checks.append(ValidationCheck("nofail_added", True, 4,
+                    message=f"{self.NOFAIL_MOUNTPOINT} entry has 'nofail' — safe for missing device"))
+                score += 4
+            else:
+                checks.append(ValidationCheck("nofail_added", False, 0, max_points=4,
+                    message=f"{self.NOFAIL_MOUNTPOINT} entry still lacks 'nofail' — will block boot if device absent"))
+
+        return ValidationResult(self.id, score >= self.points * 0.6, score, self.points, checks)
 
 
 # ---------------------------------------------------------------------------

--- a/tasks/filesystems.py
+++ b/tasks/filesystems.py
@@ -33,7 +33,7 @@ class CreateFilesystemTask(BaseTask):
         self.tags = ['v10-new', 'filesystem', 'mkfs']
         self.exam_tips = [
             "Use 'lsblk -f' or 'blkid' to verify filesystem type after creation",
-            "XFS is the default filesystem in RHEL 9 - know both mkfs.xfs and mkfs.ext4",
+            "XFS is the default filesystem in RHEL 10 - know both mkfs.xfs and mkfs.ext4",
             "Always verify the device path before formatting to avoid data loss",
         ]
         self.device = None

--- a/tasks/filesystems.py
+++ b/tasks/filesystems.py
@@ -449,7 +449,16 @@ class ConfigureSwapTask(BaseTask):
 
 @TaskRegistry.register("filesystems")
 class ExtendFilesystemTask(BaseTask):
-    """Extend/resize a filesystem (typically after LV extension)."""
+    """
+    Fault-injection: creates a practice LV at 150MB on the first loop device,
+    formats it, and mounts it. The user must extend it to expected_size_mb.
+    """
+
+    has_fault_injection = True
+    _VG = 'vg_practice'
+    _LV = 'lv_practice'
+    _MP = '/mnt/practice_extend'
+    _INITIAL_MB = 150
 
     def __init__(self):
         super().__init__(
@@ -458,12 +467,12 @@ class ExtendFilesystemTask(BaseTask):
             difficulty="exam",
             points=10
         )
-        self.tags = ['v10-new', 'filesystem', 'resize', 'xfs', 'ext4']
+        self.tags = ['v10-new', 'filesystem', 'resize', 'xfs', 'ext4', 'fault-injection']
         self.exam_tips = [
-            "For XFS: use 'xfs_growfs <mount_point>' (requires mounted filesystem)",
+            "For XFS: use 'xfs_growfs <mount_point>' (must be mounted)",
             "For ext4: use 'resize2fs <device>' (can be done online for growth)",
-            "XFS can only grow, never shrink - plan accordingly",
-            "Always extend the underlying LV/partition before resizing filesystem",
+            "XFS can only grow, never shrink — plan accordingly",
+            "Always extend the LV first (lvextend), then resize the filesystem",
             "Verify new size with 'df -h' after resizing",
         ]
         self.device = None
@@ -471,38 +480,94 @@ class ExtendFilesystemTask(BaseTask):
         self.expected_size_mb = None
 
     def generate(self, **params):
-        """Generate filesystem extend task."""
-        # Try to detect existing practice LV
-        vg, lv = get_practice_lv()
-        if vg and lv:
-            default_dev = f'/dev/mapper/{vg}-{lv}'
-        else:
-            default_dev = '/dev/mapper/vg_practice-lv_practice'
-        self.device = params.get('device') or default_dev
+        self.device = f'/dev/mapper/{self._VG}-{self._LV}'
         self.fstype = params.get('fstype', random.choice(['xfs', 'ext4']))
         self.expected_size_mb = params.get('size', random.choice([250, 300, 350]))
 
-        resize_cmd = 'xfs_growfs' if self.fstype == 'xfs' else 'resize2fs'
+        grow_cmd = f'xfs_growfs {self._MP}' if self.fstype == 'xfs' else f'resize2fs {self.device}'
 
         self.description = (
             f"Extend a filesystem:\n"
             f"  - Device: {self.device}\n"
-            f"  - Filesystem type: {self.fstype}\n"
+            f"  - Mount point: {self._MP}\n"
+            f"  - Filesystem type: {self.fstype}  (currently {self._INITIAL_MB}MB)\n"
             f"  - Resize to approximately {self.expected_size_mb}MB\n"
-            f"  - Filesystem must remain mounted (if applicable)\n"
-            f"  - Data must not be lost\n"
-            f"  - Note: if this LV does not exist yet, set up practice disks first (Setup → 1)"
+            f"  - Keep the filesystem mounted — data must not be lost"
         )
-
         self.hints = [
-            "First extend the underlying LV with lvextend, then resize the filesystem",
-            f"For XFS: xfs_growfs <mount_point> (must be mounted)",
-            f"For ext4: resize2fs {self.device}",
-            "XFS can only grow, never shrink",
-            "Verify the new size with 'df -h' after resizing",
+            f"Step 1 — extend the LV: lvextend -L {self.expected_size_mb}M /dev/{self._VG}/{self._LV}",
+            f"Step 2 — grow the filesystem: {grow_cmd}",
+            "Verify: df -h | grep practice_extend",
         ]
-
         return self
+
+    def inject_fault(self):
+        import os
+        import subprocess as _sp
+        from utils.helpers import get_loop_devices
+
+        loops = get_loop_devices()
+        if not loops:
+            return False, "No loop devices available — run 'Setup → 1' first to create practice disks"
+
+        pv_dev = loops[0]
+        vg, lv, mp = self._VG, self._LV, self._MP
+
+        # pvcreate
+        r = _sp.run(['pvcreate', '-ff', '-y', pv_dev], capture_output=True, text=True)
+        if r.returncode != 0:
+            return False, f"pvcreate failed: {r.stderr.strip()}"
+
+        # vgcreate
+        r = _sp.run(['vgcreate', vg, pv_dev], capture_output=True, text=True)
+        if r.returncode != 0:
+            return False, f"vgcreate failed: {r.stderr.strip()}"
+
+        # lvcreate at initial size
+        r = _sp.run(['lvcreate', '-L', f'{self._INITIAL_MB}M', '-n', lv, vg],
+                    capture_output=True, text=True)
+        if r.returncode != 0:
+            return False, f"lvcreate failed: {r.stderr.strip()}"
+
+        # format
+        if self.fstype == 'xfs':
+            r = _sp.run(['mkfs.xfs', self.device], capture_output=True, text=True)
+        else:
+            r = _sp.run(['mkfs.ext4', '-F', self.device], capture_output=True, text=True)
+        if r.returncode != 0:
+            return False, f"mkfs.{self.fstype} failed: {r.stderr.strip()}"
+
+        # mount
+        os.makedirs(mp, exist_ok=True)
+        r = _sp.run(['mount', self.device, mp], capture_output=True, text=True)
+        if r.returncode != 0:
+            return False, f"mount failed: {r.stderr.strip()}"
+
+        from tasks.troubleshooting import save_fault_state
+        save_fault_state(self.id, {'vg': vg, 'lv': lv, 'pv': pv_dev, 'mp': mp})
+        return True, (f"Created {vg}/{lv} ({self._INITIAL_MB}MB {self.fstype}) "
+                      f"on {pv_dev}, mounted at {mp}")
+
+    def restore_fault(self):
+        import subprocess as _sp
+        from tasks.troubleshooting import load_fault_state, clear_fault_state
+
+        state = load_fault_state()
+        info = state.get('restore_info', {}) if state else {}
+        vg = info.get('vg', self._VG)
+        lv = info.get('lv', self._LV)
+        pv = info.get('pv', '')
+        mp = info.get('mp', self._MP)
+
+        _sp.run(['umount', mp], capture_output=True)
+        _sp.run(['lvremove', '-ff', f'/dev/{vg}/{lv}'], capture_output=True)
+        _sp.run(['vgchange', '-an', vg], capture_output=True)
+        _sp.run(['vgremove', '-ff', vg], capture_output=True)
+        if pv:
+            _sp.run(['pvremove', '-ff', '-y', pv], capture_output=True)
+
+        clear_fault_state()
+        return True, f"Removed {vg}/{lv} and cleaned up {mp}"
 
     def validate(self):
         """Validate filesystem has been extended."""

--- a/tasks/firewall.py
+++ b/tasks/firewall.py
@@ -82,7 +82,9 @@ _PORT_FORWARD_CONFIGS = [
 
 @TaskRegistry.register("firewall")
 class EnableFirewallTask(BaseTask):
-    """Enable and start firewalld."""
+    """Fault-injection: firewalld is stopped and disabled; user must re-enable it."""
+
+    has_fault_injection = True
 
     def __init__(self):
         super().__init__(
@@ -92,7 +94,7 @@ class EnableFirewallTask(BaseTask):
             points=5,
         )
         self.requires_persistence = True
-        self.tags = ['firewalld', 'enable', 'persistence']
+        self.tags = ['firewalld', 'enable', 'persistence', 'fault-injection']
         self.exam_tips = [
             "Use 'systemctl enable --now firewalld' to enable and start in one command.",
             "Verify with 'firewall-cmd --state' which should return 'running'.",
@@ -101,19 +103,34 @@ class EnableFirewallTask(BaseTask):
 
     def generate(self, **params):
         self.description = (
-            "Enable and start the firewalld service:\n"
-            "  - The firewalld service must be running\n"
-            "  - The firewalld service must be enabled to start at boot\n"
-            "  - Verify with: firewall-cmd --state"
+            "TROUBLESHOOTING: firewalld Is Stopped and Disabled\n"
+            "Symptom: The system firewall is not running and will not start at boot.\n\n"
+            "Tasks:\n"
+            "  1. Start the firewalld service\n"
+            "  2. Enable it to start automatically at boot\n"
+            "  3. Verify with: firewall-cmd --state"
         )
-
         self.hints = [
             "systemctl enable --now firewalld",
-            "systemctl is-active firewalld",
-            "systemctl is-enabled firewalld",
-            "firewall-cmd --state",
+            "firewall-cmd --state  (should return 'running')",
+            "systemctl is-enabled firewalld  (should return 'enabled')",
         ]
         return self
+
+    def inject_fault(self):
+        import subprocess as _sp
+        _sp.run(['systemctl', 'stop', 'firewalld'], capture_output=True)
+        _sp.run(['systemctl', 'disable', 'firewalld'], capture_output=True)
+        from tasks.troubleshooting import save_fault_state
+        save_fault_state(self.id, {'service': 'firewalld'})
+        return True, "Stopped and disabled firewalld"
+
+    def restore_fault(self):
+        import subprocess as _sp
+        _sp.run(['systemctl', 'enable', '--now', 'firewalld'], capture_output=True)
+        from tasks.troubleshooting import clear_fault_state
+        clear_fault_state()
+        return True, "Re-enabled and started firewalld"
 
     def validate(self):
         checks = []
@@ -789,7 +806,14 @@ class ConfigurePortForwardTask(BaseTask):
 
 @TaskRegistry.register("firewall")
 class FirewallReloadTask(BaseTask):
-    """Reload the firewall to apply permanent rules to the runtime."""
+    """
+    Fault-injection: adds 'tftp' to the permanent firewall config but NOT
+    the runtime, simulating a sysadmin who ran --permanent but forgot --reload.
+    The user must run firewall-cmd --reload to apply it.
+    """
+
+    has_fault_injection = True
+    _INJECT_SERVICE = 'tftp'
 
     def __init__(self):
         super().__init__(
@@ -799,71 +823,77 @@ class FirewallReloadTask(BaseTask):
             points=5,
         )
         self.requires_persistence = False
-        self.tags = ['firewalld', 'reload']
+        self.tags = ['firewalld', 'reload', 'fault-injection']
         self.exam_tips = [
-            "'firewall-cmd --reload' applies all --permanent rules to the running config.",
-            "This does NOT restart the service; existing connections are preserved.",
-            "After reload, verify with 'firewall-cmd --state'.",
+            "'firewall-cmd --reload' applies permanent rules to the running config instantly.",
+            "Without --reload, --permanent changes only take effect after the next reboot.",
+            "Always reload after making permanent changes so they are immediately active.",
         ]
 
     def generate(self, **params):
         self.description = (
-            "Reload the firewall configuration:\n"
-            "  - Ensure firewalld is running\n"
-            "  - Reload the firewall to apply any pending permanent rules\n"
-            "  - Verify the firewall state is 'running' after reload"
+            "TROUBLESHOOTING: Permanent Firewall Rule Not Active\n"
+            f"Symptom: The '{self._INJECT_SERVICE}' service was added to the permanent\n"
+            "firewall config, but it is NOT in the active runtime rules yet.\n"
+            "A reload was never run.\n\n"
+            "Tasks:\n"
+            "  1. Confirm the discrepancy between permanent and runtime rules\n"
+            "  2. Reload the firewall to apply all pending permanent rules\n"
+            "  3. Verify the service is now active in the runtime config"
         )
-
         self.hints = [
-            "firewall-cmd --reload",
-            "firewall-cmd --state",
+            "Compare: firewall-cmd --list-services  vs  firewall-cmd --permanent --list-services",
+            "Apply permanent rules to runtime: firewall-cmd --reload",
+            f"Verify: firewall-cmd --query-service={self._INJECT_SERVICE}",
         ]
         return self
 
+    def inject_fault(self):
+        import subprocess as _sp
+        svc = self._INJECT_SERVICE
+        # Ensure it's NOT in the runtime (remove if somehow already there)
+        _sp.run(['firewall-cmd', '--remove-service', svc], capture_output=True)
+        # Add only to permanent config — the "forgot to reload" scenario
+        _sp.run(['firewall-cmd', '--permanent', '--add-service', svc], capture_output=True)
+        from tasks.troubleshooting import save_fault_state
+        save_fault_state(self.id, {'service': svc})
+        return True, f"Added {svc} to permanent config only (runtime not updated)"
+
+    def restore_fault(self):
+        import subprocess as _sp
+        svc = self._INJECT_SERVICE
+        _sp.run(['firewall-cmd', '--permanent', '--remove-service', svc], capture_output=True)
+        _sp.run(['firewall-cmd', '--remove-service', svc], capture_output=True)
+        from tasks.troubleshooting import clear_fault_state
+        clear_fault_state()
+        return True, f"Removed {svc} from permanent and runtime firewall"
+
     def validate(self):
         checks = []
-        total_points = 0
+        score = 0
+        svc = self._INJECT_SERVICE
 
-        # Check 1: firewalld is active (3 pts)
-        result = execute_safe(['systemctl', 'is-active', 'firewalld'])
-        if result.success and result.stdout.strip() == 'active':
-            checks.append(ValidationCheck(
-                name="firewalld_running",
-                passed=True,
-                points=3,
-                message="firewalld is running",
-            ))
-            total_points += 3
+        # Check 1: service active in runtime (3 pts)
+        r = execute_safe(['firewall-cmd', '--query-service', svc])
+        if r.success and r.stdout.strip() == 'yes':
+            checks.append(ValidationCheck("service_in_runtime", True, 3,
+                message=f"'{svc}' is active in the runtime firewall (reload was run)"))
+            score += 3
         else:
-            checks.append(ValidationCheck(
-                name="firewalld_running",
-                passed=False,
-                points=0,
-                max_points=3,
-                message=f"firewalld is not running (got: {result.stdout.strip()})",
-            ))
+            checks.append(ValidationCheck("service_in_runtime", False, 0, max_points=3,
+                message=f"'{svc}' still not in runtime — run: firewall-cmd --reload"))
 
-        # Check 2: firewall-cmd --state returns running (2 pts)
-        result = execute_safe(['firewall-cmd', '--state'])
-        if result.success and 'running' in result.stdout.strip():
-            checks.append(ValidationCheck(
-                name="firewall_state_running",
-                passed=True,
-                points=2,
-                message="firewall-cmd --state reports 'running'",
-            ))
-            total_points += 2
+        # Check 2: firewall still running (2 pts)
+        r = execute_safe(['firewall-cmd', '--state'])
+        if r.success and 'running' in r.stdout:
+            checks.append(ValidationCheck("firewall_running", True, 2,
+                message="firewalld is running"))
+            score += 2
         else:
-            checks.append(ValidationCheck(
-                name="firewall_state_running",
-                passed=False,
-                points=0,
-                max_points=2,
-                message=f"firewall-cmd --state did not report 'running'",
-            ))
+            checks.append(ValidationCheck("firewall_running", False, 0, max_points=2,
+                message="firewalld is not running"))
 
-        passed = total_points >= (self.points * 0.6)
-        return ValidationResult(self.id, passed, total_points, self.points, checks)
+        return ValidationResult(self.id, score >= self.points * 0.6, score, self.points, checks)
 
 
 # ===== 9. TroubleshootFirewallTask (hard / 18pts) ==========================

--- a/tasks/firewall.py
+++ b/tasks/firewall.py
@@ -100,6 +100,33 @@ class EnableFirewallTask(BaseTask):
             "Verify with 'firewall-cmd --state' which should return 'running'.",
             "If firewalld is masked, unmask it first: 'systemctl unmask firewalld'.",
         ]
+        # firewalld ships active+enabled on RHEL, so without breaking it first
+        # this task would pass without the candidate doing anything.
+        self.has_fault_injection = True
+        self._fault_info = None
+
+    def inject_fault(self):
+        from tasks.troubleshooting import save_fault_state, _run
+        act = _run(['systemctl', 'is-active', 'firewalld'])
+        was_active = act.stdout.strip() == 'active'
+        en = _run(['systemctl', 'is-enabled', 'firewalld'])
+        was_enabled = 'enabled' in (en.stdout or '')
+        _run(['systemctl', 'stop', 'firewalld'])
+        _run(['systemctl', 'disable', 'firewalld'])
+        self._fault_info = {
+            'service': 'firewalld',
+            'was_active': was_active,
+            'was_enabled': was_enabled,
+        }
+        save_fault_state(self.id, self._fault_info)
+        return True, "Stopped and disabled firewalld"
+
+    def restore_fault(self):
+        from tasks.troubleshooting import _restore_service, clear_fault_state
+        msgs = []
+        _restore_service(self._fault_info or {'service': 'firewalld'}, msgs)
+        clear_fault_state()
+        return True, '; '.join(msgs)
 
     def generate(self, **params):
         self.description = (

--- a/tasks/journalctl.py
+++ b/tasks/journalctl.py
@@ -203,7 +203,12 @@ class BootLogAnalysisTask(BaseTask):
 # ---------------------------------------------------------------------------
 @TaskRegistry.register("journalctl")
 class PersistentJournalTask(BaseTask):
-    """Configure persistent journal storage so logs survive reboot."""
+    """
+    Fault-injection: sets Storage=volatile so logs are lost on reboot.
+    User must re-enable persistent logging.
+    """
+
+    has_fault_injection = True
 
     def __init__(self):
         super().__init__(
@@ -213,69 +218,101 @@ class PersistentJournalTask(BaseTask):
             points=10
         )
         self.requires_persistence = True
-        self.tags = ['v10-new', 'journalctl', 'persistent-journal']
+        self.tags = ['v10-new', 'journalctl', 'persistent-journal', 'fault-injection']
         self.exam_tips = [
-            "By default on RHEL, journal is volatile (stored in /run/log/journal).",
-            "mkdir -p /var/log/journal and restart systemd-journald to enable persistence.",
-            "Alternatively set Storage=persistent in /etc/systemd/journald.conf.",
-            "Storage=auto persists if /var/log/journal/ exists (RHEL default behavior).",
+            "Journal persistence is controlled by Storage= in /etc/systemd/journald.conf.",
+            "Storage=persistent: always save to disk.",
+            "Storage=auto: saves to disk only if /var/log/journal/ directory exists.",
+            "After config changes: systemctl restart systemd-journald",
         ]
         self.storage_setting = None
 
     def generate(self, **params):
-        """Generate persistent journal configuration task."""
         storage_options = [
-            ('persistent', 'Storage=persistent',
-             'Explicitly enable persistent storage in journald.conf'),
-            ('auto', 'Storage=auto',
-             'Use auto mode (persists if /var/log/journal/ directory exists)'),
+            ('persistent', 'Storage=persistent'),
+            ('auto', 'Storage=auto'),
         ]
-
-        choice = params.get('storage')
-        if choice:
-            for opt, setting, desc in storage_options:
-                if opt == choice:
-                    self.storage_setting = opt
-                    setting_str = setting
-                    setting_desc = desc
-                    break
-            else:
-                self.storage_setting = choice
-                setting_str = f"Storage={choice}"
-                setting_desc = 'the specified setting'
-        else:
-            self.storage_setting, setting_str, setting_desc = random.choice(storage_options)
+        self.storage_setting, self._target_setting = params.get(
+            'storage', random.choice(storage_options)
+        ) if isinstance(params.get('storage'), tuple) else random.choice(storage_options)
 
         self.description = (
-            f"Configure persistent systemd journal storage:\n"
-            f"\n"
-            f"  By default, the systemd journal stores logs in volatile memory\n"
-            f"  (/run/log/journal) and they are lost on reboot.\n"
-            f"\n"
-            f"  Required configuration:\n"
-            f"  1. Create the persistent journal directory: /var/log/journal\n"
-            f"  2. Set correct ownership: chown root:systemd-journal /var/log/journal\n"
-            f"  3. Set correct permissions: chmod 2755 /var/log/journal\n"
-            f"  4. Edit /etc/systemd/journald.conf:\n"
-            f"     - Set {setting_str} under the [Journal] section\n"
-            f"     ({setting_desc})\n"
-            f"  5. Restart the journal service: systemctl restart systemd-journald\n"
-            f"\n"
-            f"  After configuration, logs will persist across reboots.\n"
-            f"  Verify with: journalctl --list-boots"
+            f"Troubleshoot system journal configuration:\n\n"
+            f"Symptom: Boot logs are not available from previous reboots.\n"
+            f"The systemd journal is not persisting logs to disk.\n\n"
+            f"Tasks:\n"
+            f"  1. Identify why journal logs are not persisting across reboots\n"
+            f"  2. Configure the journal for persistent storage\n"
+            f"  3. Restart the journal service to apply the change\n"
+            f"  4. Verify: journalctl --list-boots shows entries"
         )
-
         self.hints = [
-            "mkdir -p /var/log/journal",
-            "chown root:systemd-journal /var/log/journal",
-            "chmod 2755 /var/log/journal",
-            f"Edit /etc/systemd/journald.conf: set {setting_str} under [Journal]",
-            "systemctl restart systemd-journald",
-            "Verify: journalctl --list-boots (should show multiple boots if persistent)",
-            "Also verify: ls -ld /var/log/journal/",
+            "Check current config: cat /etc/systemd/journald.conf | grep -i storage",
+            "Journal config file: /etc/systemd/journald.conf  (section: [Journal])",
+            "Verify persistence directory: ls -ld /var/log/journal",
+            "Apply change: systemctl restart systemd-journald",
         ]
-
         return self
+
+    def inject_fault(self):
+        import subprocess as _sp
+        import shutil
+
+        # Save original journald.conf
+        conf = '/etc/systemd/journald.conf'
+        backup = '/var/lib/rhcsa-simulator/journald.conf.bak'
+        os.makedirs(os.path.dirname(backup), exist_ok=True)
+        shutil.copy2(conf, backup)
+
+        # Remove /var/log/journal to break persistence
+        journal_dir = '/var/log/journal'
+        had_dir = os.path.isdir(journal_dir)
+        if had_dir:
+            shutil.rmtree(journal_dir)
+
+        # Set Storage=volatile in journald.conf
+        with open(conf) as f:
+            content = f.read()
+        import re
+        content = re.sub(r'(?m)^#?Storage=.*$', 'Storage=volatile', content)
+        if 'Storage=' not in content:
+            content = content.replace('[Journal]', '[Journal]\nStorage=volatile')
+        with open(conf, 'w') as f:
+            f.write(content)
+
+        _sp.run(['systemctl', 'restart', 'systemd-journald'], capture_output=True)
+
+        from tasks.troubleshooting import save_fault_state
+        save_fault_state(self.id, {
+            'backup': backup,
+            'had_dir': had_dir,
+            'target_setting': self._target_setting,
+        })
+        return True, "Set Storage=volatile and removed /var/log/journal"
+
+    def restore_fault(self):
+        import subprocess as _sp
+        import shutil
+        from tasks.troubleshooting import load_fault_state, clear_fault_state
+
+        state = load_fault_state()
+        info = state.get('restore_info', {}) if state else {}
+        backup = info.get('backup', '/var/lib/rhcsa-simulator/journald.conf.bak')
+        had_dir = info.get('had_dir', True)
+        journal_dir = '/var/log/journal'
+
+        if os.path.exists(backup):
+            shutil.copy2(backup, '/etc/systemd/journald.conf')
+            os.remove(backup)
+
+        if had_dir and not os.path.isdir(journal_dir):
+            os.makedirs(journal_dir, exist_ok=True)
+            _sp.run(['chown', 'root:systemd-journal', journal_dir], capture_output=True)
+            _sp.run(['chmod', '2755', journal_dir], capture_output=True)
+
+        _sp.run(['systemctl', 'restart', 'systemd-journald'], capture_output=True)
+        clear_fault_state()
+        return True, "Restored journald.conf and restarted systemd-journald"
 
     def validate(self):
         """Validate persistent journal is properly configured."""

--- a/tasks/lvm.py
+++ b/tasks/lvm.py
@@ -483,7 +483,13 @@ class LVMFullWorkflowTask(BaseTask):
 
 @TaskRegistry.register("lvm")
 class ExtendVGTask(BaseTask):
-    """Extend a volume group by adding a new physical volume."""
+    """
+    Fault-injection: creates vg_practice on loop0 at start, uses loop1
+    (or sda) as the device to add. User must pvcreate + vgextend.
+    """
+
+    has_fault_injection = True
+    _VG = 'vg_practice'
 
     def __init__(self):
         super().__init__(
@@ -493,45 +499,89 @@ class ExtendVGTask(BaseTask):
             points=10
         )
         self.task_order = 40
-        self.tags = ['v10-new', 'lvm-extend']
+        self.tags = ['v10-new', 'lvm-extend', 'fault-injection']
         self.exam_tips = [
-            "First create PV on new device with 'pvcreate'",
-            "Then extend VG with 'vgextend <vg_name> <new_device>'",
-            "Verify increased VG size with 'vgs' command",
-            "Free space in VG can then be used to extend existing LVs",
+            "pvcreate initializes a disk/device as a physical volume.",
+            "vgextend <vg> <device> adds a PV to an existing VG.",
+            "vgs shows VG size — verify it increased after vgextend.",
+            "Free space in the VG can then be used with lvcreate or lvextend.",
         ]
         self.requires_persistence = True
-        self.vg_name = None
-        self.new_device = None
+        self.vg_name = self._VG
+        self.base_device = None   # device the VG is built on (injected)
+        self.new_device = None    # device user must add
 
     def generate(self, **params):
-        existing_vg = get_practice_vg()
-        self.vg_name = params.get('vg_name', existing_vg or 'vg_practice')
+        from utils.helpers import get_loop_devices, list_all_block_devices
+        loops = get_loop_devices()
 
-        # Get a secondary device if available
-        devices = get_all_practice_devices()
-        if len(devices) > 1:
-            self.new_device = devices[1]
+        # Use loop0 for the existing VG, loop1 (or sda) as the device to add
+        if len(loops) >= 2:
+            self.base_device = loops[0]
+            self.new_device = loops[1]
+        elif len(loops) == 1:
+            self.base_device = loops[0]
+            # Try to find sda as the second device
+            all_devs = list_all_block_devices()
+            candidates = [d for d in all_devs if 'sda' in d and d != self.base_device]
+            self.new_device = candidates[0] if candidates else '/dev/sdb'
         else:
-            self.new_device = params.get('device', '/dev/vdc')
+            self.base_device = '/dev/vdb'
+            self.new_device = '/dev/vdc'
 
+        self.vg_name = params.get('vg_name', self._VG)
         self.description = (
             f"Extend a volume group:\n"
-            f"  - Volume group: {self.vg_name}\n"
-            f"  - Add new device: {self.new_device}\n"
-            f"  - Create PV on the new device first\n"
-            f"  - Verify VG has increased in size"
+            f"  - Volume group: {self.vg_name}  (already exists)\n"
+            f"  - Add new physical volume from: {self.new_device}\n"
+            f"  - Initialize the new device as a PV first\n"
+            f"  - Extend the VG to include the new PV\n"
+            f"  - Verify the VG size has increased"
         )
-
         self.hints = [
-            f"Create PV on new device: pvcreate {self.new_device}",
+            f"Confirm VG exists: vgs {self.vg_name}",
+            f"Initialize PV: pvcreate {self.new_device}",
             f"Extend VG: vgextend {self.vg_name} {self.new_device}",
             f"Verify: vgs {self.vg_name}",
-            "Check VG size before and after with 'vgs'",
-            "New PV must exist before extending VG"
         ]
-
         return self
+
+    def inject_fault(self):
+        import subprocess as _sp
+        vg = self.vg_name
+        dev = self.base_device
+
+        r = _sp.run(['pvcreate', '-ff', '-y', dev], capture_output=True, text=True)
+        if r.returncode != 0:
+            return False, f"pvcreate {dev} failed: {r.stderr.strip()}"
+
+        r = _sp.run(['vgcreate', vg, dev], capture_output=True, text=True)
+        if r.returncode != 0:
+            return False, f"vgcreate {vg} failed: {r.stderr.strip()}"
+
+        from tasks.troubleshooting import save_fault_state
+        save_fault_state(self.id, {'vg': vg, 'base_dev': dev, 'new_dev': self.new_device})
+        return True, f"Created {vg} on {dev}; user must add {self.new_device}"
+
+    def restore_fault(self):
+        import subprocess as _sp
+        from tasks.troubleshooting import load_fault_state, clear_fault_state
+
+        state = load_fault_state()
+        info = state.get('restore_info', {}) if state else {}
+        vg = info.get('vg', self.vg_name)
+        base_dev = info.get('base_dev', self.base_device)
+        new_dev = info.get('new_dev', self.new_device)
+
+        # Remove any LVs first
+        _sp.run(['lvremove', '-ff', vg], capture_output=True)
+        _sp.run(['vgchange', '-an', vg], capture_output=True)
+        _sp.run(['vgremove', '-ff', vg], capture_output=True)
+        for dev in filter(None, [base_dev, new_dev]):
+            _sp.run(['pvremove', '-ff', '-y', dev], capture_output=True)
+
+        clear_fault_state()
+        return True, f"Removed {vg} and cleaned up PVs"
 
     def validate(self):
         checks = []

--- a/tasks/lvm.py
+++ b/tasks/lvm.py
@@ -373,7 +373,7 @@ class LVMFullWorkflowTask(BaseTask):
             "Complete LVM workflow: pvcreate → vgcreate → lvcreate → mkfs → mount → fstab",
             "Use UUID in /etc/fstab for persistent mounting (get with blkid)",
             "Test fstab with 'mount -a' before rebooting",
-            "XFS is default filesystem in RHEL 9, but ext4 also commonly used",
+            "XFS is default filesystem in RHEL 10, but ext4 also commonly used",
             "This is a common multi-step exam task worth significant points",
         ]
         self.requires_persistence = True

--- a/tasks/networking.py
+++ b/tasks/networking.py
@@ -1506,7 +1506,14 @@ class ConfigureSearchDomainTask(BaseTask):
 
 @TaskRegistry.register("networking")
 class FullNetworkSetupTask(BaseTask):
-    """Complete network configuration: static IP + DNS + hostname + gateway."""
+    """
+    Complete network configuration using a practice dummy interface.
+    inject_fault creates dummy0 so the task never touches the live interface.
+    """
+
+    has_fault_injection = True
+    _DUMMY_IFACE = 'dummy0'
+    _CONN_NAME = 'practice-net'
 
     def __init__(self):
         super().__init__(
@@ -1516,56 +1523,99 @@ class FullNetworkSetupTask(BaseTask):
             points=20
         )
         self.requires_persistence = True
-        self.tags = ["nmcli", "hostnamectl", "full-setup", "persistence", "compound"]
+        self.tags = ["nmcli", "hostnamectl", "full-setup", "persistence", "compound", "fault-injection"]
         self.exam_tips = [
-            "This is a compound task - tackle each piece: hostname, IP, gateway, DNS.",
-            "Set hostname with hostnamectl, everything else with nmcli.",
-            "Always bring the connection up after all modifications.",
-            "Verify every component independently before moving on.",
+            "Tackle each component: hostname first, then IP/gateway/DNS via nmcli.",
+            "'nmcli con add' creates a new connection; 'nmcli con mod' edits an existing one.",
+            "Always run 'nmcli con up <name>' after configuring to activate.",
+            "Verify: hostnamectl; ip addr show dummy0; nmcli con show practice-net",
         ]
         self.hostname = None
-        self.interface = None
-        self.connection_name = None
+        self.interface = self._DUMMY_IFACE
+        self.connection_name = self._CONN_NAME
         self.ip_address = None
         self.prefix = None
         self.gateway = None
         self.dns_servers = None
+        self._orig_hostname = None
 
     def generate(self, **params):
         subnet = _random_subnet()
         self.hostname = params.get('hostname', _random_hostname())
-        self.interface = params.get('interface') or _get_practice_interface()
-        self.connection_name = params.get('connection') or _get_connection_name(self.interface) or self.interface
         self.ip_address = params.get('ip', f'192.168.{subnet}.{_random_host()}')
         self.prefix = params.get('prefix', '24')
         self.gateway = params.get('gateway', f'192.168.{subnet}.1')
         self.dns_servers = params.get('dns', _random_dns_pair())
         if isinstance(self.dns_servers, str):
             self.dns_servers = [self.dns_servers]
-        dns_str = ' '.join(self.dns_servers)
+        dns_str = ', '.join(self.dns_servers)
 
         self.description = (
             f"Perform a COMPLETE network configuration:\n"
-            f"  1. Set hostname to: {self.hostname}\n"
-            f"  2. Configure connection '{self.connection_name}' on {self.interface}:\n"
+            f"  1. Set system hostname to: {self.hostname}\n"
+            f"  2. Create a new nmcli connection named '{self.connection_name}'\n"
+            f"     bound to interface: {self.interface}\n"
             f"     - IP Address: {self.ip_address}/{self.prefix}\n"
             f"     - Gateway: {self.gateway}\n"
-            f"     - DNS Servers: {', '.join(self.dns_servers)}\n"
+            f"     - DNS Servers: {dns_str}\n"
             f"     - IPv4 method: manual\n"
-            f"  3. Activate the connection\n"
-            f"  ALL settings must persist across reboots."
+            f"  3. Bring the connection up\n"
+            f"  ALL settings must persist across reboots.\n"
+            f"\n"
+            f"  Note: '{self.interface}' is a virtual practice interface — safe to configure."
         )
-
         self.hints = [
-            f"hostnamectl set-hostname {self.hostname}",
-            f"nmcli con mod {self.connection_name} ipv4.addresses {self.ip_address}/{self.prefix}",
-            f"nmcli con mod {self.connection_name} ipv4.gateway {self.gateway}",
-            f"nmcli con mod {self.connection_name} ipv4.dns \"{dns_str}\"",
-            f"nmcli con mod {self.connection_name} ipv4.method manual",
-            f"nmcli con up {self.connection_name}",
-            "Verify: hostnamectl; ip addr; ip route; cat /etc/resolv.conf",
+            f"Set hostname: hostnamectl set-hostname {self.hostname}",
+            f"Add connection: nmcli con add type dummy ifname {self.interface} con-name {self.connection_name} \\",
+            f"  ipv4.method manual ipv4.addresses {self.ip_address}/{self.prefix} \\",
+            f"  ipv4.gateway {self.gateway} ipv4.dns \"{' '.join(self.dns_servers)}\"",
+            f"Activate: nmcli con up {self.connection_name}",
+            f"Verify: ip addr show {self.interface}; nmcli con show {self.connection_name}",
         ]
         return self
+
+    def inject_fault(self):
+        import subprocess as _sp
+        # Create the dummy kernel module and interface
+        _sp.run(['modprobe', 'dummy'], capture_output=True)
+        r = _sp.run(['ip', 'link', 'add', self._DUMMY_IFACE, 'type', 'dummy'],
+                    capture_output=True, text=True)
+        if r.returncode != 0 and 'File exists' not in r.stderr:
+            return False, f"Could not create dummy0: {r.stderr.strip()}"
+        _sp.run(['ip', 'link', 'set', self._DUMMY_IFACE, 'up'], capture_output=True)
+
+        # Remove any existing practice-net connection so the user starts fresh
+        _sp.run(['nmcli', 'con', 'delete', self._CONN_NAME], capture_output=True)
+
+        # Save current hostname for restore
+        r2 = _sp.run(['hostname'], capture_output=True, text=True)
+        self._orig_hostname = r2.stdout.strip()
+
+        from tasks.troubleshooting import save_fault_state
+        save_fault_state(self.id, {
+            'orig_hostname': self._orig_hostname,
+            'iface': self._DUMMY_IFACE,
+            'conn': self._CONN_NAME,
+        })
+        return True, f"Created {self._DUMMY_IFACE} virtual interface for practice"
+
+    def restore_fault(self):
+        import subprocess as _sp
+        from tasks.troubleshooting import load_fault_state, clear_fault_state
+
+        state = load_fault_state()
+        info = state.get('restore_info', {}) if state else {}
+        orig_hostname = info.get('orig_hostname', '')
+        iface = info.get('iface', self._DUMMY_IFACE)
+        conn = info.get('conn', self._CONN_NAME)
+
+        _sp.run(['nmcli', 'con', 'delete', conn], capture_output=True)
+        _sp.run(['ip', 'link', 'delete', iface], capture_output=True)
+        if orig_hostname:
+            _sp.run(['hostnamectl', 'set-hostname', orig_hostname], capture_output=True)
+
+        clear_fault_state()
+        return True, f"Removed {iface}, {conn} connection, restored hostname"
 
     def validate(self):
         checks = []
@@ -1575,68 +1625,69 @@ class FullNetworkSetupTask(BaseTask):
         result = execute_safe(['hostname'])
         current_hostname = result.stdout.strip() if result.success else None
         if current_hostname == self.hostname:
-            checks.append(ValidationCheck("hostname_set", True, 4,
-                          f"Hostname is {self.hostname}"))
+            checks.append(ValidationCheck("hostname_set", True, 4, f"Hostname is {self.hostname}"))
             total += 4
         else:
             checks.append(ValidationCheck("hostname_set", False, 0,
                           f"Hostname is '{current_hostname}', expected '{self.hostname}'", max_points=4))
 
-        # 2. IP address (5 pts)
+        # 2. nmcli connection exists with correct profile (6 pts)
+        conn = get_nmcli_connection_info(self.connection_name)
+        if conn:
+            checks.append(ValidationCheck("conn_exists", True, 2, f"Connection '{self.connection_name}' exists"))
+            total += 2
+            # Check method
+            if conn.get('ipv4.method') == 'manual':
+                checks.append(ValidationCheck("method_manual", True, 2, "ipv4.method is 'manual'"))
+                total += 2
+            else:
+                checks.append(ValidationCheck("method_manual", False, 0,
+                              f"ipv4.method is '{conn.get('ipv4.method', '?')}'", max_points=2))
+            # Check address in profile
+            addr_field = conn.get('ipv4.addresses', '')
+            if self.ip_address in addr_field:
+                checks.append(ValidationCheck("ip_in_profile", True, 2,
+                              f"IP {self.ip_address} in connection profile"))
+                total += 2
+            else:
+                checks.append(ValidationCheck("ip_in_profile", False, 0,
+                              f"IP {self.ip_address} not found in profile (got: {addr_field})", max_points=2))
+        else:
+            checks.append(ValidationCheck("conn_exists", False, 0,
+                          f"Connection '{self.connection_name}' not found", max_points=6))
+
+        # 3. IP address on interface (5 pts)
         actual_ip = get_ip_address(self.interface)
         if actual_ip == self.ip_address:
-            checks.append(ValidationCheck("ip_configured", True, 5,
-                          f"IP {self.ip_address} configured on {self.interface}"))
+            checks.append(ValidationCheck("ip_active", True, 5,
+                          f"IP {self.ip_address} active on {self.interface}"))
             total += 5
         else:
-            checks.append(ValidationCheck("ip_configured", False, 0,
-                          f"IP is {actual_ip}, expected {self.ip_address}", max_points=5))
+            checks.append(ValidationCheck("ip_active", False, 0,
+                          f"IP on {self.interface} is '{actual_ip}', expected '{self.ip_address}'", max_points=5))
 
-        # 3. Gateway (3 pts)
-        gw = get_default_gateway()
-        if gw == self.gateway:
-            checks.append(ValidationCheck("gateway_configured", True, 3,
-                          f"Gateway {self.gateway} is active"))
-            total += 3
+        # 4. DNS servers in profile (3 pts)
+        if conn:
+            dns_field = conn.get('ipv4.dns', '')
+            found = sum(1 for d in self.dns_servers if d in dns_field)
+            if found == len(self.dns_servers):
+                checks.append(ValidationCheck("dns_configured", True, 3, "DNS servers configured in profile"))
+                total += 3
+            elif found > 0:
+                checks.append(ValidationCheck("dns_configured", True, 1, f"{found}/{len(self.dns_servers)} DNS servers configured"))
+                total += 1
+            else:
+                checks.append(ValidationCheck("dns_configured", False, 0, "DNS not configured in profile", max_points=3))
         else:
-            checks.append(ValidationCheck("gateway_configured", False, 0,
-                          f"Gateway is {gw}, expected {self.gateway}", max_points=3))
+            checks.append(ValidationCheck("dns_configured", False, 0, "Connection not found", max_points=3))
 
-        # 4. DNS servers (3 pts)
-        current_dns = get_dns_servers()
-        all_dns = all(d in current_dns for d in self.dns_servers)
-        if all_dns:
-            checks.append(ValidationCheck("dns_configured", True, 3,
-                          "All DNS servers configured"))
-            total += 3
-        elif any(d in current_dns for d in self.dns_servers):
-            checks.append(ValidationCheck("dns_configured", True, 1,
-                          "Some DNS servers configured (partial)"))
-            total += 1
-        else:
-            checks.append(ValidationCheck("dns_configured", False, 0,
-                          f"DNS not configured (current: {current_dns})", max_points=3))
-
-        # 5. Persistent config - method is manual (3 pts)
-        conn = get_nmcli_connection_info(self.connection_name)
-        if conn and conn.get('ipv4.method') == 'manual':
-            checks.append(ValidationCheck("method_manual", True, 3,
-                          "ipv4.method is 'manual' (persistent)"))
-            total += 3
-        else:
-            method = conn.get('ipv4.method', 'unknown') if conn else 'connection not found'
-            checks.append(ValidationCheck("method_manual", False, 0,
-                          f"ipv4.method is '{method}'", max_points=3))
-
-        # 6. Interface UP (2 pts)
+        # 5. Interface UP (2 pts)
         state = get_interface_state(self.interface)
         if state == 'UP':
-            checks.append(ValidationCheck("interface_up", True, 2,
-                          f"Interface {self.interface} is UP"))
+            checks.append(ValidationCheck("interface_up", True, 2, f"{self.interface} is UP"))
             total += 2
         else:
-            checks.append(ValidationCheck("interface_up", False, 0,
-                          f"Interface is {state}", max_points=2))
+            checks.append(ValidationCheck("interface_up", False, 0, f"{self.interface} is {state}", max_points=2))
 
         passed = total >= (self.points * 0.7)
         return ValidationResult(self.id, passed, total, self.points, checks)

--- a/tasks/networking.py
+++ b/tasks/networking.py
@@ -28,19 +28,59 @@ logger = logging.getLogger(__name__)
 # Helper utilities
 # ---------------------------------------------------------------------------
 
+# A dedicated, isolated dummy interface used by every task that *modifies*
+# network settings. Reconfiguring the candidate's real/primary NIC (ens160,
+# eth0, ...) would drop their live connection, so practice always happens on
+# this throwaway interface instead.
+PRACTICE_INTERFACE = 'dummy0'
+PRACTICE_CONNECTION = 'dummy0'
+# RFC 5737 documentation range — a harmless placeholder so the interface comes
+# up with an address (tasks that assign a *specific* IP still have to change it).
+_PRACTICE_BASE_IP = '192.0.2.10/24'
+
+
+def _ensure_practice_interface():
+    """
+    Make sure the isolated 'dummy0' practice interface exists and is up.
+
+    Idempotent and best-effort: on systems without root / iproute2 / NM the
+    calls fail silently and the interface name is still returned so task
+    generation never raises.
+    """
+    import subprocess
+
+    def _run(cmd):
+        try:
+            return subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        except Exception:
+            return None
+
+    show = _run(['ip', 'link', 'show', PRACTICE_INTERFACE])
+    if show is None or show.returncode != 0:
+        _run(['ip', 'link', 'add', PRACTICE_INTERFACE, 'type', 'dummy'])
+    _run(['ip', 'link', 'set', PRACTICE_INTERFACE, 'up'])
+
+    # Bind a NetworkManager profile so nmcli con mod/up behaves like a real NIC.
+    shown = _run(['nmcli', '-t', '-f', 'NAME', 'con', 'show'])
+    names = shown.stdout.splitlines() if shown and shown.stdout else []
+    if PRACTICE_CONNECTION not in names:
+        _run(['nmcli', 'con', 'add', 'type', 'dummy',
+              'con-name', PRACTICE_CONNECTION, 'ifname', PRACTICE_INTERFACE,
+              'ipv4.method', 'manual', 'ipv4.addresses', _PRACTICE_BASE_IP])
+        _run(['nmcli', 'con', 'up', PRACTICE_CONNECTION])
+    return PRACTICE_INTERFACE
+
+
 def _get_practice_interface():
-    """Get an interface suitable for practice (prefers non-primary)."""
-    try:
-        from device.network_manager import (
-            get_practice_interface, get_primary_interface,
-            get_connection_for_interface
-        )
-        iface = get_practice_interface()
-        if iface:
-            return iface
-    except Exception:
-        pass
-    return 'eth0'
+    """
+    Return an isolated dummy interface for practice tasks.
+
+    IMPORTANT: this NEVER returns the primary/live interface. The previous
+    implementation fell back to the primary NIC when no spare interface
+    existed, which meant a static-IP task could clobber the candidate's live
+    connection. A dedicated 'dummy0' interface is created on demand instead.
+    """
+    return _ensure_practice_interface()
 
 
 def _get_primary_interface():
@@ -87,7 +127,7 @@ def _random_hostname():
     names = [
         'server1.example.com', 'server2.example.com',
         'node1.lab.example.com', 'node2.lab.example.com',
-        'rhel9.lab.local', 'workstation.test.net',
+        'rhel10.lab.local', 'workstation.test.net',
         'app01.prod.example.com', 'db01.corp.example.com',
         'web01.example.com', 'mail.example.com',
     ]

--- a/tasks/packages.py
+++ b/tasks/packages.py
@@ -378,7 +378,7 @@ class DowngradePackageTask(BaseTask):
         ]
 
     def generate(self, **params):
-        packages = ['vim-enhanced', 'wget', 'tmux', 'bash-completion']
+        packages = ['vim-enhanced', 'wget', 'bash-completion', 'nano', 'man-db']
         self.package_name = params.get('package', random.choice(packages))
 
         self.description = (

--- a/tasks/repos.py
+++ b/tasks/repos.py
@@ -40,31 +40,27 @@ class ConfigureRepoTask(BaseTask):
 
     def generate(self, **params):
         """Generate a repository configuration task with randomized parameters."""
+        # RHCSA exam-style repos — recognisable to candidates, won't break dnf
         repo_configs = [
             {
-                'repo_id': 'localrepo',
-                'repo_name': 'Local Repository',
-                'base_url': 'file:///repo/BaseOS',
+                'repo_id': 'BaseOS',
+                'repo_name': 'Red Hat Enterprise Linux 10 - BaseOS',
+                'base_url': 'http://content.example.com/rhel10.0/x86_64/dvd/BaseOS/',
             },
             {
-                'repo_id': 'internalmirror',
-                'repo_name': 'Internal Mirror Repository',
-                'base_url': 'http://mirror.internal.example.com/rhel9/BaseOS/x86_64/os',
+                'repo_id': 'AppStream',
+                'repo_name': 'Red Hat Enterprise Linux 10 - AppStream',
+                'base_url': 'http://content.example.com/rhel10.0/x86_64/dvd/AppStream/',
             },
             {
-                'repo_id': 'customrepo',
-                'repo_name': 'Custom Packages Repository',
-                'base_url': 'http://content.example.com/rhel9/custom',
+                'repo_id': 'extras',
+                'repo_name': 'RHEL 10 Extras',
+                'base_url': 'http://content.example.com/rhel10.0/x86_64/extras/',
             },
             {
-                'repo_id': 'examrepo',
-                'repo_name': 'Exam Content Repository',
-                'base_url': 'http://repo.lab.example.com/rhel9/packages',
-            },
-            {
-                'repo_id': 'backuprepo',
-                'repo_name': 'Backup Software Repository',
-                'base_url': 'ftp://ftp.example.com/pub/rhel9/extras',
+                'repo_id': 'supplementary',
+                'repo_name': 'RHEL 10 Supplementary',
+                'base_url': 'http://content.example.com/rhel10.0/x86_64/supplementary/',
             },
         ]
 
@@ -75,21 +71,19 @@ class ConfigureRepoTask(BaseTask):
         self.gpgcheck = params.get('gpgcheck', random.choice([0, 0, 0, 1]))
 
         self.description = (
-            f"Configure a new DNF repository:\n"
+            f"Configure a DNF repository:\n"
             f"  - Repository ID: {self.repo_id}\n"
             f"  - Repository name: {self.repo_name}\n"
             f"  - Base URL: {self.base_url}\n"
-            f"  - GPG check: {'enabled' if self.gpgcheck else 'disabled'}\n"
-            f"  - The repository must be enabled\n"
+            f"  - GPG check: {'enabled (gpgcheck=1)' if self.gpgcheck else 'disabled (gpgcheck=0)'}\n"
+            f"  - Repository must be enabled\n"
             f"  - Create the file: /etc/yum.repos.d/{self.repo_id}.repo"
         )
 
         self.hints = [
-            f"Create file /etc/yum.repos.d/{self.repo_id}.repo",
-            f"File contents should be:\n[{self.repo_id}]\nname={self.repo_name}\n"
-            f"baseurl={self.base_url}\nenabled=1\ngpgcheck={self.gpgcheck}",
+            f"Repo files go in /etc/yum.repos.d/ and must end in .repo",
+            f"Every repo file needs: [repoid], name=, baseurl=, enabled=, gpgcheck=",
             "Verify with: dnf repolist",
-            "Alternative: dnf config-manager --add-repo <url>",
         ]
 
         return self

--- a/tasks/repos.py
+++ b/tasks/repos.py
@@ -62,6 +62,16 @@ class ConfigureRepoTask(BaseTask):
                 'repo_name': 'RHEL 10 Supplementary',
                 'base_url': 'http://content.example.com/rhel10.0/x86_64/supplementary/',
             },
+            {
+                'repo_id': 'internalmirror',
+                'repo_name': 'Internal Mirror Repository',
+                'base_url': 'http://mirror.internal.example.com/rhel10/BaseOS/x86_64/os',
+            },
+            {
+                'repo_id': 'examrepo',
+                'repo_name': 'Exam Content Repository',
+                'base_url': 'http://repo.lab.example.com/rhel10/packages',
+            },
         ]
 
         config = params.get('config', random.choice(repo_configs))
@@ -219,25 +229,25 @@ class ConfigureRepoGPGTask(BaseTask):
             {
                 'repo_id': 'securerepo',
                 'repo_name': 'Secure Package Repository',
-                'base_url': 'http://content.example.com/rhel9/secure',
-                'gpg_key_url': 'http://content.example.com/rhel9/RPM-GPG-KEY-secure',
+                'base_url': 'http://content.example.com/rhel10/secure',
+                'gpg_key_url': 'http://content.example.com/rhel10/RPM-GPG-KEY-secure',
             },
             {
                 'repo_id': 'vendorrepo',
                 'repo_name': 'Vendor Software Repository',
-                'base_url': 'https://packages.vendor.example.com/rhel9/x86_64',
+                'base_url': 'https://packages.vendor.example.com/rhel10/x86_64',
                 'gpg_key_url': 'https://packages.vendor.example.com/RPM-GPG-KEY-vendor',
             },
             {
                 'repo_id': 'signedrepo',
                 'repo_name': 'Signed Packages Repository',
-                'base_url': 'http://repo.lab.example.com/rhel9/signed',
+                'base_url': 'http://repo.lab.example.com/rhel10/signed',
                 'gpg_key_url': 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-lab',
             },
             {
                 'repo_id': 'productrepo',
                 'repo_name': 'Product Repository',
-                'base_url': 'http://mirror.internal.example.com/products/rhel9',
+                'base_url': 'http://mirror.internal.example.com/products/rhel10',
                 'gpg_key_url': 'http://mirror.internal.example.com/RPM-GPG-KEY-product',
             },
         ]
@@ -413,8 +423,8 @@ class EnableDisableRepoTask(BaseTask):
         """Generate enable/disable repository task."""
         repos = [
             'epel', 'crb', 'baseos', 'appstream',
-            'rhel-9-for-x86_64-baseos-rpms',
-            'rhel-9-for-x86_64-appstream-rpms',
+            'rhel-10-for-x86_64-baseos-rpms',
+            'rhel-10-for-x86_64-appstream-rpms',
         ]
         self.repo_name = params.get('repo', random.choice(repos))
         self.action = params.get('action', random.choice(['enable', 'disable']))
@@ -514,7 +524,7 @@ class ConfigureBaseOSAppStreamTask(BaseTask):
             "You need BOTH BaseOS and AppStream repos configured",
             "Without these repos, you cannot install packages for other tasks",
             "Configure repos FIRST on the exam before attempting other tasks",
-            "Common format: http://content.example.com/rhel9.0/x86_64/dvd/BaseOS",
+            "Common format: http://content.example.com/rhel10.0/x86_64/dvd/BaseOS",
         ]
         self.server_url = None
         self.baseos_url = None
@@ -525,10 +535,10 @@ class ConfigureBaseOSAppStreamTask(BaseTask):
     def generate(self, **params):
         """Generate BaseOS + AppStream repository configuration task."""
         servers = [
-            'http://content.example.com/rhel9.0/x86_64/dvd',
-            'http://repo.lab.example.com/rhel9/x86_64',
-            'http://mirror.internal.example.com/rhel9',
-            'http://classroom.example.com/content/rhel9.0/x86_64/dvd',
+            'http://content.example.com/rhel10.0/x86_64/dvd',
+            'http://repo.lab.example.com/rhel10/x86_64',
+            'http://mirror.internal.example.com/rhel10',
+            'http://classroom.example.com/content/rhel10.0/x86_64/dvd',
             'file:///repo',
         ]
 
@@ -756,29 +766,29 @@ class TroubleshootBrokenRepoTask(BaseTask):
             {
                 'repo_id': 'broken-baseos',
                 'break_type': 'wrong_url',
-                'correct_url': 'http://content.example.com/rhel9/BaseOS',
-                'broken_url': 'http://content.example.com/rhel8/BaseOS',
+                'correct_url': 'http://content.example.com/rhel10/BaseOS',
+                'broken_url': 'http://content.example.com/rhel9/BaseOS',
                 'desc': 'The BaseOS URL points to the wrong RHEL version',
             },
             {
                 'repo_id': 'broken-appstream',
                 'break_type': 'missing_baseurl',
-                'correct_url': 'http://content.example.com/rhel9/AppStream',
+                'correct_url': 'http://content.example.com/rhel10/AppStream',
                 'broken_url': '',
                 'desc': 'The AppStream repository has no baseurl configured',
             },
             {
                 'repo_id': 'broken-custom',
                 'break_type': 'disabled',
-                'correct_url': 'http://repo.lab.example.com/rhel9/custom',
-                'broken_url': 'http://repo.lab.example.com/rhel9/custom',
+                'correct_url': 'http://repo.lab.example.com/rhel10/custom',
+                'broken_url': 'http://repo.lab.example.com/rhel10/custom',
                 'desc': 'The custom repository exists but is disabled (enabled=0)',
             },
             {
                 'repo_id': 'broken-extras',
                 'break_type': 'bad_gpgkey',
-                'correct_url': 'http://mirror.internal.example.com/rhel9/extras',
-                'broken_url': 'http://mirror.internal.example.com/rhel9/extras',
+                'correct_url': 'http://mirror.internal.example.com/rhel10/extras',
+                'broken_url': 'http://mirror.internal.example.com/rhel10/extras',
                 'desc': 'The extras repository has an invalid GPG key path',
             },
             {
@@ -969,7 +979,7 @@ class AddThirdPartyRepoTask(BaseTask):
             {
                 'repo_id': 'elrepo',
                 'repo_name': 'ELRepo Repository',
-                'base_url': 'https://elrepo.org/linux/elrepo/el9/x86_64/',
+                'base_url': 'https://elrepo.org/linux/elrepo/el10/x86_64/',
                 'gpgcheck': 1,
                 'gpg_key_url': 'https://www.elrepo.org/RPM-GPG-KEY-elrepo.org',
             },

--- a/tasks/scripting.py
+++ b/tasks/scripting.py
@@ -879,19 +879,11 @@ class ScriptCommandSubstitutionTask(BaseTask):
             f"  - Store command output in a variable"
         )
 
-        if self.task_type == 'count_users':
-            example = 'USER_COUNT=$(wc -l < /etc/passwd)'
-        elif self.task_type == 'current_date':
-            example = 'BACKUP_FILE="backup_$(date +%Y%m%d).tar"'
-        else:
-            example = 'FREE_SPACE=$(df -h / | tail -1 | awk \'{print $4}\')'
-
         self.hints = [
-            "Modern syntax: VAR=$(command)",
+            "Modern syntax: VAR=$(command)  — preferred over backticks",
             "Legacy syntax: VAR=`command`",
-            f"Example: {example}",
-            'Use the variable: echo "Result: $VAR"',
-            "Nested: $(cat $(find /etc -name hosts))"
+            "Make the script executable: chmod +x " + self.script_path,
+            'Use the variable after assignment: echo "$VAR"',
         ]
 
         return self

--- a/tasks/systemd_timers.py
+++ b/tasks/systemd_timers.py
@@ -735,7 +735,7 @@ class EnableTimerTask(BaseTask):
         self.timer_name = None
 
     def generate(self, **params):
-        # Pick a well-known timer that typically ships with RHEL 9
+        # Pick a well-known timer that typically ships with RHEL 10
         well_known_timers = [
             'fstrim',
             'logrotate',

--- a/tasks/time_services.py
+++ b/tasks/time_services.py
@@ -382,11 +382,12 @@ class SetSystemDateTask(BaseTask):
 
     def inject_fault(self):
         import subprocess as _sp
-        _sp.run(['timedatectl', 'set-ntp', 'false'], capture_output=True)
-        _sp.run(['systemctl', 'stop', 'chronyd'], capture_output=True)
+        # Start from NTP-enabled state so the user must disable it to set time.
+        _sp.run(['timedatectl', 'set-ntp', 'true'], capture_output=True)
+        _sp.run(['systemctl', 'enable', '--now', 'chronyd'], capture_output=True)
         from tasks.troubleshooting import save_fault_state
         save_fault_state(self.id, {'service': 'chronyd'})
-        return True, "Disabled NTP so manual time-setting is possible"
+        return True, "NTP is active — disable it, then set the clock to the target time"
 
     def restore_fault(self):
         import subprocess as _sp
@@ -397,31 +398,41 @@ class SetSystemDateTask(BaseTask):
         return True, "Re-enabled NTP sync"
 
     def validate(self):
+        import datetime
         checks = []
         score = 0
 
-        # Check 1: NTP was disabled first (user ran set-ntp false) — now should be off
-        # OR they re-enabled it: either state shows they engaged with the task.
-        # We award points for knowing to disable NTP before setting time manually.
+        # Check 1: NTP disabled (prerequisite the user must do)
         r = execute_safe(['timedatectl', 'show', '--property=NTP'])
-        ntp_off = r.success and 'NTP=no' in r.stdout
-        if ntp_off:
-            checks.append(ValidationCheck("ntp_disabled", True, 3,
-                message="NTP is disabled — manual time can be set with timedatectl set-time"))
-            score += 3
+        if r.success and 'NTP=no' in r.stdout:
+            checks.append(ValidationCheck("ntp_disabled", True, 2,
+                message="NTP is disabled — manual time setting is possible"))
+            score += 2
         else:
-            checks.append(ValidationCheck("ntp_disabled", False, 0, max_points=3,
-                message="NTP must be disabled before setting time manually: timedatectl set-ntp false"))
+            checks.append(ValidationCheck("ntp_disabled", False, 0, max_points=2,
+                message="NTP is still active: run 'timedatectl set-ntp false' first"))
 
-        # Check 2: chronyd is stopped (consistent with NTP disabled for manual set)
-        r = execute_safe(['systemctl', 'is-active', 'chronyd'])
-        if r.success and r.stdout.strip() != 'active':
-            checks.append(ValidationCheck("chrony_stopped", True, 3,
-                message="chronyd is stopped — system clock is under manual control"))
-            score += 3
-        else:
-            checks.append(ValidationCheck("chrony_stopped", False, 0, max_points=3,
-                message="chronyd is still running — stop it before setting time manually"))
+        # Check 2: System time is approximately the target (within 5 minutes)
+        try:
+            target_dt = datetime.datetime.strptime(self.target_time, '%Y-%m-%d %H:%M:%S')
+            r2 = execute_safe(['date', '+%s'])
+            if r2.success:
+                current_ts = int(r2.stdout.strip())
+                target_ts = int(target_dt.timestamp())
+                delta = abs(current_ts - target_ts)
+                if delta <= 300:
+                    checks.append(ValidationCheck("time_set", True, 4,
+                        message=f"System time matches target ({self.target_time})"))
+                    score += 4
+                else:
+                    checks.append(ValidationCheck("time_set", False, 0, max_points=4,
+                        message=f"System time is off by {delta}s — run: timedatectl set-time '{self.target_time}'"))
+            else:
+                checks.append(ValidationCheck("time_set", False, 0, max_points=4,
+                    message="Could not read system time"))
+        except Exception:
+            checks.append(ValidationCheck("time_set", False, 0, max_points=4,
+                message="Time validation error"))
 
         return ValidationResult(self.id, score >= self.points * 0.7, score, self.points, checks)
 

--- a/tasks/time_services.py
+++ b/tasks/time_services.py
@@ -14,6 +14,44 @@ from validators.file_validators import validate_file_exists, validate_file_conta
 logger = logging.getLogger(__name__)
 
 
+# ── Fault injection for time-sync tasks ──────────────────────────────────────
+# On a fresh RHEL system chronyd is already active+enabled and NTP is already
+# on, so a "make NTP work" task would otherwise pass without the candidate doing
+# anything. These helpers break that default state so real work is required.
+
+def _inject_time_sync_fault(task_id):
+    """Stop/disable chronyd and turn NTP off, saving prior state for restore."""
+    from tasks.troubleshooting import save_fault_state, _run
+
+    act = _run(['systemctl', 'is-active', 'chronyd'])
+    was_active = act.stdout.strip() == 'active'
+    en = _run(['systemctl', 'is-enabled', 'chronyd'])
+    was_enabled = 'enabled' in (en.stdout or '')
+    ntp = _run(['timedatectl', 'show', '--property=NTP'])
+    ntp_was_on = 'yes' in (ntp.stdout or '').lower()
+
+    _run(['timedatectl', 'set-ntp', 'false'])
+    _run(['systemctl', 'stop', 'chronyd'])
+    _run(['systemctl', 'disable', 'chronyd'])
+
+    info = {
+        'chronyd_was_active': was_active,
+        'chronyd_was_enabled': was_enabled,
+        'ntp_was_on': ntp_was_on,
+    }
+    save_fault_state(task_id, info)
+    return info, "Stopped/disabled chronyd and turned NTP off"
+
+
+def _restore_time_sync_fault(info):
+    """Restore chronyd/NTP to the state captured by _inject_time_sync_fault."""
+    from tasks.troubleshooting import _restore_time_sync, clear_fault_state
+    msgs = []
+    _restore_time_sync(info or {}, msgs)
+    clear_fault_state()
+    return '; '.join(msgs)
+
+
 @TaskRegistry.register("time_services")
 class ConfigureTimezoneTask(BaseTask):
     """Set system timezone."""
@@ -101,6 +139,8 @@ class ConfigureChronydTask(BaseTask):
             difficulty="medium",
             points=12
         )
+        self.has_fault_injection = True
+        self._fault_info = None
         self.ntp_server = None
 
     def generate(self, **params):
@@ -130,6 +170,13 @@ class ConfigureChronydTask(BaseTask):
         ]
 
         return self
+
+    def inject_fault(self):
+        self._fault_info, msg = _inject_time_sync_fault(self.id)
+        return True, msg
+
+    def restore_fault(self):
+        return True, _restore_time_sync_fault(self._fault_info)
 
     def validate(self):
         """Validate chrony configuration."""
@@ -236,6 +283,8 @@ class EnableNTPSyncTask(BaseTask):
             difficulty="easy",
             points=6
         )
+        self.has_fault_injection = True
+        self._fault_info = None
         self.exam_tips = [
             "'timedatectl set-ntp true' enables NTP and starts chronyd automatically.",
             "'systemctl enable --now chronyd' is the lower-level equivalent.",
@@ -260,21 +309,11 @@ class EnableNTPSyncTask(BaseTask):
         return self
 
     def inject_fault(self):
-        import subprocess as _sp
-        _sp.run(['timedatectl', 'set-ntp', 'false'], capture_output=True)
-        _sp.run(['systemctl', 'stop', 'chronyd'], capture_output=True)
-        _sp.run(['systemctl', 'disable', 'chronyd'], capture_output=True)
-        from tasks.troubleshooting import save_fault_state
-        save_fault_state(self.id, {'service': 'chronyd'})
-        return True, "Disabled NTP and stopped chronyd"
+        self._fault_info, msg = _inject_time_sync_fault(self.id)
+        return True, msg
 
     def restore_fault(self):
-        import subprocess as _sp
-        _sp.run(['systemctl', 'enable', '--now', 'chronyd'], capture_output=True)
-        _sp.run(['timedatectl', 'set-ntp', 'true'], capture_output=True)
-        from tasks.troubleshooting import clear_fault_state
-        clear_fault_state()
-        return True, "Re-enabled chronyd and NTP"
+        return True, _restore_time_sync_fault(self._fault_info)
 
     def validate(self):
         checks = []

--- a/tasks/time_services.py
+++ b/tasks/time_services.py
@@ -225,7 +225,9 @@ class ConfigureChronydTask(BaseTask):
 
 @TaskRegistry.register("time_services")
 class EnableNTPSyncTask(BaseTask):
-    """Enable NTP time synchronization."""
+    """Fault-injection: chronyd is stopped/disabled; user must re-enable it."""
+
+    has_fault_injection = True
 
     def __init__(self):
         super().__init__(
@@ -234,86 +236,78 @@ class EnableNTPSyncTask(BaseTask):
             difficulty="easy",
             points=6
         )
-
-    def generate(self, **params):
-        """Generate NTP enable task."""
-        self.description = (
-            f"Enable NTP time synchronization:\n"
-            f"  - Enable automatic time sync\n"
-            f"  - Ensure chronyd service is running\n"
-            f"  - Verify NTP is active"
-        )
-
-        self.hints = [
-            "Enable NTP: timedatectl set-ntp true",
-            "Check status: timedatectl",
-            "This requires chronyd (or ntpd) to be installed",
-            "Start chronyd: systemctl start chronyd"
+        self.exam_tips = [
+            "'timedatectl set-ntp true' enables NTP and starts chronyd automatically.",
+            "'systemctl enable --now chronyd' is the lower-level equivalent.",
+            "Verify sync with: timedatectl status  (look for 'NTP service: active')",
         ]
 
+    def generate(self, **params):
+        self.description = (
+            "TROUBLESHOOTING: NTP Time Sync Disabled\n"
+            "Symptom: The system clock is not synchronizing with time servers.\n"
+            "chronyd has been stopped and disabled.\n\n"
+            "Tasks:\n"
+            "  1. Re-enable automatic NTP time synchronization\n"
+            "  2. Ensure the chronyd service is running\n"
+            "  3. Verify NTP sync is active"
+        )
+        self.hints = [
+            "Enable NTP: timedatectl set-ntp true",
+            "Or: systemctl enable --now chronyd",
+            "Verify: timedatectl  (look for 'NTP service: active')",
+        ]
         return self
 
+    def inject_fault(self):
+        import subprocess as _sp
+        _sp.run(['timedatectl', 'set-ntp', 'false'], capture_output=True)
+        _sp.run(['systemctl', 'stop', 'chronyd'], capture_output=True)
+        _sp.run(['systemctl', 'disable', 'chronyd'], capture_output=True)
+        from tasks.troubleshooting import save_fault_state
+        save_fault_state(self.id, {'service': 'chronyd'})
+        return True, "Disabled NTP and stopped chronyd"
+
+    def restore_fault(self):
+        import subprocess as _sp
+        _sp.run(['systemctl', 'enable', '--now', 'chronyd'], capture_output=True)
+        _sp.run(['timedatectl', 'set-ntp', 'true'], capture_output=True)
+        from tasks.troubleshooting import clear_fault_state
+        clear_fault_state()
+        return True, "Re-enabled chronyd and NTP"
+
     def validate(self):
-        """Validate NTP is enabled."""
         checks = []
-        total_points = 0
+        score = 0
 
-        # Check 1: NTP enabled
-        result = execute_safe(['timedatectl', 'show', '--property=NTP'])
-        if result.success and 'yes' in result.stdout.lower():
-            checks.append(ValidationCheck(
-                name="ntp_enabled",
-                passed=True,
-                points=3,
-                message="NTP is enabled"
-            ))
-            total_points += 3
+        r = execute_safe(['timedatectl', 'show', '--property=NTP'])
+        if r.success and 'NTP=yes' in r.stdout:
+            checks.append(ValidationCheck("ntp_enabled", True, 3, message="NTP is enabled"))
+            score += 3
         else:
-            checks.append(ValidationCheck(
-                name="ntp_enabled",
-                passed=False,
-                points=0,
-                max_points=3,
-                message="NTP is not enabled"
-            ))
+            checks.append(ValidationCheck("ntp_enabled", False, 0, max_points=3,
+                                          message="NTP is not enabled (timedatectl set-ntp true)"))
 
-        # Check 2: Time service running
-        result = execute_safe(['systemctl', 'is-active', 'chronyd'])
-        if result.success and result.stdout.strip() == 'active':
-            checks.append(ValidationCheck(
-                name="service_running",
-                passed=True,
-                points=3,
-                message="Time service is running"
-            ))
-            total_points += 3
+        r = execute_safe(['systemctl', 'is-active', 'chronyd'])
+        svc_ok = r.success and r.stdout.strip() == 'active'
+        if not svc_ok:
+            r2 = execute_safe(['systemctl', 'is-active', 'ntpd'])
+            svc_ok = r2.success and r2.stdout.strip() == 'active'
+        if svc_ok:
+            checks.append(ValidationCheck("service_running", True, 3, message="Time service is running"))
+            score += 3
         else:
-            # Try ntpd
-            result2 = execute_safe(['systemctl', 'is-active', 'ntpd'])
-            if result2.success and result2.stdout.strip() == 'active':
-                checks.append(ValidationCheck(
-                    name="service_running",
-                    passed=True,
-                    points=3,
-                    message="ntpd service is running"
-                ))
-                total_points += 3
-            else:
-                checks.append(ValidationCheck(
-                    name="service_running",
-                    passed=False,
-                    points=0,
-                    max_points=3,
-                    message="No time service running"
-                ))
+            checks.append(ValidationCheck("service_running", False, 0, max_points=3,
+                                          message="No time service running (systemctl start chronyd)"))
 
-        passed = total_points >= (self.points * 0.7)
-        return ValidationResult(self.id, passed, total_points, self.points, checks)
+        return ValidationResult(self.id, score >= self.points * 0.7, score, self.points, checks)
 
 
 @TaskRegistry.register("time_services")
 class SetSystemDateTask(BaseTask):
-    """Set system date and time manually."""
+    """Set system date and time manually (requires disabling NTP first)."""
+
+    has_fault_injection = True
 
     def __init__(self):
         super().__init__(
@@ -323,48 +317,74 @@ class SetSystemDateTask(BaseTask):
             points=6
         )
         self.target_time = None
+        self.exam_tips = [
+            "timedatectl set-ntp false MUST come before set-time or it will be rejected.",
+            "After setting time manually, re-enable NTP: timedatectl set-ntp true",
+            "The format is: timedatectl set-time 'YYYY-MM-DD HH:MM:SS'",
+        ]
 
     def generate(self, **params):
-        """Generate set time task."""
-        # Use a specific time for testing
         self.target_time = params.get('time', '2025-06-15 14:30:00')
 
         self.description = (
-            f"Set system date and time:\n"
-            f"  - Set to: {self.target_time}\n"
-            f"  - Disable NTP first (required)\n"
-            f"  - Use timedatectl command"
+            f"Set the system clock manually:\n"
+            f"  1. Disable NTP synchronization (required before manual set)\n"
+            f"  2. Set the system time to: {self.target_time}\n"
+            f"  3. Verify the time was applied\n"
+            f"  (Re-enabling NTP afterwards is good practice but not validated here)"
         )
-
         self.hints = [
             "Disable NTP first: timedatectl set-ntp false",
             f"Set time: timedatectl set-time '{self.target_time}'",
-            "Format: YYYY-MM-DD HH:MM:SS",
-            "Verify: timedatectl or date",
-            "Re-enable NTP after: timedatectl set-ntp true"
+            "Verify: timedatectl  or  date",
+            "Re-enable after: timedatectl set-ntp true",
         ]
-
         return self
 
+    def inject_fault(self):
+        import subprocess as _sp
+        _sp.run(['timedatectl', 'set-ntp', 'false'], capture_output=True)
+        _sp.run(['systemctl', 'stop', 'chronyd'], capture_output=True)
+        from tasks.troubleshooting import save_fault_state
+        save_fault_state(self.id, {'service': 'chronyd'})
+        return True, "Disabled NTP so manual time-setting is possible"
+
+    def restore_fault(self):
+        import subprocess as _sp
+        _sp.run(['timedatectl', 'set-ntp', 'true'], capture_output=True)
+        _sp.run(['systemctl', 'enable', '--now', 'chronyd'], capture_output=True)
+        from tasks.troubleshooting import clear_fault_state
+        clear_fault_state()
+        return True, "Re-enabled NTP sync"
+
     def validate(self):
-        """Validate time setting (just checks NTP is disabled since we can't persist time)."""
         checks = []
-        total_points = 0
+        score = 0
 
-        # For this task, we just verify NTP can be disabled
-        result = execute_safe(['timedatectl', 'show', '--property=NTP'])
+        # Check 1: NTP was disabled first (user ran set-ntp false) — now should be off
+        # OR they re-enabled it: either state shows they engaged with the task.
+        # We award points for knowing to disable NTP before setting time manually.
+        r = execute_safe(['timedatectl', 'show', '--property=NTP'])
+        ntp_off = r.success and 'NTP=no' in r.stdout
+        if ntp_off:
+            checks.append(ValidationCheck("ntp_disabled", True, 3,
+                message="NTP is disabled — manual time can be set with timedatectl set-time"))
+            score += 3
+        else:
+            checks.append(ValidationCheck("ntp_disabled", False, 0, max_points=3,
+                message="NTP must be disabled before setting time manually: timedatectl set-ntp false"))
 
-        # This is a learning task - validate that user understands the process
-        checks.append(ValidationCheck(
-            name="time_task",
-            passed=True,
-            points=6,
-            message="Time setting task - verify manually with 'timedatectl'"
-        ))
-        total_points += 6
+        # Check 2: chronyd is stopped (consistent with NTP disabled for manual set)
+        r = execute_safe(['systemctl', 'is-active', 'chronyd'])
+        if r.success and r.stdout.strip() != 'active':
+            checks.append(ValidationCheck("chrony_stopped", True, 3,
+                message="chronyd is stopped — system clock is under manual control"))
+            score += 3
+        else:
+            checks.append(ValidationCheck("chrony_stopped", False, 0, max_points=3,
+                message="chronyd is still running — stop it before setting time manually"))
 
-        passed = True
-        return ValidationResult(self.id, passed, total_points, self.points, checks)
+        return ValidationResult(self.id, score >= self.points * 0.7, score, self.points, checks)
 
 
 @TaskRegistry.register("time_services")

--- a/tasks/troubleshooting.py
+++ b/tasks/troubleshooting.py
@@ -91,6 +91,18 @@ def restore_any_active_fault():
         if param:
             subprocess.run(['grubby', '--remove-args', param, '--update-kernel=ALL'], capture_output=True)
             msgs.append(f"Removed injected kernel parameter '{param}'")
+    elif task_id == 'fs_extend_001':
+        vg = info.get('vg', 'vg_practice')
+        lv = info.get('lv', 'lv_practice')
+        pv = info.get('pv', '')
+        mp = info.get('mp', '/mnt/practice_extend')
+        subprocess.run(['umount', mp], capture_output=True)
+        subprocess.run(['lvremove', '-ff', f'/dev/{vg}/{lv}'], capture_output=True)
+        subprocess.run(['vgchange', '-an', vg], capture_output=True)
+        subprocess.run(['vgremove', '-ff', vg], capture_output=True)
+        if pv:
+            subprocess.run(['pvremove', '-ff', '-y', pv], capture_output=True)
+        msgs.append(f"Cleaned up practice LVM ({vg}/{lv}) and {mp}")
     else:
         msgs.append(f"Unknown fault type: {task_id}")
 

--- a/tasks/troubleshooting.py
+++ b/tasks/troubleshooting.py
@@ -103,6 +103,44 @@ def restore_any_active_fault():
         if pv:
             subprocess.run(['pvremove', '-ff', '-y', pv], capture_output=True)
         msgs.append(f"Cleaned up practice LVM ({vg}/{lv}) and {mp}")
+    elif task_id == 'lvm_vg_extend_001':
+        vg = info.get('vg', 'vg_practice')
+        for dev in filter(None, [info.get('base_dev'), info.get('new_dev')]):
+            pass
+        subprocess.run(['vgchange', '-an', vg], capture_output=True)
+        subprocess.run(['vgremove', '-ff', vg], capture_output=True)
+        for dev in filter(None, [info.get('base_dev'), info.get('new_dev')]):
+            subprocess.run(['pvremove', '-ff', '-y', dev], capture_output=True)
+        msgs.append(f"Cleaned up VG {vg}")
+    elif task_id == 'journalctl_persistent_journal_001':
+        import shutil as _shutil
+        backup = info.get('backup', '/var/lib/rhcsa-simulator/journald.conf.bak')
+        if os.path.exists(backup):
+            _shutil.copy2(backup, '/etc/systemd/journald.conf')
+            os.remove(backup)
+        subprocess.run(['systemctl', 'restart', 'systemd-journald'], capture_output=True)
+        msgs.append("Restored journald.conf")
+    elif task_id == 'boot_troubleshoot_001':
+        orig_target = info.get('orig_target', 'multi-user.target')
+        subprocess.run(['systemctl', 'set-default', orig_target], capture_output=True)
+        added_param = info.get('added_param')
+        removed_param = info.get('removed_param')
+        if added_param:
+            subprocess.run(['grubby', '--remove-args', added_param, '--update-kernel=ALL'], capture_output=True)
+        if removed_param:
+            subprocess.run(['grubby', '--args', removed_param, '--update-kernel=ALL'], capture_output=True)
+        grub_cfg = info.get('grub_cfg', '/boot/grub2/grub.cfg')
+        subprocess.run(['grub2-mkconfig', '-o', grub_cfg], capture_output=True)
+        msgs.append(f"Restored boot config (target={orig_target})")
+    elif task_id == 'net_full_setup_001':
+        iface = info.get('iface', 'dummy0')
+        conn = info.get('conn', 'practice-net')
+        orig_hostname = info.get('orig_hostname', '')
+        subprocess.run(['nmcli', 'con', 'delete', conn], capture_output=True)
+        subprocess.run(['ip', 'link', 'delete', iface], capture_output=True)
+        if orig_hostname:
+            subprocess.run(['hostnamectl', 'set-hostname', orig_hostname], capture_output=True)
+        msgs.append(f"Cleaned up {iface} and {conn}")
     else:
         msgs.append(f"Unknown fault type: {task_id}")
 
@@ -254,20 +292,20 @@ class SELinuxHttpdContextFaultTask(TroubleshootingTask):
     def generate(self, **params):
         self.description = (
             "TROUBLESHOOTING: Apache Serving 403 Forbidden\n"
-            "=" * 50 + "\n\n"
-            "Symptom: httpd is running but returns 403 Forbidden for all requests.\n"
-            "The web content exists in /var/www/html but cannot be served.\n\n"
+            + "=" * 50 + "\n\n"
+            "Symptom: httpd is running but clients receive 403 Forbidden\n"
+            "for all requests. Web content exists but cannot be served.\n\n"
             "Tasks:\n"
-            "  1. Identify why httpd cannot read /var/www/html\n"
-            "  2. Fix the SELinux issue\n"
-            "  3. Verify httpd can serve content (curl http://localhost)\n"
-            "  4. Ensure the fix survives a relabel (restorecon)"
+            "  1. Diagnose why httpd cannot read the web content\n"
+            "  2. Fix the root cause\n"
+            "  3. Verify: curl http://localhost returns the page content\n"
+            "  4. Ensure the fix is permanent (survives relabeling)"
         )
         self.hints = [
-            "Check SELinux denials: ausearch -m AVC -ts recent | audit2why",
-            "Inspect the context: ls -lZ /var/www/html",
-            "The correct context type is httpd_sys_content_t",
-            "Fix: restorecon -Rv /var/www/html",
+            "Check service status: systemctl status httpd",
+            "Look for access denials: ausearch -m AVC -ts recent",
+            "Inspect file permissions and security context: ls -laZ /var/www/html",
+            "Verify context is correct after any fix with: ls -lZ /var/www/html",
         ]
         return self
 
@@ -364,7 +402,7 @@ class SELinuxHttpdBooleanFaultTask(TroubleshootingTask):
     def generate(self, **params):
         self.description = (
             "TROUBLESHOOTING: Apache Cannot Connect to Backend\n"
-            "=" * 50 + "\n\n"
+            + "=" * 50 + "\n\n"
             "Symptom: httpd is running but cannot make outgoing network connections\n"
             "to a backend service (proxy, database, API). Requests time out.\n\n"
             "Tasks:\n"
@@ -465,7 +503,7 @@ class FirewallHttpBlockedFaultTask(TroubleshootingTask):
     def generate(self, **params):
         self.description = (
             "TROUBLESHOOTING: Web Server Unreachable from Network\n"
-            "=" * 50 + "\n\n"
+            + "=" * 50 + "\n\n"
             "Symptom: httpd is running and serving locally (curl localhost works),\n"
             "but the web server is not reachable from external clients on port 80.\n\n"
             "Tasks:\n"
@@ -560,7 +598,7 @@ class SshdBadConfigFaultTask(TroubleshootingTask):
     def generate(self, **params):
         self.description = (
             "TROUBLESHOOTING: sshd Will Not Restart\n"
-            "=" * 50 + "\n\n"
+            + "=" * 50 + "\n\n"
             "Symptom: Attempting to restart sshd fails with a config parse error.\n"
             "Current sessions still work, but sshd cannot be reloaded or restarted.\n\n"
             "Tasks:\n"
@@ -649,7 +687,7 @@ class HttpdDisabledFaultTask(TroubleshootingTask):
     def generate(self, **params):
         self.description = (
             "TROUBLESHOOTING: Web Service Not Running at Boot\n"
-            "=" * 50 + "\n\n"
+            + "=" * 50 + "\n\n"
             "Symptom: After a reboot, httpd is not running. The service was\n"
             "previously configured but is now stopped and disabled.\n\n"
             "Tasks:\n"
@@ -738,7 +776,7 @@ class SudoersWrongPermsFaultTask(TroubleshootingTask):
     def generate(self, **params):
         self.description = (
             f"TROUBLESHOOTING: sudo Privileges Not Working\n"
-            "=" * 50 + "\n\n"
+            + "=" * 50 + "\n\n"
             f"Symptom: User '{self.PRACTICE_USER}' has a sudoers file in\n"
             f"/etc/sudoers.d/ but sudo still says they are not in the sudoers file.\n\n"
             "Tasks:\n"
@@ -844,7 +882,7 @@ class BadFstabFaultTask(TroubleshootingTask):
     def generate(self, **params):
         self.description = (
             "TROUBLESHOOTING: Bad /etc/fstab Entry\n"
-            "=" * 50 + "\n\n"
+            + "=" * 50 + "\n\n"
             "Symptom: After adding a filesystem to /etc/fstab, running 'mount -a'\n"
             "produces errors. The bad entry will cause an emergency mode boot.\n\n"
             "Tasks:\n"

--- a/tasks/troubleshooting.py
+++ b/tasks/troubleshooting.py
@@ -72,8 +72,25 @@ def restore_any_active_fault():
         _restore_service(info, msgs)
     elif task_id.startswith('fault_sudoers'):
         _restore_sudoers_full(info, msgs)
-    elif task_id.startswith('fault_fstab'):
+    elif task_id.startswith('fault_fstab') or task_id == 'boot_fstab_validate_001':
         _restore_fstab(info, msgs)
+    elif task_id in ('time_ntp_001', 'time_set_001'):
+        subprocess.run(['systemctl', 'enable', '--now', 'chronyd'], capture_output=True)
+        subprocess.run(['timedatectl', 'set-ntp', 'true'], capture_output=True)
+        msgs.append("Re-enabled NTP / chronyd")
+    elif task_id == 'fw_enable_001':
+        subprocess.run(['systemctl', 'enable', '--now', 'firewalld'], capture_output=True)
+        msgs.append("Re-enabled firewalld")
+    elif task_id == 'fw_reload_001':
+        svc = info.get('service', 'tftp')
+        subprocess.run(['firewall-cmd', '--permanent', '--remove-service', svc], capture_output=True)
+        subprocess.run(['firewall-cmd', '--remove-service', svc], capture_output=True)
+        msgs.append(f"Removed injected firewall service '{svc}'")
+    elif task_id == 'boot_kernel_param_remove_001':
+        param = info.get('parameter', '')
+        if param:
+            subprocess.run(['grubby', '--remove-args', param, '--update-kernel=ALL'], capture_output=True)
+            msgs.append(f"Removed injected kernel parameter '{param}'")
     else:
         msgs.append(f"Unknown fault type: {task_id}")
 

--- a/tasks/troubleshooting.py
+++ b/tasks/troubleshooting.py
@@ -74,13 +74,10 @@ def restore_any_active_fault():
         _restore_sudoers_full(info, msgs)
     elif task_id.startswith('fault_fstab') or task_id == 'boot_fstab_validate_001':
         _restore_fstab(info, msgs)
-    elif task_id in ('time_ntp_001', 'time_set_001'):
-        subprocess.run(['systemctl', 'enable', '--now', 'chronyd'], capture_output=True)
-        subprocess.run(['timedatectl', 'set-ntp', 'true'], capture_output=True)
-        msgs.append("Re-enabled NTP / chronyd")
-    elif task_id == 'fw_enable_001':
-        subprocess.run(['systemctl', 'enable', '--now', 'firewalld'], capture_output=True)
-        msgs.append("Re-enabled firewalld")
+    elif task_id.startswith('time_ntp') or task_id.startswith('time_chrony') or task_id == 'time_set_001':
+        _restore_time_sync(info, msgs)
+    elif task_id.startswith('fw_enable') or task_id == 'fw_enable_001':
+        _restore_service(info, msgs)
     elif task_id == 'fw_reload_001':
         svc = info.get('service', 'tftp')
         subprocess.run(['firewall-cmd', '--permanent', '--remove-service', svc], capture_output=True)
@@ -105,8 +102,6 @@ def restore_any_active_fault():
         msgs.append(f"Cleaned up practice LVM ({vg}/{lv}) and {mp}")
     elif task_id == 'lvm_vg_extend_001':
         vg = info.get('vg', 'vg_practice')
-        for dev in filter(None, [info.get('base_dev'), info.get('new_dev')]):
-            pass
         subprocess.run(['vgchange', '-an', vg], capture_output=True)
         subprocess.run(['vgremove', '-ff', vg], capture_output=True)
         for dev in filter(None, [info.get('base_dev'), info.get('new_dev')]):
@@ -236,6 +231,17 @@ def _restore_sudoers_full(info, msgs):
         msgs.append(f"Removed practice user {user}")
 
 
+def _restore_time_sync(info, msgs):
+    """Restore chronyd/NTP state broken by the time-sync fault injectors."""
+    if info.get('chronyd_was_enabled', True):
+        _run(['systemctl', 'enable', 'chronyd'])
+    if info.get('chronyd_was_active', True):
+        _run(['systemctl', 'start', 'chronyd'])
+    if info.get('ntp_was_on', True):
+        _run(['timedatectl', 'set-ntp', 'true'])
+    msgs.append("Restored chronyd/NTP state")
+
+
 def _restore_fstab(info, msgs):
     marker = info.get('marker', '')
     if marker:
@@ -293,8 +299,8 @@ class SELinuxHttpdContextFaultTask(TroubleshootingTask):
         self.description = (
             "TROUBLESHOOTING: Apache Serving 403 Forbidden\n"
             + "=" * 50 + "\n\n"
-            "Symptom: httpd is running but clients receive 403 Forbidden\n"
-            "for all requests. Web content exists but cannot be served.\n\n"
+            "Symptom: httpd is running but returns 403 Forbidden for all requests.\n"
+            "The web content exists in /var/www/html but cannot be served.\n\n"
             "Tasks:\n"
             "  1. Diagnose why httpd cannot read the web content\n"
             "  2. Fix the root cause\n"
@@ -302,10 +308,10 @@ class SELinuxHttpdContextFaultTask(TroubleshootingTask):
             "  4. Ensure the fix is permanent (survives relabeling)"
         )
         self.hints = [
-            "Check service status: systemctl status httpd",
-            "Look for access denials: ausearch -m AVC -ts recent",
-            "Inspect file permissions and security context: ls -laZ /var/www/html",
-            "Verify context is correct after any fix with: ls -lZ /var/www/html",
+            "Check SELinux denials: ausearch -m AVC -ts recent | audit2why",
+            "Inspect the context with ls -lZ and compare to a working web root",
+            "Web content is normally labelled with the httpd_sys_content_t type",
+            "Restore the default file context recursively so it survives a relabel",
         ]
         return self
 
@@ -413,8 +419,8 @@ class SELinuxHttpdBooleanFaultTask(TroubleshootingTask):
         self.hints = [
             "Check denials: ausearch -m AVC -ts recent | audit2why",
             "List relevant booleans: getsebool -a | grep httpd",
-            f"Fix: setsebool -P {self.boolean_name} on",
-            "Verify: getsebool httpd_can_network_connect",
+            "audit2why names the boolean to enable — set it persistently (-P)",
+            "Verify with getsebool once you have enabled it",
         ]
         return self
 
@@ -513,8 +519,8 @@ class FirewallHttpBlockedFaultTask(TroubleshootingTask):
         )
         self.hints = [
             "Check active rules: firewall-cmd --list-all",
-            "Add service: firewall-cmd --zone=public --add-service=http --permanent",
-            "Reload to activate: firewall-cmd --reload",
+            "Add the http service to the active zone and make the change permanent",
+            "Reload to activate permanent changes: firewall-cmd --reload",
             "Verify: firewall-cmd --query-service=http",
         ]
         return self
@@ -697,7 +703,7 @@ class HttpdDisabledFaultTask(TroubleshootingTask):
         )
         self.hints = [
             "Check service state: systemctl status httpd",
-            "Start + enable: systemctl enable --now httpd",
+            "Start the service now AND enable it so it comes back at boot",
             "Verify: systemctl is-active httpd && systemctl is-enabled httpd",
         ]
         return self
@@ -787,7 +793,7 @@ class SudoersWrongPermsFaultTask(TroubleshootingTask):
         self.hints = [
             "Check file permissions: ls -l /etc/sudoers.d/",
             "sudo ignores files with world-writable or group-writable permissions",
-            f"Fix: chmod 440 {self.SUDOERS_FILE}",
+            "Restore the restrictive permissions sudo requires on a sudoers file",
             f"Verify: sudo -l -U {self.PRACTICE_USER}",
         ]
         return self

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -621,3 +621,23 @@ def print_timer_status(remaining_str, is_critical=False, is_warning=False):
         time_display = success(remaining_str)
 
     print(f"  {icon}{time_display} remaining")
+
+
+def page_output(text: str) -> None:
+    """
+    Display text through less if it is taller than the terminal.
+    Preserves ANSI color codes (-R), exits immediately if content
+    fits on one screen (-F), and does not clear the screen on exit (-X).
+    Falls back to plain print if less is not available.
+    """
+    import os
+    import subprocess
+    pager = os.environ.get('PAGER', 'less')
+    try:
+        proc = subprocess.Popen(
+            [pager, '-R', '-F', '-X'],
+            stdin=subprocess.PIPE,
+        )
+        proc.communicate(input=text.encode('utf-8', errors='replace'))
+    except (FileNotFoundError, OSError):
+        print(text)

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -625,19 +625,25 @@ def print_timer_status(remaining_str, is_critical=False, is_warning=False):
 
 def page_output(text: str) -> None:
     """
-    Display text through less if it is taller than the terminal.
-    Preserves ANSI color codes (-R), exits immediately if content
-    fits on one screen (-F), and does not clear the screen on exit (-X).
-    Falls back to plain print if less is not available.
+    Display text through less (ANSI-color-aware).
+    Writes to a temp file so less can use stdin for keyboard navigation.
+    -R: show ANSI colors  -F: exit if fits on one screen  -X: no clear on exit
+    Falls back to plain print if less is unavailable.
     """
     import os
     import subprocess
+    import tempfile
+
     pager = os.environ.get('PAGER', 'less')
     try:
-        proc = subprocess.Popen(
-            [pager, '-R', '-F', '-X'],
-            stdin=subprocess.PIPE,
-        )
-        proc.communicate(input=text.encode('utf-8', errors='replace'))
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.txt', delete=False, encoding='utf-8'
+        ) as tf:
+            tf.write(text)
+            fname = tf.name
+        try:
+            subprocess.run([pager, '-R', '-F', '-X', fname])
+        finally:
+            os.unlink(fname)
     except (FileNotFoundError, OSError):
         print(text)


### PR DESCRIPTION
## Summary

- **Fault injection for auto-passing tasks** — `EnableNTPSyncTask`, `ConfigureChronydTask`, `EnableFirewallTask`, `PersistentJournalTask`, `BootTroubleshootingTask`, `ExtendFilesystemTask`, `ExtendVGTask` all now inject a real fault before showing the task so the student can't score points without doing anything
- **Fixed `SetSystemDateTask.validate()`** — previously awarded full marks for the fault-injected state itself (NTP disabled + chronyd stopped); now validates that the user actually set the clock to the target time
- **Dummy network interface** — all networking tasks use `dummy0` (created on demand) instead of the live `ens160` connection; `FullNetworkSetupTask` added with full inject/restore
- **Answer-giving hints removed** — SELinux 403 task, `ScriptCommandSubstitutionTask`, `ConfigureRepoTask`, firewall/httpd/sudoers troubleshooting tasks no longer include the exact fix command in hints
- **Title repetition bug** — Python implicit string concatenation `"TITLE\n" "=" * 50` repeated the title 50×; fixed with explicit `+` in all 7 troubleshooting task descriptions
- **RHEL 9 → RHEL 10** — repo URLs, task descriptions, and exam tips updated throughout `repos.py`, `filesystems.py`, `lvm.py`, `systemd_timers.py`, `networking.py`
- **Pager** — task display now pipes through `less` via a temp file so keyboard navigation works in tmux without `ctrl+b [`
- **Task preview** — session shows a task list before any faults are injected; user can press R to reshuffle or S to start
- **`tmux` removed** from downgrade package pool (can't downgrade it while running the simulator in tmux)
- **Crash recovery** — `restore_any_active_fault()` dispatcher updated for all new task IDs

## Test plan

- [ ] Run a networking practice session — confirm `dummy0` is used, not `ens160`
- [ ] Run `EnableFirewallTask` — confirm firewalld is stopped before task appears
- [ ] Run `SetSystemDateTask` — confirm task fails if you do nothing, passes after `timedatectl set-ntp false && timedatectl set-time '...'`
- [ ] Run `PersistentJournalTask` — confirm `/var/log/journal` is missing when task appears
- [ ] Check troubleshooting task titles print correctly (no repetition)
- [ ] Verify pager works without tmux scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)