### PR TITLE
Fix 10 exam bugs

### DIFF
--- a/tasks/boot.py
+++ b/tasks/boot.py
@@ -737,22 +737,23 @@ class ValidateFstabTask(BaseTask):
 
     def inject_fault(self):
         import subprocess as _sp
+
+        with open('/etc/fstab') as f:
+            current = f.read()
+        if 'UUID=00000000-dead-beef-0000-badbadbad00' in current:
+            return True, "fstab fault already active"
+
         os.makedirs(self.NOFAIL_MOUNTPOINT, exist_ok=True)
 
         entries = (
-            f"UUID=00000000-dead-beef-0000-badbadbad00 /mnt/nonexistent xfs defaults 0 2"
-            f"  # {self.BAD_UUID_MARKER}\n"
-            f"/dev/sdZ99 {self.NOFAIL_MOUNTPOINT} xfs defaults 0 0"
-            f"  # {self.NOFAIL_MARKER}\n"
+            "UUID=00000000-dead-beef-0000-badbadbad00 /mnt/nonexistent xfs defaults 0 2\n"
+            f"/dev/sdZ99 {self.NOFAIL_MOUNTPOINT} xfs defaults 0 0\n"
         )
         with open('/etc/fstab', 'a') as f:
             f.write(entries)
 
         from tasks.troubleshooting import save_fault_state
-        save_fault_state(self.id, {
-            'bad_uuid_marker': self.BAD_UUID_MARKER,
-            'nofail_marker': self.NOFAIL_MARKER,
-        })
+        save_fault_state(self.id, {})
         return True, "Added bad UUID entry and nofail-missing /backup entry to /etc/fstab"
 
     def restore_fault(self):
@@ -760,7 +761,8 @@ class ValidateFstabTask(BaseTask):
             with open('/etc/fstab') as f:
                 lines = f.readlines()
             cleaned = [l for l in lines
-                       if self.BAD_UUID_MARKER not in l and self.NOFAIL_MARKER not in l]
+                       if 'UUID=00000000-dead-beef-0000-badbadbad00' not in l
+                       and '/dev/sdZ99' not in l]
             with open('/etc/fstab', 'w') as f:
                 f.writelines(cleaned)
             try:
@@ -782,7 +784,7 @@ class ValidateFstabTask(BaseTask):
         fstab_text = ''.join(fstab_lines)
 
         # Check 1: bad UUID entry removed (4 pts)
-        if self.BAD_UUID_MARKER not in fstab_text:
+        if 'UUID=00000000-dead-beef-0000-badbadbad00' not in fstab_text:
             checks.append(ValidationCheck("bad_entry_removed", True, 4,
                 message="Non-existent UUID entry has been removed"))
             score += 4
@@ -812,7 +814,7 @@ class ValidateFstabTask(BaseTask):
 
         # Check 4: /backup entry has nofail (4 pts)
         nofail_line = next(
-            (l for l in fstab_lines if self.NOFAIL_MARKER in l), None
+            (l for l in fstab_lines if '/dev/sdZ99' in l), None
         )
         if nofail_line is None:
             # User removed the line entirely — also acceptable, award partial

--- a/tasks/boot_recovery.py
+++ b/tasks/boot_recovery.py
@@ -25,6 +25,8 @@ logger = logging.getLogger(__name__)
 class RootPasswordResetTask(BaseTask):
     """Reset root password using the rd.break boot procedure."""
 
+    exam_eligible = False
+
     def __init__(self):
         super().__init__(
             id="boot_recovery_root_pw_reset_001",

--- a/tasks/filesystems.py
+++ b/tasks/filesystems.py
@@ -23,6 +23,8 @@ logger = logging.getLogger(__name__)
 class CreateFilesystemTask(BaseTask):
     """Create a filesystem on a device."""
 
+    exclusive_resource = 'physical_disk'
+
     def __init__(self):
         super().__init__(
             id="fs_create_001",
@@ -101,6 +103,8 @@ class CreateFilesystemTask(BaseTask):
 @TaskRegistry.register("filesystems")
 class MountFilesystemTask(BaseTask):
     """Mount a filesystem at a specific mount point."""
+
+    exclusive_resource = 'physical_disk'
 
     def __init__(self):
         super().__init__(
@@ -195,6 +199,8 @@ class MountFilesystemTask(BaseTask):
 @TaskRegistry.register("filesystems")
 class PersistentMountTask(BaseTask):
     """Configure persistent mount in /etc/fstab using UUID."""
+
+    exclusive_resource = 'physical_disk'
 
     def __init__(self):
         super().__init__(
@@ -344,6 +350,8 @@ class PersistentMountTask(BaseTask):
 class ConfigureSwapTask(BaseTask):
     """Swap configuration — lives in tasks/swap.py; kept here only to avoid import errors."""
 
+    exclusive_resource = 'physical_disk'
+
     def __init__(self):
         super().__init__(
             id="fs_swap_001",
@@ -467,7 +475,7 @@ class ExtendFilesystemTask(BaseTask):
             difficulty="exam",
             points=10
         )
-        self.tags = ['v10-new', 'filesystem', 'resize', 'xfs', 'ext4', 'fault-injection']
+        self.tags = ['v10-new', 'filesystem', 'resize', 'ext4', 'fault-injection']
         self.exam_tips = [
             "For XFS: use 'xfs_growfs <mount_point>' (must be mounted)",
             "For ext4: use 'resize2fs <device>' (can be done online for growth)",
@@ -481,7 +489,7 @@ class ExtendFilesystemTask(BaseTask):
 
     def generate(self, **params):
         self.device = f'/dev/mapper/{self._VG}-{self._LV}'
-        self.fstype = params.get('fstype', random.choice(['xfs', 'ext4']))
+        self.fstype = params.get('fstype', 'ext4')
         self.expected_size_mb = params.get('size', random.choice([250, 300, 350]))
 
         grow_cmd = f'xfs_growfs {self._MP}' if self.fstype == 'xfs' else f'resize2fs {self.device}'
@@ -505,6 +513,10 @@ class ExtendFilesystemTask(BaseTask):
         import os
         import subprocess as _sp
         from utils.helpers import get_loop_devices
+
+        check = _sp.run(['vgs', '--noheadings', '-o', 'vg_name'], capture_output=True, text=True)
+        if self._VG in (check.stdout or ''):
+            return True, f"{self._VG} already set up"
 
         loops = get_loop_devices()
         if not loops:
@@ -565,6 +577,7 @@ class ExtendFilesystemTask(BaseTask):
         _sp.run(['vgremove', '-ff', vg], capture_output=True)
         if pv:
             _sp.run(['pvremove', '-ff', '-y', pv], capture_output=True)
+            _sp.run(['wipefs', '-a', pv], capture_output=True)
 
         clear_fault_state()
         return True, f"Removed {vg}/{lv} and cleaned up {mp}"

--- a/tasks/journalctl.py
+++ b/tasks/journalctl.py
@@ -262,6 +262,10 @@ class PersistentJournalTask(BaseTask):
         conf = '/etc/systemd/journald.conf'
         backup = '/var/lib/rhcsa-simulator/journald.conf.bak'
         os.makedirs(os.path.dirname(backup), exist_ok=True)
+        if not os.path.exists(conf):
+            os.makedirs(os.path.dirname(conf), exist_ok=True)
+            with open(conf, 'w') as f:
+                f.write('[Journal]\n# Storage=auto\n')
         shutil.copy2(conf, backup)
 
         # Remove /var/log/journal to break persistence

--- a/tasks/lvm.py
+++ b/tasks/lvm.py
@@ -360,6 +360,8 @@ class ExtendLVTask(BaseTask):
 class LVMFullWorkflowTask(BaseTask):
     """Complete LVM workflow: Create PV, VG, LV, format, and mount."""
 
+    exclusive_resource = 'physical_disk'
+
     def __init__(self):
         super().__init__(
             id="lvm_full_workflow_001",
@@ -411,13 +413,11 @@ class LVMFullWorkflowTask(BaseTask):
         )
 
         self.hints = [
-            f"Step 1: pvcreate {self.device}",
-            f"Step 2: vgcreate {self.vg_name} {self.device}",
-            f"Step 3: lvcreate -L {self.lv_size_mb}M -n {self.lv_name} {self.vg_name}",
-            f"Step 4: mkfs.{self.fstype} /dev/{self.vg_name}/{self.lv_name}",
-            f"Step 5: mkdir -p {self.mount_point} && mount /dev/{self.vg_name}/{self.lv_name} {self.mount_point}",
-            f"Step 6: Add to /etc/fstab with UUID (get with blkid)",
-            "Full path: /dev/mapper/{vg_name}-{lv_name}"
+            f"The LVM stack is: physical volume → volume group → logical volume → filesystem → mount",
+            f"pvcreate initializes {self.device} as a PV; vgcreate builds a VG on top of it",
+            f"lvcreate -L <size>M -n <name> <vg> creates a logical volume",
+            f"Format with mkfs.{self.fstype}, then mount and add to /etc/fstab using UUID",
+            f"Test persistence: mount -a (should not error after fstab edit)",
         ]
 
         return self

--- a/tasks/networking.py
+++ b/tasks/networking.py
@@ -66,7 +66,9 @@ def _ensure_practice_interface():
     if PRACTICE_CONNECTION not in names:
         _run(['nmcli', 'con', 'add', 'type', 'dummy',
               'con-name', PRACTICE_CONNECTION, 'ifname', PRACTICE_INTERFACE,
-              'ipv4.method', 'manual', 'ipv4.addresses', _PRACTICE_BASE_IP])
+              'ipv4.method', 'manual', 'ipv4.addresses', _PRACTICE_BASE_IP,
+              'ipv4.never-default', 'yes', 'ipv6.never-default', 'yes',
+              'connection.autoconnect', 'no'])
         _run(['nmcli', 'con', 'up', PRACTICE_CONNECTION])
     return PRACTICE_INTERFACE
 

--- a/tasks/registry.py
+++ b/tasks/registry.py
@@ -211,7 +211,18 @@ class TaskRegistry:
             if not trimmed:
                 break
 
+        def _exam_eligible(task):
+            """Return True if the task may appear in an exam."""
+            if task is None:
+                return False
+            if getattr(task, 'exam_eligible', True) is False:
+                return False
+            if getattr(task, 'requires_reboot', False):
+                return False
+            return True
+
         # Generate tasks per domain — enforce one task per category to avoid duplicates
+        used_exclusive_resources = set()
         for domain_num, needed in domain_counts.items():
             domain_cats = [
                 cat for cat, dom in settings.CATEGORY_TO_DOMAIN.items()
@@ -235,7 +246,16 @@ class TaskRegistry:
                 task = cls.get_random_task(category=cat, difficulty="exam")
                 if not task:
                     task = cls.get_random_task(category=cat)
+                if not _exam_eligible(task):
+                    task = None
+                if task:
+                    res = getattr(task, 'exclusive_resource', None)
+                    if res and res in used_exclusive_resources:
+                        task = None
                 if task and task.id not in exclude_ids:
+                    res = getattr(task, 'exclusive_resource', None)
+                    if res:
+                        used_exclusive_resources.add(res)
                     tasks.append(task)
                     exclude_ids.append(task.id)
                     used_cats.add(cat)
@@ -244,7 +264,16 @@ class TaskRegistry:
         # If we couldn't fill all slots, add random tasks (allowing category repeats as last resort)
         while len(tasks) < count:
             task = cls.get_random_task(difficulty="exam")
+            if not _exam_eligible(task):
+                task = None
+            if task:
+                res = getattr(task, 'exclusive_resource', None)
+                if res and res in used_exclusive_resources:
+                    task = None
             if task and task.id not in exclude_ids:
+                res = getattr(task, 'exclusive_resource', None)
+                if res:
+                    used_exclusive_resources.add(res)
                 tasks.append(task)
                 exclude_ids.append(task.id)
 

--- a/tasks/selinux.py
+++ b/tasks/selinux.py
@@ -4,6 +4,7 @@ Covers modes, contexts, booleans, ports, troubleshooting, AVC analysis,
 user mappings, service diagnostics, and filesystem relabeling.
 """
 
+import os
 import random
 import logging
 from tasks.base import BaseTask
@@ -462,6 +463,8 @@ class SetSELinuxPortTask(BaseTask):
 class TroubleshootSELinuxDenialTask(BaseTask):
     """Troubleshoot and fix an SELinux denial using audit2why / sealert."""
 
+    has_fault_injection = True
+
     def __init__(self):
         super().__init__(
             id="selinux_denial_001",
@@ -517,10 +520,9 @@ class TroubleshootSELinuxDenialTask(BaseTask):
                 f"  4. Verify the service can access the directory"
             )
             self.hints = [
-                "ausearch -m avc -ts recent | audit2why",
-                "sealert -a /var/log/audit/audit.log",
-                f"semanage fcontext -a -t {self.expected_context} '{self.directory}(/.*)?'",
-                f"restorecon -Rv {self.directory}",
+                "Check the audit log: ausearch -m avc -ts recent | audit2why",
+                f"The directory needs the correct SELinux type for {self.service} to access it",
+                "Use semanage fcontext to make the change persistent, then apply it",
             ]
         else:  # boolean
             self.description = (
@@ -541,6 +543,33 @@ class TroubleshootSELinuxDenialTask(BaseTask):
             ]
 
         return self
+
+    def inject_fault(self):
+        import subprocess as _sp
+        if self.fix_type == 'fcontext' and self.directory:
+            os.makedirs(self.directory, exist_ok=True)
+            test_file = os.path.join(self.directory, 'index.html')
+            if not os.path.exists(test_file):
+                with open(test_file, 'w') as f:
+                    f.write('<html><body>Test</body></html>\n')
+            _sp.run(['chcon', '-Rt', 'tmp_t', self.directory], capture_output=True)
+            from tasks.troubleshooting import save_fault_state
+            save_fault_state(self.id, {'directory': self.directory, 'fix_type': self.fix_type})
+            return True, f"Created {self.directory} with wrong SELinux context (tmp_t)"
+        return True, "No directory setup needed for boolean fix type"
+
+    def restore_fault(self):
+        import subprocess as _sp
+        import shutil
+        from tasks.troubleshooting import load_fault_state, clear_fault_state
+        state = load_fault_state()
+        info = state.get('restore_info', {}) if state else {}
+        directory = info.get('directory', self.directory)
+        if directory and os.path.exists(directory):
+            _sp.run(['restorecon', '-Rv', directory], capture_output=True)
+            shutil.rmtree(directory, ignore_errors=True)
+        clear_fault_state()
+        return True, f"Removed {directory}"
 
     def validate(self):
         checks = []

--- a/tasks/swap.py
+++ b/tasks/swap.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 class CreateSwapPartitionTask(BaseTask):
     """Create and activate a swap partition."""
 
+    exclusive_resource = 'physical_disk'
+
     def __init__(self):
         super().__init__(
             id="swap_partition_001",


### PR DESCRIPTION
## Summary

- **Bug 1** (journalctl.py): Create `/etc/systemd/journald.conf` with default content before `shutil.copy2` if it doesn't exist (RHEL 10 uses drop-in dirs)
- **Bug 2** (filesystems.py): `ExtendFilesystemTask` always uses `ext4` (XFS needs 300MB min, task only allocates 150MB); add idempotency check and `wipefs -a` in restore
- **Bug 3** (boot.py): Removed comment markers from injected fstab entries; updated `restore_fault()` and `validate()` to match lines by content
- **Bug 4** (boot.py): `ValidateFstabTask.inject_fault()` now checks if fault is already active before appending
- **Bug 5** (boot_recovery.py): Added `exam_eligible = False` to `RootPasswordResetTask`
- **Bug 6** (selinux.py): Added `has_fault_injection = True`, `inject_fault()`, `restore_fault()` to `TroubleshootSELinuxDenialTask`; replaced exact-command hints with directional ones
- **Bug 7** (registry.py, lvm.py, swap.py, filesystems.py): Added `exclusive_resource = 'physical_disk'` to 5 task classes; `generate_exam()` tracks and enforces exclusive resource conflicts
- **Bug 8** (registry.py): `generate_exam()` skips tasks with `exam_eligible=False` or `requires_reboot=True` in both the domain loop and the fallback fill loop
- **Bug 9** (networking.py): `_ensure_practice_interface()` nmcli con add now includes `ipv4.never-default yes`, `ipv6.never-default yes`, `connection.autoconnect no`
- **Bug 10** (lvm.py): Replaced step-by-step exact commands in `LVMFullWorkflowTask` hints with directional guidance

## Test plan

- [ ] `python3 -c "from tasks.registry import TaskRegistry; TaskRegistry.initialize()"` passes (194 tasks)
- [ ] Run `sudo python3 rhcsa_simulator.py --exam` and confirm no `RootPasswordResetTask` or `requires_reboot` tasks appear
- [ ] Run `sudo python3 rhcsa_simulator.py --exam` multiple times; confirm at most one `physical_disk`-exclusive task per exam
- [ ] Inject `ValidateFstabTask` fault: confirm fstab entries have no comment markers
- [ ] Check dummy0 NM profile has `ipv4.never-default=yes` after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FgWz3fNftoscdNVgDjRc9Q