### PR TITLE
Fix exam device conflicts + generation-time task provisioning + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ python3 -m pytest -v            # Verbose output
 
 - `rhcsa_simulator.py` — Main entry point
 - `core/` — Engine: task manager, exam loop, SM-2 spaced repetition, ResultsDB
-- `tasks/` — Task definitions (198 tasks, 27 categories, 9 domains)
+- `tasks/` — Task definitions (194 tasks, 25 categories, 8 domains)
 - `validators/` — Safe read-only system validators for each task type
 - `utils/` — AI feedback, progress reports, device detection
 - `config/` — Settings and constants

--- a/README.md
+++ b/README.md
@@ -1,513 +1,245 @@
 # RHCSA Mock Exam Simulator
 
-A realistic command-line RHCSA EX200 v10 (Red Hat Enterprise Linux 10) exam simulator that generates exam tasks, validates your system configuration, and tracks your progress over time.
+A realistic command-line **RHCSA EX200 v10** (Red Hat Enterprise Linux 10) exam
+simulator. It generates exam tasks, sets up the practice environment for you,
+validates your real system configuration with safe read-only checks, and tracks
+your progress over time.
 
-> **EX200 v10 aligned**: All tasks cover the official Red Hat EX200 v10 exam objectives. Containers/Podman and DNF module streams have been removed (they are not on the v10 exam). Flatpak, systemd timers, tuning profiles (tuned-adm), and secure file transfer (scp) are included as they appear on the v10 objectives.
+> **EX200 v10 aligned** — tasks cover the Red Hat EX200 v10 objectives. The bank
+> currently ships **194 tasks across 25 categories in 8 domains**. Flatpak,
+> systemd timers, tuning profiles (`tuned-adm`), and secure file transfer are
+> included; legacy module streams are not.
 
-> **Note**: This project is under active development. While functional and useful for RHCSA prep, you may encounter bugs or incomplete features. Contributions, bug reports, and feedback are welcome!
+> **Active development** — functional and useful for RHCSA prep, but you may hit
+> rough edges. Bug reports and contributions welcome.
 
-## Features
+---
 
-### Learning Modes
-- **Learn Mode**: Study RHCSA concepts with detailed explanations, command syntax, examples, common mistakes, and exam tricks
-- **Guided Practice**: Practice tasks with progressive 3-level hints (concept → command structure → full solution)
-- **Command Recall Training**: Build muscle memory by typing commands before execution with instant accuracy feedback
+## Quick Start
 
-### Testing Modes
-- **Full Exam Mode**: Simulates a complete RHCSA exam with 15-20 tasks covering all objectives
-- **Practice Mode**: Focus on specific categories (Users, LVM, SELinux, etc.) at different difficulty levels with **retry support**
-- **Scenario Mode**: Multi-step real-world scenarios that combine multiple skills
-- **Troubleshooting Mode**: Diagnose and fix broken system configurations
+```bash
+# 1. On a RHEL 10 / Rocky 10 / Alma 10 VM, become root
+sudo -i
 
-### Core Features
-- **Automatic Validation**: Validates your system configuration using safe, read-only commands
-- **Adaptive Feedback**: Explains what was expected vs. what was found for each failed check
-- **Progress Tracking**: Saves exam results and displays statistics over time
-- **Weak Area Analysis**: Identifies your weak spots and provides targeted recommendations
-- **Bookmarks**: Save difficult tasks to revisit later
-- **Export Reports**: Generate progress reports in TXT, HTML, or PDF format
-- **Timer Support**: Optional 2.5-hour timer to simulate real exam conditions
-- **Offline Operation**: No internet connection required
-- **Safe & Secure**: Uses command whitelisting and validation-only approach
+# 2. Get the code
+git clone https://github.com/justbest23/rhcsa-simulator.git
+cd rhcsa-simulator
 
-### Practice Disk Support
-- **Dynamic Device Detection**: LVM tasks automatically detect available disks
-- **Loop Device Support**: Create virtual practice disks - no extra hardware needed!
-- **Easy Setup**: Menu-driven setup for practice disks (option 13)
-- **Works on Cloud VMs**: Practice LVM on AWS/Azure/GCP without adding volumes
+# 3. Install (interactive). For an unattended install use: ./install.sh --yes
+./install.sh
 
-### AI-Powered Feedback (Optional)
-- **Intelligent Analysis**: Line-by-line command analysis using Claude AI
-- **Smart Explanations**: Understands WHY you failed, not just that you failed
-- **Approach Comparison**: Compares your solution to optimal approaches
-- **Contextual Tips**: RHCSA exam tips personalized to each task
-- **Command Tracking**: Automatically tracks and categorizes commands you execute
+# 4. Launch (must be root — validation inspects real system state)
+rhcsa-simulator
 
-**Setup**: See [AI_SETUP.md](AI_SETUP.md) for configuration instructions (requires Anthropic API key)
+# 5. At the menu, press  E  for a full Mock Exam, or  Q  for a 5-task quick round.
+```
+
+That's it. The simulator **auto-creates the practice disks it needs** (loop
+devices, plus any spare disk such as `/dev/sda`) and **sets up each task's
+starting state** when an exam begins — so a "kill the apache processes" task
+actually has processes running, and an "extend the logical volume" task actually
+has a volume to extend. When the exam ends, it tears all of that back down.
+
+**Typical loop:** read a task → do it on the system in another terminal → come
+back and press Enter to validate → review per-check feedback and score.
+
+---
 
 ## Requirements
 
-- **OS**: RHEL 10, Rocky Linux 9/10, or Alma Linux 9/10 (EX200 v10 exam targets RHEL 10)
-- **Python**: 3.9 or later (included in RHEL 10)
-- **Privileges**: Must run as root (uses `sudo`)
-- **Dependencies**: None (uses Python standard library only)
+| | Minimum |
+|---|---|
+| **OS** | RHEL 10, Rocky Linux 9/10, or AlmaLinux 9/10 (EX200 v10 targets RHEL 10) |
+| **Python** | 3.6+ (ships with the OS) |
+| **Privileges** | root (validation reads users, services, mounts, SELinux, etc.) |
+| **Dependencies** | none — Python standard library only |
+| **Disk** | a few hundred MB free under `/var/lib/rhcsa-simulator` for loop-device images |
+| **Network** | not required (optional, only for the DNF-history practice setup) |
+
+### Recommended VM configuration
+
+Practice on a **throwaway VM you can snapshot/revert**, never a machine you care
+about — tasks change real system state (users, partitions, services, firewall,
+SELinux).
+
+- **vCPUs:** 2
+- **RAM:** 2–4 GB
+- **Primary disk:** 20 GB (OS)
+- **A spare disk for storage practice:** optional. The simulator auto-creates
+  500 MB loop devices, so you don't *need* one. If you add a small spare disk
+  (e.g. a 1–2 GB `/dev/sda`), it is detected and added to the practice device
+  pool automatically — handy for realistic `fdisk`/`parted` partitioning.
+- **Install type:** minimal install is fine.
+- **Snapshot first:** take a VM snapshot before a session so you can revert.
+- **SELinux:** leave it **Enforcing** for realistic SELinux tasks.
+- **Networking:** any NAT/bridged setup; only needed if you want the optional
+  DNF transaction-history practice data.
+
+> Cloud VMs (AWS/Azure/GCP) work well — loop devices mean you don't have to
+> attach extra block storage to practice LVM/partitioning.
+
+---
 
 ## Installation
 
-### Quick Install
+### Install script
 
 ```bash
-# Download or clone the repository
 cd rhcsa-simulator
-
-# Run installation script
-sudo ./install.sh
+./install.sh            # interactive
+./install.sh --yes      # unattended (overwrite existing install, no prompts)
+./install.sh --no-populate   # skip the optional DNF-history setup
 ```
 
-The installer will:
-- Check Python version
-- Copy files to `/opt/rhcsa-simulator`
-- Create symlink at `/usr/local/bin/rhcsa-simulator`
-- Set proper permissions
+The installer:
+- checks the Python version and OS,
+- copies files to `/opt/rhcsa-simulator`,
+- creates the `rhcsa-simulator` command at `/usr/local/bin/rhcsa-simulator`,
+- sets permissions,
+- offers to build some DNF transaction history for the package-history tasks.
 
-### Manual Installation
+`install.sh` auto-detects a non-interactive shell (piped/scripted) and runs
+unattended, so it won't stall in automation.
+
+### Run without installing
 
 ```bash
-sudo mkdir -p /opt/rhcsa-simulator
-sudo cp -r * /opt/rhcsa-simulator/
-sudo chmod +x /opt/rhcsa-simulator/rhcsa_simulator.py
-sudo ln -s /opt/rhcsa-simulator/rhcsa_simulator.py /usr/local/bin/test-rhcsa-simulator
+sudo python3 rhcsa_simulator.py
 ```
+
+---
 
 ## Usage
 
-### Launch the Simulator
+Launch the interactive menu:
 
 ```bash
-sudo test-rhcsa-simulator
+sudo rhcsa-simulator
 ```
 
-**Note**: Root privileges are required to validate system state (users, services, permissions, etc.)
+Main menu options:
 
-### Exam Mode
+| Key | Mode | What it does |
+|---|---|---|
+| `Q` | **Quick Practice** | 5 random tasks, fast feedback |
+| `E` | **Mock Exam** | Full timed exam (20–25 tasks) with environment setup + reboot-persistence simulation |
+| `1` | **Learn Mode** | Study by domain — concepts, commands, tips |
+| `2` | **Practice Mode** | One category at a time, with retry & progressive hints |
+| `3` | **Adaptive Mode** | SM-2 spaced repetition — focuses your weak/overdue areas |
+| `4` | **Dashboard** | Stats, history, weak areas |
+| `5` | **Export Report** | Write a progress report (text) to `data/` |
+| `6` | **Result History** | Drill into past exams task by task |
+| `S` | **Setup** | Practice disks, system reset, DNF-history setup |
+| `0` | Exit | |
 
-1. Select "Exam Mode" from main menu
-2. Review exam information (tasks, duration, pass threshold)
-3. Press Enter to generate exam tasks
-4. Read all tasks carefully
-5. Complete tasks on your Linux system
-6. Return to simulator and press Enter to validate
-7. Review your results and detailed feedback
+### Command-line shortcuts
 
-### Learn Mode
-
-1. Select "Learn Mode" from main menu
-2. Choose a topic to study
-3. Review:
-   - Concept explanations
-   - Command syntax with examples
-   - Common mistakes to avoid
-   - Exam-specific tricks and tips
-4. Optionally jump to practice mode for that topic
-
-### Guided Practice Mode
-
-1. Select "Guided Practice" from main menu
-2. Choose a category and difficulty level
-3. Read each task carefully
-4. Use progressive hints if needed:
-   - Hint 1: Concept reminder
-   - Hint 2: Command structure and syntax
-   - Hint 3: Full solution with examples
-5. Complete task and get adaptive feedback
-6. Review detailed explanations for any failures
-
-### Command Recall Training
-
-1. Select "Command Recall" from main menu
-2. Choose a category and difficulty level
-3. Read the task description
-4. Type the command(s) you would use
-5. Get instant feedback on command accuracy
-6. Build muscle memory and improve speed
-
-### Practice Mode
-
-1. Select "Practice Mode" from main menu
-2. Choose a category:
-   - Users & Groups
-   - Permissions & ACLs
-   - LVM (Logical Volume Management)
-   - SELinux
-   - Services (systemd)
-   - And more...
-3. Select difficulty level (easy/exam/hard)
-4. Complete each task and get immediate feedback
-5. **If you fail**: Choose to Retry, see Solution, or Continue
-6. Review fix suggestions for each failed check
-
-### Setup Practice Disks (for LVM)
-
-If you don't have spare disks for LVM practice:
-
-1. Select "Setup Practice Disks" from main menu (option 13)
-2. Choose "Create practice disks (2 x 500MB)"
-3. Virtual loop devices are created automatically
-4. LVM tasks will now use these devices
-
-**Manual method:**
 ```bash
-# Create disk images
-sudo dd if=/dev/zero of=/tmp/disk1.img bs=1M count=500
-sudo dd if=/dev/zero of=/tmp/disk2.img bs=1M count=500
-
-# Attach as loop devices
-sudo losetup -f --show /tmp/disk1.img  # Returns /dev/loop0
-sudo losetup -f --show /tmp/disk2.img  # Returns /dev/loop1
-
-# Now practice LVM on /dev/loop0, /dev/loop1
+rhcsa-simulator --quick            # 5 random tasks
+rhcsa-simulator --quick lvm        # 5 LVM tasks
+rhcsa-simulator --exam             # jump straight into a mock exam
+rhcsa-simulator --practice lvm     # practice a specific category
+rhcsa-simulator --learn            # study mode
+rhcsa-simulator --adaptive         # SM-2 weak-area practice
+rhcsa-simulator --list-categories  # list categories/domains (no root needed)
+rhcsa-simulator --version
 ```
 
-### View Progress
+---
 
-Track your improvement over time:
-- Overall statistics (average score, pass rate)
-- Recent exam results
-- Performance by category
+## Practice disks (LVM / partitioning / swap / filesystems)
 
-### Weak Area Analysis
+You normally don't have to do anything — exams provision disks automatically.
+To manage them yourself, use **Setup → Practice Disks**:
 
-Identify where you need more practice:
-1. Select "Weak Areas" from main menu
-2. View categories with lowest success rates
-3. Get personalized recommendations
-4. Focus your study time effectively
+- **Create loop devices** — three 500 MB virtual disks (no spare hardware needed).
+- **Use a real disk** — point practice at a spare drive already in the VM.
+- **Clean up / reset** — remove practice LVM structures and detach loop devices.
 
-### Bookmarks
+Under the hood, every whole-disk task in an exam is handed a **distinct** device
+from the pool, so an LVM task and a partitioning task never collide on the same
+disk. Loop-device images live in `/var/lib/rhcsa-simulator/loops/`.
 
-Save tasks to revisit later:
-- Bookmark difficult tasks during practice
-- Review all bookmarked tasks from menu
-- Clear bookmarks when mastered
+**Setup also offers:** *System Reset* (remove practice artifacts — LVM, swap
+files, practice repos, cron/at jobs, scripts — without touching SSH/network/users)
+and *Populate Practice Environment* (build DNF transaction history).
 
-### Export Reports
+---
 
-Generate progress reports:
-1. Select "Export Report" from main menu
-2. Choose format: TXT, HTML, or PDF
-3. Share or print your progress
+## Task domains & categories
 
-## Recommended Learning Path
+8 EX200 v10 domains, 25 categories:
 
-For best results, follow this progression:
+1. **Software Management** — packages, repos, flatpak
+2. **System Setup & Boot** — boot targets, boot recovery, journald
+3. **Users, Groups & Permissions** — users/groups, permissions/ACLs, essential tools
+4. **Storage & Filesystems** — partitioning, LVM, filesystems, swap, network storage
+5. **Network & DNS** — networking, SSH
+6. **Systemd, Services & Processes** — services, systemd timers, processes, time services, troubleshooting
+7. **Security** — SELinux, firewall
+8. **Automation & Scripting** — scheduling (cron/at/timers), shell scripting
 
-1. **Learn** - Study each topic with Learn Mode
-   - Understand concepts before practicing
-   - Review command syntax and examples
-   - Learn common mistakes and exam tricks
+Run `rhcsa-simulator --list-categories` for the live list and per-category task counts.
 
-2. **Guided Practice** - Build confidence with hints
-   - Start practicing tasks with support
-   - Use hints when stuck
-   - Learn from adaptive feedback
+---
 
-3. **Command Recall** - Build muscle memory
-   - Practice typing commands from memory
-   - Improve speed and accuracy
-   - Build exam-day confidence
+## How it works
 
-4. **Practice Mode** - Test without hints
-   - Validate your knowledge independently
-   - Identify weak areas
-   - Build problem-solving skills
+**Read-only validation.** The simulator checks your work with whitelisted,
+timeout-protected, read-only commands (`id`, `lsblk`, `systemctl is-active`,
+`getenforce`, …). It does not modify your system *to grade* it — only the
+exam's setup/teardown phase changes state, and it reverses what it created.
 
-5. **Exam Mode** - Full exam simulation
-   - Take complete timed exams
-   - Simulate real exam pressure
-   - Track your progress over time
+**Scoring.** Each task is worth points with multiple checks and partial credit.
+Default pass threshold is 70%. A full exam is 20–25 tasks over a 3-hour timer
+(configurable), followed by a reboot-persistence simulation for tasks that must
+survive a reboot.
 
-**Pro Tip**: Cycle through topics rather than mastering one at a time. This improves retention and helps you see connections between different RHCSA objectives.
+**Progress.** Results and spaced-repetition state are stored in a local SQLite
+database under `/opt/rhcsa-simulator/data/` (`ResultsDB`). Adaptive mode uses an
+SM-2 schedule (per-category easiness factor, 1→6→interval×EF progression).
 
-## Task Categories
-
-The simulator covers **100% of RHCSA EX200 exam objectives**:
-
-### Core System Administration
-1. **Essential Tools** - find, grep, tar, archives
-2. **Users & Groups** - user/group management, sudo
-3. **Permissions** - chmod, chown, ACLs, special bits
-4. **Services** - systemd service management
-5. **Boot Targets** - multi-user, graphical targets
-6. **Processes** - process management, priorities
-7. **Scheduling** - cron, at, systemd timers
-
-### Storage Management
-8. **LVM** - physical volumes, volume groups, logical volumes
-9. **File Systems** - create, mount, fstab, XFS, ext4
-10. **Disk Partitioning** - fdisk, parted, GPT/MBR
-11. **RAID** - mdadm arrays, persistent configuration
-12. **Advanced Storage** - Stratis, thin provisioning, swap
-
-### Networking & Security
-13. **Networking** - interface configuration, DNS, hostnames
-14. **SELinux** - contexts, booleans, modes
-15. **SSH** - key generation, authorized_keys, sshd security
-16. **Firewall** - firewalld zones, services, ports
-
-### Additional Topics
-17. **Shell Scripting** - bash scripts, conditionals, loops, arguments
-18. **Package Management** - dnf, rpm, repos, module streams
-19. **Time Services** - chrony, NTP, timezone configuration
-20. **Network Storage** - NFS mounts, autofs, CIFS/SMB
-21. **Containers** - Podman basics
-
-## Example Tasks
-
-### User Management
-```
-Task: Create a user named 'examuser42' with the following requirements:
-  - UID: 2500
-  - Primary group: developers
-  - Supplementary groups: wheel, sysadmin
-  - Home directory: /home/examuser42
-  - Login shell: /bin/bash
-```
-
-### SELinux
-```
-Task: Configure SELinux context for directory '/srv/web01':
-  - Set SELinux type to: httpd_sys_content_t
-  - Apply context recursively to all files
-  - Make the change persistent across relabels
-```
-
-### Services
-```
-Task: Configure the 'httpd' service:
-  - Start the service
-  - Enable the service to start at boot
-```
-
-## How It Works
-
-### Validation Process
-
-The simulator uses **read-only validation**:
-- Does NOT modify your system
-- Only checks if tasks were completed correctly
-- Uses safe, whitelisted commands (`id`, `ls`, `systemctl status`, etc.)
-- All commands have timeout protection
-- Command injection prevention
-
-### Scoring
-
-- Each task has a point value (4-12 points typically)
-- Tasks have multiple validation checks
-- Partial credit is awarded for partial completion
-- Pass threshold: 70% (configurable)
-
-### Results Storage
-
-Results are saved to JSON files in `/opt/rhcsa-simulator/data/results/`:
-- Exam ID and timestamp
-- Task-by-task results
-- Category breakdown
-- Total score and pass/fail status
+---
 
 ## Architecture
 
 ```
 rhcsa-simulator/
-├── rhcsa_simulator.py       # Main entry point
-├── config/                   # Configuration
-├── core/                     # Orchestration (exam, practice, menu, results)
-├── tasks/                    # Task categories (20+ task types)
-├── validators/               # Validation framework
-├── utils/                    # Utilities (logging, formatting, helpers)
-└── data/                     # Results storage
+├── rhcsa_simulator.py   # entry point / CLI
+├── config/              # settings, exam objectives
+├── core/                # exam, practice, learn, adaptive, menu, results_db, reboot engine
+├── tasks/               # task definitions by category (+ fault injection/teardown)
+├── validators/          # safe read-only validation framework
+├── device/              # loop-device / practice-disk management
+├── utils/               # helpers, formatting, logging, device pool/allocator
+└── data/                # SQLite progress DB
 ```
 
-## Extending the Simulator
+## Extending — adding a task
 
-### Adding New Tasks
+1. Open the category file (e.g. `tasks/users_groups.py`).
+2. Subclass `BaseTask`, decorate with `@TaskRegistry.register("category")`.
+3. Implement `generate()` (build the prompt) and `validate()` (return a
+   `ValidationResult`).
+4. If the task needs a whole disk, set `disk_slots = 1` so the allocator gives
+   it a dedicated device. If it needs a starting state (a process to kill, an LV
+   to extend), add `has_fault_injection = True` with `inject_fault()` /
+   `restore_fault()`.
 
-1. Open the appropriate category file (e.g., `tasks/users_groups.py`)
-2. Create a new class extending `BaseTask`
-3. Register with `@TaskRegistry.register("category_name")`
-4. Implement `generate()` and `validate()` methods
+## AI-powered feedback (optional)
 
-Example:
-
-```python
-@TaskRegistry.register("users_groups")
-class MyNewTask(BaseTask):
-    def __init__(self):
-        super().__init__(
-            id="my_task_001",
-            category="users_groups",
-            difficulty="exam",
-            points=8
-        )
-
-    def generate(self, **params):
-        self.description = "Task description here"
-        self.hints = ["Hint 1", "Hint 2"]
-        return self
-
-    def validate(self):
-        checks = []
-        # Add validation checks
-        return ValidationResult(self.id, passed, score, max_score, checks)
-```
-
-## Security
-
-- **Command Whitelisting**: Only approved read-only commands
-- **Timeout Protection**: All commands have 5-second timeout
-- **Pattern Blocking**: Detects dangerous patterns (rm -rf, etc.)
-- **No System Modifications**: Validation is read-only
-- **Root Required**: Needed to check system state, not to modify it
+Set `ANTHROPIC_API_KEY` to enable line-by-line command analysis. See
+[AI_SETUP.md](AI_SETUP.md).
 
 ## Troubleshooting
 
-### "Must run as root" error
-```bash
-sudo rhcsa-simulator  # Don't forget sudo!
-```
-
-### Module import errors
-```bash
-# Ensure you're in the correct directory
-cd /opt/rhcsa-simulator
-sudo python3 rhcsa_simulator.py
-```
-
-### No tasks available
-- Run `sudo rhcsa-simulator` to initialize task registry
-- Check logs at `/opt/rhcsa-simulator/data/logs/rhcsa_simulator.log`
-
-### LVM tasks reference missing devices (e.g., /dev/vdb)
-Use the built-in practice disk feature:
-```bash
-sudo rhcsa-simulator
-# Select option 13: Setup Practice Disks
-# Create 2 x 500MB practice disks
-```
-
-Or manually:
-```bash
-sudo dd if=/dev/zero of=/tmp/disk1.img bs=1M count=500
-sudo losetup -f --show /tmp/disk1.img
-# Use the returned device (e.g., /dev/loop0) for LVM practice
-```
-
-### Cleaning up practice disks
-```bash
-# Remove LVM structures first
-sudo vgremove -f <vgname>
-sudo pvremove /dev/loop0
-
-# Detach loop devices
-sudo losetup -d /dev/loop0
-sudo losetup -d /dev/loop1
-
-# Remove image files
-sudo rm /var/lib/rhcsa-simulator/loops/*.img
-```
-
-## Development
-
-### Project Stats
-- **Lines of Code**: ~16,000+
-- **Task Categories**: 21
-- **Task Types**: 178 tasks covering 100% of RHCSA objectives
-- **Validators**: 90+ validation functions
-- **Modes**: 8 (Learn, Guided Practice, Command Recall, Exam, Practice, Scenario, Troubleshoot, Flashcards)
-- **Dependencies**: 0 (Python stdlib only, optional: anthropic for AI feedback)
-
-### Testing Tasks
-
-```python
-# Run from project root
-cd /opt/rhcsa-simulator
-sudo python3 -c "
-from tasks.registry import TaskRegistry
-TaskRegistry.initialize()
-TaskRegistry.print_statistics()
-"
-```
-
-## Contributing
-
-To add more tasks:
-1. Choose a category or create a new one
-2. Follow the pattern in `tasks/users_groups.py`
-3. Use existing validators from `validators/` modules
-4. Test thoroughly on a test system
+- **"must be run as root"** — launch with `sudo`; validation needs root.
+- **Storage tasks fail in a container** — loop devices/SELinux/systemd may be
+  limited; use a real RHEL/Rocky/Alma VM.
+- **Left in a messy state after a crash** — run **Setup → System Reset**; it also
+  restores any practice "faults" that were still active.
+- **Reinstall from scratch** — re-run `./install.sh --yes`.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details.
-
-This is an educational tool for RHCSA exam preparation. Use at your own risk on test systems only.
-
-## Disclaimer
-
-- This simulator is NOT affiliated with Red Hat
-- Practice on test systems only
-- Always backup important data
-- Validation commands are safe but require root to check system state
-
-## Resources
-
-- [RHCSA Exam Objectives](https://www.redhat.com/en/services/training/ex200-red-hat-certified-system-administrator-rhcsa-exam)
-- [RHEL Documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/)
-
-## Version
-
-**v3.0.0** - 100% RHCSA Coverage Release (Current)
-- **178 tasks**: 41 new tasks for complete RHCSA EX200 coverage
-- **Shell Scripting**: 6 tasks (conditionals, loops, arguments, exit codes)
-- **Package Management**: 8 tasks (dnf, rpm, repos, module streams)
-- **NFS/Autofs**: 6 tasks (mounts, autofs, home directories)
-- **Time Services**: 5 tasks (chrony, NTP, timezone)
-- **Disk Partitioning**: 5 tasks (fdisk, parted, GPT/MBR)
-- **SSH**: 4 tasks (keys, authorized_keys, sshd security)
-- **RAID**: 4 tasks (create, persist, manage, remove)
-- **SMB/CIFS**: 2 tasks (mount shares, credentials)
-- **Enhanced validation**: New safe commands for all new task types
-
-**v2.5.0** - Auto-Cleanup & Content Expansion
-- **DeviceManager**: Automatic cleanup of LVM/disk resources between tasks
-- **Comprehensive boot training**: 14 boot tasks including password reset procedure practice
-- **Expanded learning content**: Detailed boot/recovery section with rd.break walkthrough
-- **Bug fixes**: Fixed f-string hints, command recall evaluation
-- **CLI quick modes**: `--quick lvm`, `--exam`, `--learn users`
-
-**v2.2.0** - Practice Disk Support
-- Dynamic device detection for LVM tasks
-- Loop device support - practice LVM without extra disks
-- "Setup Practice Disks" menu option
-- Works on cloud VMs (AWS, Azure, GCP) without adding volumes
-
-**v2.1.0** - Enhanced Practice & Analytics
-- Retry option in Practice Mode (R to retry, S for solution)
-- Scenario Mode - multi-step real-world scenarios
-- Troubleshooting Mode - diagnose broken systems
-- Weak Area Analysis with recommendations
-- Bookmarks - save tasks for later
-- Export Reports (TXT, HTML, PDF)
-- Fix suggestions for failed validation checks
-
-**v2.0.0** - AI-Powered Feedback Release
-- Added AI-powered intelligent feedback using Claude API
-- Command history tracking and analysis
-- Line-by-line approach comparison
-- Contextual failure explanations
-- Complete RHCSA exam coverage (all 12 categories)
-
-**v1.0.0** - Initial release
-
----
-
-**Good luck with your RHCSA certification!**
+See [LICENSE](LICENSE).

--- a/core/exam.py
+++ b/core/exam.py
@@ -55,15 +55,28 @@ class ExamSession:
             print("Exam cancelled.")
             return None
 
+        # Build the practice device pool first (auto-creates >=3 loop devices,
+        # plus any spare non-system disk like /dev/sda) so the generator can cap
+        # whole-disk tasks to the number of devices we can actually hand out.
+        from utils import helpers
+        try:
+            pool = helpers.build_device_pool()
+        except Exception:
+            pool = []
+        disk_budget = len(pool) if pool else None
+
         # Generate domain-balanced tasks
         print("\nGenerating exam tasks...")
-        self.tasks = TaskRegistry.generate_exam(self.task_count)
+        self.tasks = TaskRegistry.generate_exam(self.task_count, disk_budget=disk_budget)
 
         if not self.tasks:
             print(fmt.error("Error: Could not generate exam tasks"))
             return None
 
         print(fmt.success(f"Generated {len(self.tasks)} tasks across {self._count_domains()} domains"))
+
+        # Give each whole-disk task a distinct device (no two share one disk)
+        self._provision_devices()
 
         # Inject faults / set up environments for tasks that require it
         self._inject_exam_faults()
@@ -84,6 +97,25 @@ class ExamSession:
 
         print("\nComplete the tasks on your system, then return here to validate your work.")
         print("=" * 60)
+
+    def _provision_devices(self):
+        """Assign a distinct practice device to each whole-disk task so an LVM
+        task and a partition task never collide on the same disk."""
+        from utils import helpers
+        disk_tasks = [t for t in self.tasks if getattr(t, 'disk_slots', 0) > 0]
+        if not disk_tasks:
+            return
+        need = sum(t.disk_slots for t in disk_tasks)
+        spares = len(helpers.get_spare_real_disks())
+        helpers.begin_device_allocation(min_loops=max(3, need - spares))
+        try:
+            for t in disk_tasks:
+                try:
+                    t.provision_devices()
+                except Exception:
+                    pass
+        finally:
+            helpers.end_device_allocation()
 
     def _inject_exam_faults(self):
         """Inject faults / create practice environments for all tasks that need it."""

--- a/core/learn.py
+++ b/core/learn.py
@@ -88,17 +88,18 @@ class LearnMode:
             print()
             fmt.print_menu_option("Q", "Back to Main Menu")
 
-            choice = input("\nSelect domain (1-9 or Q): ").strip()
+            max_domain = max(EXAM_OBJECTIVES.keys())
+            choice = input(f"\nSelect domain (1-{max_domain} or Q): ").strip()
 
             if choice.lower() == "q":
                 return
 
             try:
                 domain_num = int(choice)
-                if 1 <= domain_num <= 9:
+                if domain_num in EXAM_OBJECTIVES:
                     self._show_domain_topics(domain_num, weak_cats, due_cats)
                 else:
-                    print(fmt.error("Invalid selection. Choose 1-9."))
+                    print(fmt.error(f"Invalid selection. Choose 1-{max_domain}."))
                     input("Press Enter to continue...")
             except ValueError:
                 print(fmt.error("Please enter a number or Q"))

--- a/core/practice.py
+++ b/core/practice.py
@@ -27,7 +27,7 @@ class PracticeSession:
 
     def __init__(self):
         self.category = None
-        self.difficulty = "exam"
+        self.difficulty = None  # None => prompt in start(); set explicitly to skip prompt
         self.task_count = settings.DEFAULT_PRACTICE_TASKS
         self.skip_reboot = False
 
@@ -35,11 +35,15 @@ class PracticeSession:
         """Start practice session."""
         TaskRegistry.initialize()
 
-        self.category = self._select_category()
+        # Honor a pre-selected category/difficulty (e.g. from `--practice <cat>`);
+        # only prompt for what hasn't already been set.
+        if not self.category:
+            self.category = self._select_category()
         if not self.category:
             return
 
-        self.difficulty = self._select_difficulty()
+        if not self.difficulty:
+            self.difficulty = self._select_difficulty()
         self.skip_reboot = self._select_reboot_filter()
 
         tasks = TaskRegistry.get_practice_tasks(

--- a/core/results_db.py
+++ b/core/results_db.py
@@ -208,9 +208,18 @@ class ResultsDB:
                 interval = row['interval_days']
                 reps = row['repetitions']
 
-            # SM-2 algorithm
+            # SM-2 algorithm.
+            # Map the pass/fail + score onto SM-2's 0-5 quality grade. A perfect
+            # score must reach 5 — at q=4 the EF delta is exactly 0, so without a
+            # 5 the easiness factor could only ever stay flat or shrink toward the
+            # 1.3 floor (intervals would never grow).
             if passed:
-                quality = 4 if score >= max_score * 0.9 else 3
+                if score >= max_score:
+                    quality = 5
+                elif score >= max_score * 0.9:
+                    quality = 4
+                else:
+                    quality = 3
                 reps += 1
                 if reps == 1:
                     interval = 1

--- a/rhcsa_simulator.py
+++ b/rhcsa_simulator.py
@@ -3,7 +3,7 @@
 RHCSA EX200 v10 Exam Simulator v4.0.0 - Main Entry Point
 
 Features:
-- 198 tasks across 27 categories, 9 EX200 v10 domains
+- 194 tasks across 25 categories, 8 EX200 v10 domains
 - SM-2 spaced repetition for adaptive practice
 - Reboot simulation with persistence validation
 - SQLite-backed progress tracking (ResultsDB)

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -21,6 +21,11 @@ class BaseTask(ABC):
     the generate() and validate() methods.
     """
 
+    # Number of whole practice disks this task consumes (0 = none). The exam
+    # generator caps the number of disk tasks to the size of the device pool and
+    # hands each one a *distinct* device so they never collide on the same disk.
+    disk_slots = 0
+
     def __init__(self, id, category, difficulty, points):
         self.id = id
         self.category = category
@@ -49,6 +54,18 @@ class BaseTask(ABC):
     def validate(self):
         """Validate task completion. Returns ValidationResult."""
         pass
+
+    def provision_devices(self):
+        """Re-bind this task to freshly-allocated practice device(s).
+
+        Called once during exam generation while the device allocator is active.
+        The default re-runs generate(), so any task whose generate() pulls a
+        device via helpers.get_practice_device()/get_swap_practice_device() will
+        pick a *distinct* device from the allocator. Multi-disk tasks override
+        this to allocate the right number of devices.
+        """
+        if self.disk_slots:
+            self.generate()
 
     def validate_persistence(self):
         """

--- a/tasks/filesystems.py
+++ b/tasks/filesystems.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 class CreateFilesystemTask(BaseTask):
     """Create a filesystem on a device."""
 
-    exclusive_resource = 'physical_disk'
+    disk_slots = 1
 
     def __init__(self):
         super().__init__(
@@ -104,7 +104,7 @@ class CreateFilesystemTask(BaseTask):
 class MountFilesystemTask(BaseTask):
     """Mount a filesystem at a specific mount point."""
 
-    exclusive_resource = 'physical_disk'
+    disk_slots = 1
 
     def __init__(self):
         super().__init__(
@@ -200,7 +200,7 @@ class MountFilesystemTask(BaseTask):
 class PersistentMountTask(BaseTask):
     """Configure persistent mount in /etc/fstab using UUID."""
 
-    exclusive_resource = 'physical_disk'
+    disk_slots = 1
 
     def __init__(self):
         super().__init__(
@@ -350,7 +350,7 @@ class PersistentMountTask(BaseTask):
 class ConfigureSwapTask(BaseTask):
     """Swap configuration — lives in tasks/swap.py; kept here only to avoid import errors."""
 
-    exclusive_resource = 'physical_disk'
+    disk_slots = 1
 
     def __init__(self):
         super().__init__(
@@ -462,10 +462,9 @@ class ExtendFilesystemTask(BaseTask):
     formats it, and mounts it. The user must extend it to expected_size_mb.
     """
 
+    disk_slots = 1
+
     has_fault_injection = True
-    _VG = 'vg_practice'
-    _LV = 'lv_practice'
-    _MP = '/mnt/practice_extend'
     _INITIAL_MB = 150
 
     def __init__(self):
@@ -483,73 +482,62 @@ class ExtendFilesystemTask(BaseTask):
             "Always extend the LV first (lvextend), then resize the filesystem",
             "Verify new size with 'df -h' after resizing",
         ]
+        self.pv_dev = None
+        self.vg_name = None
+        self.lv_name = None
+        self.mount_point = None
         self.device = None
         self.fstype = None
         self.expected_size_mb = None
 
     def generate(self, **params):
-        self.device = f'/dev/mapper/{self._VG}-{self._LV}'
-        self.fstype = params.get('fstype', 'ext4')
+        from utils.helpers import get_practice_device
+        uid = ''.join(random.choices('0123456789', k=4))
+        self.pv_dev = params.get('device') or get_practice_device() or '/dev/loop0'
+        self.vg_name = params.get('vg_name', f'vg_prac{uid}')
+        self.lv_name = params.get('lv_name', f'lv_prac{uid}')
+        self.mount_point = params.get('mount_point', f'/mnt/practice_extend{uid}')
+        self.device = f'/dev/mapper/{self.vg_name}-{self.lv_name}'
+        # ext4 only: a 150MB XFS can't be created on RHEL 10 (xfs min > 300MB)
+        self.fstype = 'ext4'
         self.expected_size_mb = params.get('size', random.choice([250, 300, 350]))
-
-        grow_cmd = f'xfs_growfs {self._MP}' if self.fstype == 'xfs' else f'resize2fs {self.device}'
 
         self.description = (
             f"Extend a filesystem:\n"
             f"  - Device: {self.device}\n"
-            f"  - Mount point: {self._MP}\n"
+            f"  - Mount point: {self.mount_point}\n"
             f"  - Filesystem type: {self.fstype}  (currently {self._INITIAL_MB}MB)\n"
             f"  - Resize to approximately {self.expected_size_mb}MB\n"
             f"  - Keep the filesystem mounted — data must not be lost"
         )
         self.hints = [
-            f"Step 1 — extend the LV: lvextend -L {self.expected_size_mb}M /dev/{self._VG}/{self._LV}",
-            f"Step 2 — grow the filesystem: {grow_cmd}",
-            "Verify: df -h | grep practice_extend",
+            f"Step 1 — extend the LV: lvextend -L {self.expected_size_mb}M /dev/{self.vg_name}/{self.lv_name}",
+            f"Step 2 — grow the filesystem: resize2fs {self.device}",
+            f"Verify: df -h | grep {self.mount_point}",
         ]
         return self
 
     def inject_fault(self):
         import os
         import subprocess as _sp
-        from utils.helpers import get_loop_devices
 
-        check = _sp.run(['vgs', '--noheadings', '-o', 'vg_name'], capture_output=True, text=True)
-        if self._VG in (check.stdout or ''):
-            return True, f"{self._VG} already set up"
+        pv_dev, vg, lv, mp = self.pv_dev, self.vg_name, self.lv_name, self.mount_point
+        if not pv_dev:
+            return False, "No practice device available — run 'Setup → 1' first"
 
-        loops = get_loop_devices()
-        if not loops:
-            return False, "No loop devices available — run 'Setup → 1' first to create practice disks"
-
-        pv_dev = loops[0]
-        vg, lv, mp = self._VG, self._LV, self._MP
-
-        # pvcreate
         r = _sp.run(['pvcreate', '-ff', '-y', pv_dev], capture_output=True, text=True)
         if r.returncode != 0:
             return False, f"pvcreate failed: {r.stderr.strip()}"
-
-        # vgcreate
         r = _sp.run(['vgcreate', vg, pv_dev], capture_output=True, text=True)
         if r.returncode != 0:
             return False, f"vgcreate failed: {r.stderr.strip()}"
-
-        # lvcreate at initial size
         r = _sp.run(['lvcreate', '-L', f'{self._INITIAL_MB}M', '-n', lv, vg],
                     capture_output=True, text=True)
         if r.returncode != 0:
             return False, f"lvcreate failed: {r.stderr.strip()}"
-
-        # format
-        if self.fstype == 'xfs':
-            r = _sp.run(['mkfs.xfs', self.device], capture_output=True, text=True)
-        else:
-            r = _sp.run(['mkfs.ext4', '-F', self.device], capture_output=True, text=True)
+        r = _sp.run(['mkfs.ext4', '-F', self.device], capture_output=True, text=True)
         if r.returncode != 0:
-            return False, f"mkfs.{self.fstype} failed: {r.stderr.strip()}"
-
-        # mount
+            return False, f"mkfs.ext4 failed: {r.stderr.strip()}"
         os.makedirs(mp, exist_ok=True)
         r = _sp.run(['mount', self.device, mp], capture_output=True, text=True)
         if r.returncode != 0:
@@ -564,12 +552,12 @@ class ExtendFilesystemTask(BaseTask):
         import subprocess as _sp
         from tasks.troubleshooting import load_fault_state, clear_fault_state
 
-        state = load_fault_state()
+        state = load_fault_state(self.id)
         info = state.get('restore_info', {}) if state else {}
-        vg = info.get('vg', self._VG)
-        lv = info.get('lv', self._LV)
-        pv = info.get('pv', '')
-        mp = info.get('mp', self._MP)
+        vg = info.get('vg', self.vg_name)
+        lv = info.get('lv', self.lv_name)
+        pv = info.get('pv', self.pv_dev)
+        mp = info.get('mp', self.mount_point)
 
         _sp.run(['umount', mp], capture_output=True)
         _sp.run(['lvremove', '-ff', f'/dev/{vg}/{lv}'], capture_output=True)
@@ -579,7 +567,7 @@ class ExtendFilesystemTask(BaseTask):
             _sp.run(['pvremove', '-ff', '-y', pv], capture_output=True)
             _sp.run(['wipefs', '-a', pv], capture_output=True)
 
-        clear_fault_state()
+        clear_fault_state(self.id)
         return True, f"Removed {vg}/{lv} and cleaned up {mp}"
 
     def validate(self):
@@ -787,6 +775,8 @@ class CreateSwapFileTask(BaseTask):
 @TaskRegistry.register("filesystems")
 class UnmountFilesystemTask(BaseTask):
     """Safely unmount a filesystem."""
+
+    disk_slots = 1
 
     def __init__(self):
         super().__init__(

--- a/tasks/lvm.py
+++ b/tasks/lvm.py
@@ -3,6 +3,7 @@ LVM (Logical Volume Management) tasks for RHCSA exam.
 """
 
 import random
+import string
 from tasks.base import BaseTask
 from tasks.registry import TaskRegistry
 from core.validator import ValidationCheck, ValidationResult
@@ -10,9 +11,57 @@ from validators.system_validators import validate_lv_exists, get_lv_size_mb
 from utils.helpers import get_practice_device, get_all_practice_devices, get_practice_lv, get_practice_vg
 
 
+def _uid(n=4):
+    """Short random suffix so concurrent scratch VGs/LVs never share a name."""
+    return ''.join(random.choices(string.digits, k=n))
+
+
+def _scratch_setup(task, device, vg, lv=None, lv_mb=150, fstype=None):
+    """Provision a practice VG (and optional LV) on `device` for a task that
+    would otherwise assume pre-existing LVM. Records fault state for crash
+    recovery. Returns (ok, message)."""
+    import subprocess as _sp
+    from tasks.troubleshooting import save_fault_state
+    if not device:
+        return False, "No practice device available — run 'Setup → 1' first"
+    r = _sp.run(['pvcreate', '-ff', '-y', device], capture_output=True, text=True)
+    if r.returncode != 0:
+        return False, f"pvcreate {device} failed: {r.stderr.strip()}"
+    r = _sp.run(['vgcreate', vg, device], capture_output=True, text=True)
+    if r.returncode != 0:
+        return False, f"vgcreate {vg} failed: {r.stderr.strip()}"
+    if lv:
+        r = _sp.run(['lvcreate', '-L', f'{lv_mb}M', '-n', lv, vg], capture_output=True, text=True)
+        if r.returncode != 0:
+            return False, f"lvcreate {lv} failed: {r.stderr.strip()}"
+        if fstype == 'ext4':
+            _sp.run(['mkfs.ext4', '-F', f'/dev/{vg}/{lv}'], capture_output=True)
+        elif fstype == 'xfs':
+            _sp.run(['mkfs.xfs', '-f', f'/dev/{vg}/{lv}'], capture_output=True)
+    save_fault_state(task.id, {'vg': vg, 'dev': device})
+    return True, f"Provisioned {vg}" + (f"/{lv}" if lv else "")
+
+
+def _scratch_teardown(task, vg, device):
+    """Tear down a scratch VG/device created by _scratch_setup."""
+    import subprocess as _sp
+    from tasks.troubleshooting import clear_fault_state
+    if vg:
+        _sp.run(['lvremove', '-ff', vg], capture_output=True)
+        _sp.run(['vgchange', '-an', vg], capture_output=True)
+        _sp.run(['vgremove', '-ff', vg], capture_output=True)
+    if device:
+        _sp.run(['pvremove', '-ff', '-y', device], capture_output=True)
+        _sp.run(['wipefs', '-a', device], capture_output=True)
+    clear_fault_state(task.id)
+    return True, f"Removed {vg}"
+
+
 @TaskRegistry.register("lvm")
 class VerifyLVExistsTask(BaseTask):
     """Verify logical volume exists with correct size."""
+
+    disk_slots = 1
 
     def __init__(self):
         super().__init__(
@@ -76,6 +125,8 @@ class VerifyLVExistsTask(BaseTask):
 class CreatePVTask(BaseTask):
     """Create a physical volume."""
 
+    disk_slots = 1
+
     def __init__(self):
         super().__init__(
             id="lvm_pv_create_001",
@@ -133,6 +184,8 @@ class CreatePVTask(BaseTask):
 @TaskRegistry.register("lvm")
 class CreateVGTask(BaseTask):
     """Create a volume group."""
+
+    disk_slots = 1
 
     def __init__(self):
         super().__init__(
@@ -199,6 +252,9 @@ class CreateVGTask(BaseTask):
 class CreateLVTask(BaseTask):
     """Create a logical volume with specific size."""
 
+    disk_slots = 1
+    has_fault_injection = True
+
     def __init__(self):
         super().__init__(
             id="lvm_lv_create_001",
@@ -215,19 +271,18 @@ class CreateLVTask(BaseTask):
             "LV device appears at /dev/vg_name/lv_name",
         ]
         self.requires_persistence = True
+        self.device = None
         self.vg_name = None
         self.lv_name = None
         self.lv_size_mb = None
 
     def generate(self, **params):
-        # Try to detect existing practice LV
-        existing_vg, existing_lv = get_practice_lv()
-        if existing_vg and existing_lv:
-            self.vg_name = params.get('vg_name', existing_vg)
-            self.lv_name = params.get('lv_name', existing_lv)
-        else:
-            self.vg_name = params.get('vg_name', 'vg_practice')
-            self.lv_name = params.get('lv_name', 'lv_practice')
+        # Self-contained: a scratch VG is provisioned on an allocated device at
+        # exam time; the candidate creates the LV inside it.
+        self.device = params.get('device') or get_practice_device() or '/dev/loop0'
+        uid = _uid()
+        self.vg_name = params.get('vg_name', f'vg_prac{uid}')
+        self.lv_name = params.get('lv_name', f'lv_data{uid}')
         self.lv_size_mb = params.get('size', random.choice([300, 350, 400]))
 
         self.description = (
@@ -243,6 +298,12 @@ class CreateLVTask(BaseTask):
         ]
 
         return self
+
+    def inject_fault(self):
+        return _scratch_setup(self, self.device, self.vg_name)
+
+    def restore_fault(self):
+        return _scratch_teardown(self, self.vg_name, self.device)
 
     def validate(self):
         checks = []
@@ -272,6 +333,10 @@ class CreateLVTask(BaseTask):
 class ExtendLVTask(BaseTask):
     """Extend a logical volume."""
 
+    disk_slots = 1
+    has_fault_injection = True
+    _INITIAL_MB = 100
+
     def __init__(self):
         super().__init__(
             id="lvm_extend_001",
@@ -289,50 +354,45 @@ class ExtendLVTask(BaseTask):
             "Common exam task - practice both extending LV and filesystem",
         ]
         self.requires_persistence = True
+        self.device = None
         self.vg_name = None
         self.lv_name = None
-        self.new_size_mb = None
+        self.target_mb = None
         self.extend_by_mb = None
 
     def generate(self, **params):
-        # Try to detect existing practice LV
-        existing_vg, existing_lv = get_practice_lv()
-        if existing_vg and existing_lv:
-            self.vg_name = params.get('vg_name', existing_vg)
-            self.lv_name = params.get('lv_name', existing_lv)
-        else:
-            self.vg_name = params.get('vg_name', 'vg_practice')
-            self.lv_name = params.get('lv_name', 'lv_practice')
+        # Self-contained: provision a small scratch LV that the candidate extends.
+        self.device = params.get('device') or get_practice_device() or '/dev/loop0'
+        uid = _uid()
+        self.vg_name = params.get('vg_name', f'vg_prac{uid}')
+        self.lv_name = params.get('lv_name', f'lv_data{uid}')
         self.extend_by_mb = params.get('extend_by', random.choice([100, 150]))
-        self.new_size_mb = params.get('new_size', random.choice([350, 400, 450]))
-
-        use_extend_by = params.get('use_extend_by', True)
-
-        if use_extend_by:
-            task_spec = f"extend by {self.extend_by_mb}MB"
-            hint_cmd = f"lvextend -L +{self.extend_by_mb}M /dev/{self.vg_name}/{self.lv_name}"
-        else:
-            task_spec = f"resize to {self.new_size_mb}MB total"
-            hint_cmd = f"lvextend -L {self.new_size_mb}M /dev/{self.vg_name}/{self.lv_name}"
+        self.target_mb = self._INITIAL_MB + self.extend_by_mb
 
         self.description = (
             f"Extend a logical volume:\n"
             f"  - Volume group: {self.vg_name}\n"
-            f"  - Logical volume: {self.lv_name}\n"
-            f"  - Task: {task_spec}\n"
+            f"  - Logical volume: {self.lv_name}  (currently {self._INITIAL_MB}MB)\n"
+            f"  - Task: extend by {self.extend_by_mb}MB (to ~{self.target_mb}MB)\n"
             f"  - Ensure LV is extended"
         )
 
         self.hints = [
-            f"Extend LV: {hint_cmd}",
+            f"Extend LV: lvextend -L +{self.extend_by_mb}M /dev/{self.vg_name}/{self.lv_name}",
             "Check current size: lvs or lvdisplay",
             "Extend by amount: lvextend -L +<size>M /dev/vg/lv",
-            "Resize to total: lvextend -L <size>M /dev/vg/lv",
             "Use all free space: lvextend -l +100%FREE /dev/vg/lv",
             "After extending, resize filesystem with xfs_growfs or resize2fs"
         ]
 
         return self
+
+    def inject_fault(self):
+        return _scratch_setup(self, self.device, self.vg_name,
+                              lv=self.lv_name, lv_mb=self._INITIAL_MB)
+
+    def restore_fault(self):
+        return _scratch_teardown(self, self.vg_name, self.device)
 
     def validate(self):
         checks = []
@@ -343,12 +403,12 @@ class ExtendLVTask(BaseTask):
             total_points += 4
 
             actual_size = get_lv_size_mb(self.vg_name, self.lv_name)
-            # Check if LV has been extended (allow some tolerance)
-            if actual_size and actual_size >= self.extend_by_mb:
+            # Require the LV to have actually grown toward the target size.
+            if actual_size and actual_size >= self.target_mb * 0.95:
                 checks.append(ValidationCheck("lv_extended", True, 8, f"LV size is {actual_size}MB (extended)"))
                 total_points += 8
             else:
-                checks.append(ValidationCheck("lv_extended", False, 0, f"LV size is {actual_size}MB (may not be extended)", max_points=8))
+                checks.append(ValidationCheck("lv_extended", False, 0, f"LV size is {actual_size}MB (expected ~{self.target_mb}MB)", max_points=8))
         else:
             checks.append(ValidationCheck("lv_exists", False, 0, f"LV not found", max_points=4))
 
@@ -360,7 +420,7 @@ class ExtendLVTask(BaseTask):
 class LVMFullWorkflowTask(BaseTask):
     """Complete LVM workflow: Create PV, VG, LV, format, and mount."""
 
-    exclusive_resource = 'physical_disk'
+    disk_slots = 1
 
     def __init__(self):
         super().__init__(
@@ -396,9 +456,12 @@ class LVMFullWorkflowTask(BaseTask):
 
         self.vg_name = params.get('vg_name', f'vg_exam{random.randint(1,99)}')
         self.lv_name = params.get('lv_name', f'lv_data{random.randint(1,99)}')
-        self.lv_size_mb = params.get('size', random.choice([200, 300, 400]))
-        self.mount_point = params.get('mount', f'/mnt/lvm{random.randint(1,99)}')
+        # RHEL 10 mkfs.xfs refuses filesystems <= 300MB, so keep XFS sizes above
+        # that. Loop practice disks are 500MB, so 350-450MB fits comfortably.
         self.fstype = params.get('fstype', 'xfs')
+        default_sizes = [350, 400, 450] if self.fstype == 'xfs' else [200, 300, 400]
+        self.lv_size_mb = params.get('size', random.choice(default_sizes))
+        self.mount_point = params.get('mount', f'/mnt/lvm{random.randint(1,99)}')
 
         self.description = (
             f"Complete LVM setup:\n"
@@ -469,13 +532,26 @@ class LVMFullWorkflowTask(BaseTask):
         else:
             checks.append(ValidationCheck("lv_mounted", False, 0, "Not mounted", max_points=3))
 
-        # Check 6: Persistent mount (3 points)
-        from validators.file_validators import validate_file_contains
-        if validate_file_contains('/etc/fstab', self.mount_point):
-            checks.append(ValidationCheck("persistent_mount", True, 3, "Entry in /etc/fstab"))
+        # Check 6: Persistent mount (3 points) — require a real source field, not
+        # just the mount point appearing somewhere (a broken "UUID= <mp>" line
+        # must NOT pass).
+        fstab_ok = False
+        try:
+            with open('/etc/fstab') as f:
+                for line in f:
+                    s = line.split('#', 1)[0].split()
+                    if len(s) >= 2 and s[1] == self.mount_point:
+                        source = s[0]
+                        if source and source not in ('UUID=', 'LABEL='):
+                            fstab_ok = True
+                            break
+        except OSError:
+            pass
+        if fstab_ok:
+            checks.append(ValidationCheck("persistent_mount", True, 3, "Valid entry in /etc/fstab"))
             total_points += 3
         else:
-            checks.append(ValidationCheck("persistent_mount", False, 0, "No fstab entry", max_points=3))
+            checks.append(ValidationCheck("persistent_mount", False, 0, "No valid fstab entry", max_points=3))
 
         passed = total_points >= (self.points * 0.7)
         return ValidationResult(self.id, passed, total_points, self.points, checks)
@@ -487,6 +563,8 @@ class ExtendVGTask(BaseTask):
     Fault-injection: creates vg_practice on loop0 at start, uses loop1
     (or sda) as the device to add. User must pvcreate + vgextend.
     """
+
+    disk_slots = 2
 
     has_fault_injection = True
     _VG = 'vg_practice'
@@ -512,24 +590,23 @@ class ExtendVGTask(BaseTask):
         self.new_device = None    # device user must add
 
     def generate(self, **params):
-        from utils.helpers import get_loop_devices, list_all_block_devices
-        loops = get_loop_devices()
+        from utils.helpers import (device_allocation_active, allocate_practice_device,
+                                    get_loop_devices)
+        self.vg_name = params.get('vg_name', f'vg_ext{_uid()}')
 
-        # Use loop0 for the existing VG, loop1 (or sda) as the device to add
-        if len(loops) >= 2:
-            self.base_device = loops[0]
-            self.new_device = loops[1]
-        elif len(loops) == 1:
-            self.base_device = loops[0]
-            # Try to find sda as the second device
-            all_devs = list_all_block_devices()
-            candidates = [d for d in all_devs if 'sda' in d and d != self.base_device]
-            self.new_device = candidates[0] if candidates else '/dev/sdb'
+        # Needs two distinct devices: one to build the VG on, one to add.
+        if device_allocation_active():
+            self.base_device = params.get('base_device') or allocate_practice_device() or '/dev/loop0'
+            self.new_device = params.get('new_device') or allocate_practice_device() or '/dev/loop1'
         else:
-            self.base_device = '/dev/vdb'
-            self.new_device = '/dev/vdc'
+            loops = get_loop_devices()
+            if len(loops) >= 2:
+                self.base_device, self.new_device = loops[0], loops[1]
+            elif len(loops) == 1:
+                self.base_device, self.new_device = loops[0], '/dev/sda'
+            else:
+                self.base_device, self.new_device = '/dev/loop0', '/dev/loop1'
 
-        self.vg_name = params.get('vg_name', self._VG)
         self.description = (
             f"Extend a volume group:\n"
             f"  - Volume group: {self.vg_name}  (already exists)\n"
@@ -567,7 +644,7 @@ class ExtendVGTask(BaseTask):
         import subprocess as _sp
         from tasks.troubleshooting import load_fault_state, clear_fault_state
 
-        state = load_fault_state()
+        state = load_fault_state(self.id)
         info = state.get('restore_info', {}) if state else {}
         vg = info.get('vg', self.vg_name)
         base_dev = info.get('base_dev', self.base_device)
@@ -579,8 +656,9 @@ class ExtendVGTask(BaseTask):
         _sp.run(['vgremove', '-ff', vg], capture_output=True)
         for dev in filter(None, [base_dev, new_dev]):
             _sp.run(['pvremove', '-ff', '-y', dev], capture_output=True)
+            _sp.run(['wipefs', '-a', dev], capture_output=True)
 
-        clear_fault_state()
+        clear_fault_state(self.id)
         return True, f"Removed {vg} and cleaned up PVs"
 
     def validate(self):
@@ -612,6 +690,9 @@ class ExtendVGTask(BaseTask):
 class RemoveLVTask(BaseTask):
     """Remove a logical volume safely."""
 
+    disk_slots = 1
+    has_fault_injection = True
+
     def __init__(self):
         super().__init__(
             id="lvm_lv_remove_001",
@@ -628,12 +709,16 @@ class RemoveLVTask(BaseTask):
             "Verify removal with 'lvs' command",
         ]
         self.requires_persistence = True
+        self.device = None
         self.vg_name = None
         self.lv_name = None
 
     def generate(self, **params):
-        self.vg_name = params.get('vg_name', f'vg_test{random.randint(1,99)}')
-        self.lv_name = params.get('lv_name', f'lv_remove{random.randint(1,99)}')
+        # Self-contained: provision a scratch VG+LV the candidate must remove.
+        self.device = params.get('device') or get_practice_device() or '/dev/loop0'
+        uid = _uid()
+        self.vg_name = params.get('vg_name', f'vg_test{uid}')
+        self.lv_name = params.get('lv_name', f'lv_remove{uid}')
 
         self.description = (
             f"Remove a logical volume:\n"
@@ -654,6 +739,13 @@ class RemoveLVTask(BaseTask):
 
         return self
 
+    def inject_fault(self):
+        return _scratch_setup(self, self.device, self.vg_name,
+                              lv=self.lv_name, lv_mb=100)
+
+    def restore_fault(self):
+        return _scratch_teardown(self, self.vg_name, self.device)
+
     def validate(self):
         checks = []
         total_points = 0
@@ -673,6 +765,10 @@ class RemoveLVTask(BaseTask):
 class ReduceLVTask(BaseTask):
     """Reduce a logical volume (ext4 only - XFS cannot shrink)."""
 
+    disk_slots = 1
+    has_fault_injection = True
+    _INITIAL_MB = 350
+
     def __init__(self):
         super().__init__(
             id="lvm_lv_reduce_001",
@@ -689,14 +785,17 @@ class ReduceLVTask(BaseTask):
             "Reducing LVs is risky and rarely tested on exam - extending is much more common",
         ]
         self.requires_persistence = True
+        self.device = None
         self.vg_name = None
         self.lv_name = None
         self.new_size_mb = None
 
     def generate(self, **params):
-        existing_vg, existing_lv = get_practice_lv()
-        self.vg_name = params.get('vg_name', existing_vg or 'vg_practice')
-        self.lv_name = params.get('lv_name', existing_lv or 'lv_practice')
+        # Self-contained: provision an ext4 LV (larger than target) to reduce.
+        self.device = params.get('device') or get_practice_device() or '/dev/loop0'
+        uid = _uid()
+        self.vg_name = params.get('vg_name', f'vg_prac{uid}')
+        self.lv_name = params.get('lv_name', f'lv_data{uid}')
         self.new_size_mb = params.get('new_size', random.choice([100, 150, 200]))
 
         self.description = (
@@ -719,6 +818,13 @@ class ReduceLVTask(BaseTask):
         ]
 
         return self
+
+    def inject_fault(self):
+        return _scratch_setup(self, self.device, self.vg_name,
+                              lv=self.lv_name, lv_mb=self._INITIAL_MB, fstype='ext4')
+
+    def restore_fault(self):
+        return _scratch_teardown(self, self.vg_name, self.device)
 
     def validate(self):
         checks = []

--- a/tasks/partitioning.py
+++ b/tasks/partitioning.py
@@ -50,6 +50,8 @@ def _partition_dev(device, number):
 class CreateMBRPartitionTask(BaseTask):
     """Create an MBR (msdos) partition using fdisk or parted."""
 
+    disk_slots = 1
+
     def __init__(self):
         super().__init__(
             id="part_mbr_create",
@@ -152,6 +154,8 @@ class CreateMBRPartitionTask(BaseTask):
 class CreateGPTPartitionTask(BaseTask):
     """Create a GPT partition table and partition using parted or gdisk."""
 
+    disk_slots = 1
+
     def __init__(self):
         super().__init__(
             id="part_gpt_create",
@@ -247,6 +251,8 @@ class CreateGPTPartitionTask(BaseTask):
 @TaskRegistry.register("partitioning")
 class ResizePartitionTask(BaseTask):
     """Resize an existing partition (grow) using parted or growpart."""
+
+    disk_slots = 1
 
     def __init__(self):
         super().__init__(
@@ -346,6 +352,8 @@ class ResizePartitionTask(BaseTask):
 class DeletePartitionTask(BaseTask):
     """Delete an existing partition."""
 
+    disk_slots = 1
+
     def __init__(self):
         super().__init__(
             id="part_delete",
@@ -418,6 +426,8 @@ class DeletePartitionTask(BaseTask):
 @TaskRegistry.register("partitioning")
 class PartitionAndFormatTask(BaseTask):
     """Create a partition, format it, mount it, and add to fstab (exam-style)."""
+
+    disk_slots = 1
 
     def __init__(self):
         super().__init__(
@@ -551,6 +561,8 @@ class PartitionAndFormatTask(BaseTask):
 @TaskRegistry.register("partitioning")
 class ConvertPartitionTableTask(BaseTask):
     """Convert a disk partition table from MBR to GPT or vice-versa."""
+
+    disk_slots = 1
 
     def __init__(self):
         super().__init__(

--- a/tasks/processes.py
+++ b/tasks/processes.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 class KillProcessTask(BaseTask):
     """Kill a process by name or PID."""
 
+    has_fault_injection = True
+
     def __init__(self):
         super().__init__(
             id="proc_kill_001",
@@ -27,6 +29,7 @@ class KillProcessTask(BaseTask):
         )
         self.process_name = None
         self.signal = None
+        self._fake_dir = None
 
     def generate(self, **params):
         """Generate process kill task."""
@@ -52,6 +55,46 @@ class KillProcessTask(BaseTask):
         ]
 
         return self
+
+    def inject_fault(self):
+        """Start real processes the candidate must kill.
+
+        We copy `sleep` to a file named after the target process so that
+        `pgrep -x <name>` (used by validate) matches its comm, then launch a
+        couple of instances. Without this the task is trivially "passed" because
+        nothing of that name is running.
+        """
+        import subprocess as _sp
+        import os, shutil, tempfile
+        src = shutil.which('sleep') or '/usr/bin/sleep'
+        d = tempfile.mkdtemp(prefix='rhcsa_proc_')
+        fake = os.path.join(d, self.process_name)
+        try:
+            shutil.copy(src, fake)
+            os.chmod(fake, 0o755)
+            for _ in range(2):
+                _sp.Popen([fake, '600'])
+        except Exception as e:
+            shutil.rmtree(d, ignore_errors=True)
+            return False, f"Could not start '{self.process_name}': {e}"
+        self._fake_dir = d
+        from tasks.troubleshooting import save_fault_state
+        save_fault_state(self.id, {'process': self.process_name, 'dir': d})
+        return True, f"Started 2 '{self.process_name}' process(es)"
+
+    def restore_fault(self):
+        import subprocess as _sp
+        import shutil
+        from tasks.troubleshooting import load_fault_state, clear_fault_state
+        state = load_fault_state(self.id)
+        info = state.get('restore_info', {}) if state else {}
+        name = info.get('process', self.process_name)
+        d = info.get('dir', self._fake_dir)
+        _sp.run(['pkill', '-x', name], capture_output=True)
+        if d:
+            shutil.rmtree(d, ignore_errors=True)
+        clear_fault_state(self.id)
+        return True, f"Killed '{name}' processes and cleaned up"
 
     def validate(self):
         """Validate process is killed."""
@@ -303,6 +346,7 @@ class FindProcessByUserTask(BaseTask):
         )
         self.username = None
         self.action = None
+        self._created_user = False
 
     def generate(self, **params):
         """Generate find process by user task."""
@@ -339,24 +383,37 @@ class FindProcessByUserTask(BaseTask):
 
     def inject_fault(self):
         import subprocess as _sp
-        if self.action != 'kill':
-            return True, "No setup needed for list/count action"
-        # Ensure the user exists
-        _sp.run(['useradd', '-r', '-s', '/sbin/nologin', '-M', self.username],
-                capture_output=True)
+        # Provision for every action: list/count need processes to see, kill needs
+        # processes to kill. Only delete the user later if we actually create it
+        # here (apache may pre-exist as a real httpd account — never remove that).
+        existed = _sp.run(['id', self.username], capture_output=True).returncode == 0
+        self._created_user = not existed
+        if not existed:
+            _sp.run(['useradd', '-r', '-s', '/sbin/nologin', '-M', self.username],
+                    capture_output=True)
         # Start several background sleep processes as that user
         for _ in range(3):
             _sp.Popen(['runuser', '-u', self.username, '--', 'sleep', '600'])
         from tasks.troubleshooting import save_fault_state
-        save_fault_state(self.id, {'username': self.username})
+        save_fault_state(self.id, {'username': self.username,
+                                   'created_user': self._created_user})
         return True, f"Started 3 background processes as '{self.username}'"
 
     def restore_fault(self):
         import subprocess as _sp
-        from tasks.troubleshooting import clear_fault_state
+        import time
+        from tasks.troubleshooting import load_fault_state, clear_fault_state
+        state = load_fault_state(self.id)
+        info = state.get('restore_info', {}) if state else {}
+        created = info.get('created_user', getattr(self, '_created_user', False))
         _sp.run(['pkill', '-u', self.username], capture_output=True)
-        clear_fault_state()
-        return True, f"Killed remaining '{self.username}' processes"
+        msg = f"Killed remaining '{self.username}' processes"
+        if created:
+            time.sleep(0.5)  # let pkill reap processes so userdel won't fail on "in use"
+            _sp.run(['userdel', '-rf', self.username], capture_output=True)
+            msg += " and removed the user it created"
+        clear_fault_state(self.id)
+        return True, msg
 
     def validate(self):
         """Validate process management by user."""

--- a/tasks/registry.py
+++ b/tasks/registry.py
@@ -172,13 +172,26 @@ class TaskRegistry:
         return cls.get_random_tasks(count, difficulty="exam")
 
     @classmethod
-    def generate_exam(cls, count=12):
+    def generate_exam(cls, count=12, disk_budget=None):
         """
-        Generate a balanced exam across all 9 domains.
+        Generate a balanced exam across all 8 domains.
         60%+ persistence tasks, weighted by domain importance.
+
+        disk_budget caps how many whole-disk tasks (by disk_slots) may be
+        selected, so each can later be given a distinct practice device. When
+        None it is inferred from the devices currently available (without
+        creating any) with a sane floor, so callers/tests need not pass it.
         """
         tasks = []
         exclude_ids = []
+
+        if disk_budget is None:
+            try:
+                from utils.helpers import get_loop_devices, get_spare_real_disks
+                disk_budget = len(get_loop_devices()) + len(get_spare_real_disks())
+            except Exception:
+                disk_budget = 0
+            disk_budget = max(disk_budget, 3)  # floor: exam start ensures >=3 loops
 
         # Distribute tasks across domains weighted by domain weight
         from config.exam_objectives import EXAM_OBJECTIVES
@@ -221,8 +234,10 @@ class TaskRegistry:
                 return False
             return True
 
-        # Generate tasks per domain — enforce one task per category to avoid duplicates
-        used_exclusive_resources = set()
+        # Generate tasks per domain — enforce one task per category to avoid
+        # duplicates, and cap whole-disk tasks to disk_budget so each can be
+        # assigned a distinct device (no two disk tasks share one disk).
+        disk_used = 0
         for domain_num, needed in domain_counts.items():
             domain_cats = [
                 cat for cat, dom in settings.CATEGORY_TO_DOMAIN.items()
@@ -249,31 +264,29 @@ class TaskRegistry:
                 if not _exam_eligible(task):
                     task = None
                 if task:
-                    res = getattr(task, 'exclusive_resource', None)
-                    if res and res in used_exclusive_resources:
-                        task = None
+                    slots = getattr(task, 'disk_slots', 0)
+                    if slots and disk_used + slots > disk_budget:
+                        task = None  # no device left for this disk task
                 if task and task.id not in exclude_ids:
-                    res = getattr(task, 'exclusive_resource', None)
-                    if res:
-                        used_exclusive_resources.add(res)
+                    disk_used += getattr(task, 'disk_slots', 0)
                     tasks.append(task)
                     exclude_ids.append(task.id)
                     used_cats.add(cat)
                     remaining_for_domain -= 1
 
         # If we couldn't fill all slots, add random tasks (allowing category repeats as last resort)
-        while len(tasks) < count:
+        guard = 0
+        while len(tasks) < count and guard < count * 20:
+            guard += 1
             task = cls.get_random_task(difficulty="exam")
             if not _exam_eligible(task):
                 task = None
             if task:
-                res = getattr(task, 'exclusive_resource', None)
-                if res and res in used_exclusive_resources:
+                slots = getattr(task, 'disk_slots', 0)
+                if slots and disk_used + slots > disk_budget:
                     task = None
             if task and task.id not in exclude_ids:
-                res = getattr(task, 'exclusive_resource', None)
-                if res:
-                    used_exclusive_resources.add(res)
+                disk_used += getattr(task, 'disk_slots', 0)
                 tasks.append(task)
                 exclude_ids.append(task.id)
 

--- a/tasks/swap.py
+++ b/tasks/swap.py
@@ -17,7 +17,8 @@ logger = logging.getLogger(__name__)
 class CreateSwapPartitionTask(BaseTask):
     """Create and activate a swap partition."""
 
-    exclusive_resource = 'physical_disk'
+    disk_slots = 1
+
 
     def __init__(self):
         super().__init__(

--- a/tasks/troubleshooting.py
+++ b/tasks/troubleshooting.py
@@ -29,36 +29,83 @@ FAULT_STATE_FILE = '/var/lib/rhcsa-simulator/active_fault.json'
 
 # ── Fault-state bookkeeping ───────────────────────────────────────────────────
 
-def save_fault_state(task_id: str, restore_info: dict):
-    os.makedirs(os.path.dirname(FAULT_STATE_FILE), exist_ok=True)
-    with open(FAULT_STATE_FILE, 'w') as f:
-        json.dump({'task_id': task_id, 'restore_info': restore_info}, f)
-
-
-def load_fault_state() -> dict | None:
+def _read_faults() -> dict:
+    """Return {task_id: restore_info} for all active faults (migrates legacy)."""
     try:
         with open(FAULT_STATE_FILE) as f:
-            return json.load(f)
+            data = json.load(f)
     except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    if isinstance(data, dict) and 'faults' in data and isinstance(data['faults'], dict):
+        return data['faults']
+    # Legacy single-entry format: {'task_id':..., 'restore_info':...}
+    if isinstance(data, dict) and 'task_id' in data:
+        return {data['task_id']: data.get('restore_info', {})}
+    return {}
+
+
+def _write_faults(faults: dict):
+    if faults:
+        os.makedirs(os.path.dirname(FAULT_STATE_FILE), exist_ok=True)
+        with open(FAULT_STATE_FILE, 'w') as f:
+            json.dump({'faults': faults}, f)
+    else:
+        try:
+            os.remove(FAULT_STATE_FILE)
+        except FileNotFoundError:
+            pass
+
+
+def save_fault_state(task_id: str, restore_info: dict):
+    """Record an active fault. Multiple concurrent faults are kept, keyed by
+    task_id, so exam tasks that inject in parallel don't clobber each other."""
+    faults = _read_faults()
+    faults[task_id] = restore_info
+    _write_faults(faults)
+
+
+def load_fault_state(task_id: str = None) -> dict | None:
+    """Return {'task_id', 'restore_info'} for the given task (or any one fault
+    when task_id is None, for the startup 'stale fault' warning)."""
+    faults = _read_faults()
+    if not faults:
         return None
+    if task_id is None:
+        task_id = next(iter(faults))
+    elif task_id not in faults:
+        return None
+    return {'task_id': task_id, 'restore_info': faults[task_id]}
 
 
-def clear_fault_state():
-    try:
-        os.remove(FAULT_STATE_FILE)
-    except FileNotFoundError:
-        pass
+def clear_fault_state(task_id: str = None):
+    """Clear one fault (task_id given) or all faults (task_id None)."""
+    if task_id is None:
+        _write_faults({})
+        return
+    faults = _read_faults()
+    faults.pop(task_id, None)
+    _write_faults(faults)
+
+
+def get_active_faults() -> dict:
+    """All active faults as {task_id: restore_info}."""
+    return _read_faults()
 
 
 def restore_any_active_fault():
-    """Called at startup and during system_reset to restore a stale fault."""
-    state = load_fault_state()
-    if not state:
+    """Called at startup and during system_reset to restore stale fault(s)."""
+    faults = _read_faults()
+    if not faults:
         return False, "No active fault"
-    task_id = state.get('task_id', '')
-    info = state.get('restore_info', {})
     msgs = []
+    for task_id, info in list(faults.items()):
+        _dispatch_restore(task_id, info, msgs)
+    clear_fault_state()
+    return True, '\n'.join(msgs)
 
+
+def _dispatch_restore(task_id, info, msgs):
+    """Restore a single fault by task_id (crash-recovery dispatcher)."""
     # Dispatch to the right restorer
     if task_id.startswith('fault_selinux_context'):
         _restore_selinux_context(info, msgs)
@@ -136,11 +183,34 @@ def restore_any_active_fault():
         if orig_hostname:
             subprocess.run(['hostnamectl', 'set-hostname', orig_hostname], capture_output=True)
         msgs.append(f"Cleaned up {iface} and {conn}")
+    elif task_id == 'proc_kill_001':
+        name = info.get('process')
+        d = info.get('dir')
+        if name:
+            subprocess.run(['pkill', '-x', name], capture_output=True)
+        if d:
+            import shutil as _sh
+            _sh.rmtree(d, ignore_errors=True)
+        msgs.append(f"Killed injected '{name}' processes")
+    elif task_id == 'proc_find_user_001':
+        user = info.get('username', 'apache')
+        subprocess.run(['pkill', '-u', user], capture_output=True)
+        if info.get('created_user'):
+            subprocess.run(['userdel', '-rf', user], capture_output=True)
+        msgs.append(f"Cleaned up processes for user '{user}'")
+    elif task_id.startswith('lvm_lv_') or task_id == 'lvm_scratch':
+        vg = info.get('vg')
+        dev = info.get('dev')
+        if vg:
+            subprocess.run(['lvremove', '-ff', vg], capture_output=True)
+            subprocess.run(['vgchange', '-an', vg], capture_output=True)
+            subprocess.run(['vgremove', '-ff', vg], capture_output=True)
+        if dev:
+            subprocess.run(['pvremove', '-ff', '-y', dev], capture_output=True)
+            subprocess.run(['wipefs', '-a', dev], capture_output=True)
+        msgs.append(f"Cleaned up scratch LVM ({vg})")
     else:
         msgs.append(f"Unknown fault type: {task_id}")
-
-    clear_fault_state()
-    return True, '\n'.join(msgs)
 
 
 # ── Shared restore helpers ────────────────────────────────────────────────────

--- a/tasks/troubleshooting.py
+++ b/tasks/troubleshooting.py
@@ -198,7 +198,15 @@ def _dispatch_restore(task_id, info, msgs):
         if info.get('created_user'):
             subprocess.run(['userdel', '-rf', user], capture_output=True)
         msgs.append(f"Cleaned up processes for user '{user}'")
-    elif task_id.startswith('lvm_lv_') or task_id == 'lvm_scratch':
+    elif task_id.startswith('selinux_denial'):
+        import shutil as _sh
+        directory = info.get('directory')
+        if directory and os.path.exists(directory):
+            subprocess.run(['restorecon', '-Rv', directory], capture_output=True)
+            _sh.rmtree(directory, ignore_errors=True)
+        msgs.append(f"Removed injected SELinux practice dir {directory}")
+    elif (task_id.startswith('lvm_lv_') or task_id.startswith('lvm_extend')
+          or {'vg', 'dev'} <= set(info.keys())):
         vg = info.get('vg')
         dev = info.get('dev')
         if vg:

--- a/tests/e2e/test_practice_mode.py
+++ b/tests/e2e/test_practice_mode.py
@@ -40,13 +40,15 @@ class TestPracticeTask:
             checks=[ValidationCheck(name="c", passed=True, points=10, message="ok")],
         )
 
-        # Mock _select_category and _select_difficulty to skip input
+        # Mock selection helpers to skip input. start() flow consumes:
+        # preview-loop "s", then per-task "complete" + "press enter" prompts.
         with patch.object(session, "_select_category", return_value="lvm"), \
              patch.object(session, "_select_difficulty", return_value="exam"), \
-             patch("builtins.input", side_effect=["", ""]), \
+             patch.object(session, "_select_reboot_filter", return_value=False), \
+             patch("builtins.input", side_effect=["s", "", ""]), \
              patch("core.practice.get_validator") as mock_val, \
              patch("core.practice.get_results_db", return_value=tmp_db), \
-             patch("core.practice.confirm_action", side_effect=[False, True]), \
+             patch("core.practice.confirm_action", side_effect=[True]), \
              patch("core.practice.fmt"):
             mock_engine = MagicMock()
             mock_engine.validate_task.return_value = mock_result
@@ -68,13 +70,14 @@ class TestPracticeTask:
             checks=[ValidationCheck(name="c", passed=True, points=10, message="ok")],
         )
 
-        # fail -> retry -> pass -> continue
+        # preview "s" -> complete -> fail -> retry "r" -> complete -> pass -> press enter
         with patch.object(session, "_select_category", return_value="lvm"), \
              patch.object(session, "_select_difficulty", return_value="exam"), \
-             patch("builtins.input", side_effect=["", "r", "", ""]), \
+             patch.object(session, "_select_reboot_filter", return_value=False), \
+             patch("builtins.input", side_effect=["s", "", "r", "", ""]), \
              patch("core.practice.get_validator") as mock_val, \
              patch("core.practice.get_results_db", return_value=tmp_db), \
-             patch("core.practice.confirm_action", side_effect=[False, False, True]), \
+             patch("core.practice.confirm_action", side_effect=[True]), \
              patch("core.practice.fmt"):
             mock_engine = MagicMock()
             mock_engine.validate_task.side_effect = [fail_result, pass_result]

--- a/tests/unit/test_content.py
+++ b/tests/unit/test_content.py
@@ -19,9 +19,9 @@ class TestContentRegistry:
         ContentRegistry.initialize()
         assert ContentRegistry._initialized is True
 
-    def test_all_9_domains_have_categories(self):
+    def test_all_domains_have_categories(self):
         ContentRegistry.initialize()
-        for domain_num in range(1, 10):
+        for domain_num in settings.EXAM_DOMAINS:
             cats = ContentRegistry.get_categories_for_domain(domain_num)
             assert len(cats) >= 1, f"Domain {domain_num} has no categories"
 

--- a/tests/unit/test_device_pool.py
+++ b/tests/unit/test_device_pool.py
@@ -1,0 +1,54 @@
+"""
+Tests for the exam device pool / allocator (utils.helpers) and the
+generate_exam disk-budget cap (tasks.registry). These avoid creating real
+loop devices by stubbing the pool builder.
+"""
+import pytest
+from unittest.mock import patch
+
+from utils import helpers
+from tasks.registry import TaskRegistry
+
+pytestmark = pytest.mark.unit
+
+
+class TestDeviceAllocator:
+    def test_allocates_distinct_then_none(self):
+        pool = ['/dev/loop0', '/dev/loop1', '/dev/sda']
+        with patch.object(helpers, 'build_device_pool', return_value=pool):
+            helpers.begin_device_allocation()
+            try:
+                got = [helpers.allocate_practice_device() for _ in range(4)]
+            finally:
+                helpers.end_device_allocation()
+        assert got[:3] == pool          # distinct, in order
+        assert got[3] is None           # exhausted
+        assert len(set(got[:3])) == 3   # no duplicates
+
+    def test_inactive_by_default(self):
+        assert helpers.device_allocation_active() is False
+        assert helpers.allocate_practice_device() is None
+
+    def test_get_practice_device_uses_allocator_when_active(self):
+        pool = ['/dev/loopA', '/dev/loopB']
+        with patch.object(helpers, 'build_device_pool', return_value=pool):
+            helpers.begin_device_allocation()
+            try:
+                a = helpers.get_practice_device()
+                b = helpers.get_practice_device()
+            finally:
+                helpers.end_device_allocation()
+        assert a == '/dev/loopA' and b == '/dev/loopB'  # distinct per task
+
+
+class TestExamDiskBudget:
+    def test_generate_exam_respects_disk_budget(self):
+        TaskRegistry.initialize()
+        tasks = TaskRegistry.generate_exam(20, disk_budget=1)
+        used = sum(getattr(t, 'disk_slots', 0) for t in tasks)
+        assert used <= 1, f"disk_slots used ({used}) exceeded budget of 1"
+
+    def test_zero_budget_yields_no_disk_tasks(self):
+        TaskRegistry.initialize()
+        tasks = TaskRegistry.generate_exam(20, disk_budget=0)
+        assert all(getattr(t, 'disk_slots', 0) == 0 for t in tasks)

--- a/tests/unit/test_results_db.py
+++ b/tests/unit/test_results_db.py
@@ -133,8 +133,20 @@ class TestSM2Algorithm:
             score=10, max_score=10, passed=True,
         )
         stats = tmp_db.get_category_stats("selinux")
-        # With quality=4: ef = 2.5 + (0.1 - (5-4)*(0.08 + (5-4)*0.02)) = 2.5 + 0.0 = 2.5
-        assert stats["easiness_factor"] == pytest.approx(2.5, abs=0.01)
+        # Perfect score -> quality=5: ef = 2.5 + (0.1 - 0*(...)) = 2.6.
+        # (A perfect recall must be able to grow EF; q<=4 can only hold/shrink it.)
+        assert stats["easiness_factor"] == pytest.approx(2.6, abs=0.01)
+
+    def test_quality_scoring_perfect(self, tmp_db):
+        """A perfect score maps to SM-2 quality 5 and grows the easiness factor."""
+        for i in range(3):
+            tmp_db.save_practice_attempt(
+                task_id=f"t{i}", category="repos", difficulty="exam", domain=1,
+                score=10, max_score=10, passed=True,
+            )
+        stats = tmp_db.get_category_stats("repos")
+        # Three perfect passes -> EF climbs above the 2.5 starting point.
+        assert stats["easiness_factor"] > 2.5
 
     def test_failing_resets_interval(self, tmp_db):
         # Build up interval

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -568,6 +568,11 @@ def get_swap_practice_device():
     import subprocess
     import os
 
+    # During exam generation, draw a distinct device from the allocator so the
+    # swap-partition task doesn't collide with other disk tasks.
+    if device_allocation_active():
+        return allocate_practice_device()
+
     cfg = get_practice_device_config()
 
     if cfg and cfg['mode'] == 'real' and cfg.get('devices'):
@@ -738,6 +743,11 @@ def get_practice_device():
     Returns:
         str: Device path or None if none available
     """
+    # During exam generation an allocator hands out a *distinct* device per
+    # consuming task so two disk tasks never collide on the same disk.
+    if device_allocation_active():
+        return allocate_practice_device()
+
     # Use DeviceManager for smart detection (skips system disks, caches result,
     # recognizes disks with existing practice PVs/VGs)
     # Check saved config first
@@ -761,6 +771,85 @@ def get_practice_device():
     if loop_devices:
         return loop_devices[0]
 
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Exam device pool + allocator
+#
+# Several task categories (LVM, partitioning, filesystems, swap) each need a
+# whole disk. Historically they all called get_practice_device() and got the
+# *same* first device, so an LVM task and a partition task in the same exam
+# would fight over one disk. The allocator below hands each consuming task a
+# distinct device drawn from a pool of >= `min_loops` loop devices (auto-created
+# if missing) plus any spare non-system real disk (e.g. /dev/sda).
+# ---------------------------------------------------------------------------
+
+_device_alloc_pool = None   # list while allocation is active, else None
+_device_alloc_idx = 0
+
+
+def ensure_loop_devices(minimum=3):
+    """Ensure at least `minimum` loop practice devices exist; create if needed."""
+    loops = get_loop_devices()
+    if len(loops) < minimum:
+        create_practice_devices(count=minimum, size_mb=500)
+        loops = get_loop_devices()
+        if loops:
+            save_practice_device_config('loop', loops)
+    return get_loop_devices()
+
+
+def get_spare_real_disks():
+    """Non-system, unmounted real disks (e.g. /dev/sda) usable for practice."""
+    spares = []
+    try:
+        for d in list_all_block_devices():
+            if not d.get('is_system') and not d.get('mounted'):
+                spares.append(d['device'])
+    except Exception:
+        pass
+    return spares
+
+
+def build_device_pool(min_loops=3):
+    """Ordered list of distinct practice devices: loop devices (>= min_loops)
+    first, then spare non-system real disks (e.g. /dev/sda)."""
+    pool = list(ensure_loop_devices(min_loops))
+    for dev in get_spare_real_disks():
+        if dev not in pool:
+            pool.append(dev)
+    return pool
+
+
+def begin_device_allocation(min_loops=3):
+    """Start handing out distinct devices (call once at exam generation)."""
+    global _device_alloc_pool, _device_alloc_idx
+    _device_alloc_pool = build_device_pool(min_loops)
+    _device_alloc_idx = 0
+    return list(_device_alloc_pool)
+
+
+def end_device_allocation():
+    """Stop the allocator; get_practice_device() reverts to normal behaviour."""
+    global _device_alloc_pool, _device_alloc_idx
+    _device_alloc_pool = None
+    _device_alloc_idx = 0
+
+
+def device_allocation_active():
+    return _device_alloc_pool is not None
+
+
+def allocate_practice_device():
+    """Return the next un-allocated device, or None if the pool is exhausted."""
+    global _device_alloc_idx
+    if _device_alloc_pool is None:
+        return None
+    if _device_alloc_idx < len(_device_alloc_pool):
+        dev = _device_alloc_pool[_device_alloc_idx]
+        _device_alloc_idx += 1
+        return dev
     return None
 
 


### PR DESCRIPTION
Implements the follow-up fixes from `PATCH_NOTES.md` (added in #6). All **152 tests pass**, and the exam flow was verified end-to-end (generate → provision distinct devices → inject faults → restore → system left clean).

## Device allocation — fixes the reported `/dev/sda` collision
- New **device pool + allocator** (`utils/helpers`): ensures ≥3 auto-created loop devices plus any spare non-system disk (e.g. `/dev/sda`).
- `BaseTask.disk_slots` marks whole-disk tasks; `generate_exam` caps disk tasks to the pool size; the exam hands each one a **distinct** device before fault injection — so an LVM task and a partitioning task never share a disk.
- Replaces the old binary `exclusive_resource` mutex (which didn't cover partitioning/most LVM tasks) with a slot budget.

## Generation-time provisioning — no more trivial/impossible tasks
- `proc_kill` starts real processes to kill; LVM create/extend/reduce/remove provision their own scratch VG/LV (unique names, allocated device); `fs_extend`/`vg_extend` use the allocator + unique VG names.
- **Fault state is now multi-entry** (keyed by `task_id`) so concurrent exam faults don't clobber each other; crash recovery restores all of them.

## Correctness fixes
- Learn mode no longer `KeyError`s on an out-of-range domain.
- `--practice <category>` no longer re-prompts for category/difficulty.
- **SM-2**: a perfect score now maps to quality **5** so the easiness factor can grow (was capped at 4 → only flat/shrinking). Per-category EF, 1.3 floor, and 1→6→interval×EF progression confirmed correct.
- apache kill task removes the user it created (only if it created it).
- LVM full-workflow uses XFS-safe sizes (RHEL 10 `mkfs.xfs` needs >300MB) + stricter fstab check.
- Docs/counts corrected to **8 domains / 25 categories / 194 tasks**; 3 stale tests fixed; new device-pool/allocator tests added.

## Docs
- README rewritten: **Quick Start**, **required + recommended VM configuration**, and accurate modes/CLI/features.

> Note: the `./install.sh --yes` flag referenced in the new README ships in #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)