### PR TITLE
fstab safety guard + fix boot troubleshooting kernel-param check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -122,6 +122,43 @@ fi
 
 echo
 echo "========================================="
+echo "Installing fstab safety guard"
+echo "========================================="
+echo
+# The simulator and candidate add /etc/fstab entries (swap, mounts, fault
+# injection). If a session is interrupted those can be left behind and break the
+# next boot. This guard restores a known-good baseline at shutdown and early
+# boot so the system always comes up clean.
+GUARD_SRC="$SCRIPT_DIR/tools/rhcsa-fstab-guard.sh"
+GUARD_UNIT_SRC="$SCRIPT_DIR/tools/rhcsa-fstab-guard.service"
+GUARD_DST="/usr/local/sbin/rhcsa-fstab-guard.sh"
+GUARD_UNIT_DST="/etc/systemd/system/rhcsa-fstab-guard.service"
+
+if [ -f "$GUARD_SRC" ] && [ -f "$GUARD_UNIT_SRC" ]; then
+    install -m 755 "$GUARD_SRC" "$GUARD_DST"
+    install -m 644 "$GUARD_UNIT_SRC" "$GUARD_UNIT_DST"
+
+    # Capture the current (clean) fstab as the baseline.
+    "$GUARD_DST" init || echo -e "${YELLOW}Warning: could not capture fstab baseline (fstab not currently valid?)${NC}"
+
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl daemon-reload
+        if systemctl enable rhcsa-fstab-guard.service >/dev/null 2>&1; then
+            # Activate now so the shutdown hook is armed this boot too.
+            systemctl start rhcsa-fstab-guard.service >/dev/null 2>&1 || true
+            echo -e "${GREEN}✓ fstab guard installed and enabled${NC}"
+        else
+            echo -e "${YELLOW}Warning: could not enable rhcsa-fstab-guard.service${NC}"
+        fi
+    else
+        echo -e "${YELLOW}systemctl not available — guard installed but not enabled${NC}"
+    fi
+else
+    echo -e "${YELLOW}Guard files not found in tools/ — skipping${NC}"
+fi
+
+echo
+echo "========================================="
 echo "Optional: Populate Practice Environment"
 echo "========================================="
 echo

--- a/rhcsa_simulator.py
+++ b/rhcsa_simulator.py
@@ -202,6 +202,18 @@ def main():
     except SystemExit:
         return 1
 
+    # Best-effort: capture a known-good /etc/fstab baseline so the fstab guard
+    # (tools/rhcsa-fstab-guard.sh) can strip leftover practice/fault entries if a
+    # session is ever interrupted. Only captures when none exists and fstab is
+    # clean; never fails the launch.
+    try:
+        import subprocess as _sp
+        _guard = '/usr/local/sbin/rhcsa-fstab-guard.sh'
+        if os.path.exists(_guard):
+            _sp.run([_guard, 'ensure'], capture_output=True, timeout=15)
+    except Exception:
+        pass
+
     # CLI quick modes
     if args.quick:
         run_quick_practice(args.quick)

--- a/tasks/boot.py
+++ b/tasks/boot.py
@@ -492,12 +492,24 @@ class BootTroubleshootingTask(BaseTask):
         self.target = None
         self.timeout = None
         self.extra_param = None
+        self.add_param = None
+        self.remove_param = None
 
     def generate(self, **params):
         self._scenario = params.get('scenario', random.choice(self._SCENARIOS))
         self.target = self._scenario['correct_target']
         self.timeout = self._scenario['correct_timeout']
-        self.extra_param = self._scenario.get('add_param') or self._scenario.get('remove_param')
+        self.add_param = self._scenario.get('add_param')
+        self.remove_param = self._scenario.get('remove_param')
+        # Back-compat alias: the single parameter this scenario is concerned with.
+        self.extra_param = self.add_param or self.remove_param
+
+        if self.add_param:
+            param_line = f"  - Kernel command line: ensure '{self.add_param}' IS present\n"
+        elif self.remove_param:
+            param_line = f"  - Kernel command line: ensure '{self.remove_param}' is NOT present\n"
+        else:
+            param_line = ""
 
         self.description = (
             f"Boot Configuration Problem:\n"
@@ -507,6 +519,7 @@ class BootTroubleshootingTask(BaseTask):
             f"  Required end state:\n"
             f"  - Default target: {self.target}\n"
             f"  - GRUB timeout: {self.timeout} seconds\n"
+            f"{param_line}"
             f"  - All changes must persist across reboots"
         )
         self.hints = [
@@ -636,19 +649,38 @@ class BootTroubleshootingTask(BaseTask):
                 message=f"Timeout is {current}, expected {self.timeout}"
             ))
 
-        # Check 3: Extra kernel parameter present (3 points)
-        if '=' in self.extra_param:
-            pn, pv = self.extra_param.split('=', 1)
-            param_ok = validate_grub_parameter_value(pn, pv)
+        # Check 3: kernel command line is correct (3 points).
+        # add_param scenarios require the parameter to be PRESENT; remove_param
+        # scenarios require it to be ABSENT (e.g. dropping 'rhgb' for a
+        # text-mode server). Earlier versions always checked for presence, which
+        # silently failed every remove_param scenario.
+        if self.add_param:
+            param = self.add_param
+            if '=' in param:
+                pn, pv = param.split('=', 1)
+                param_ok = validate_grub_parameter_value(pn, pv)
+            else:
+                param_ok = validate_grub_parameter(param)
+            ok_msg = f"Kernel parameter '{param}' is present"
+            bad_msg = f"Kernel parameter '{param}' not found in GRUB_CMDLINE_LINUX"
+        elif self.remove_param:
+            param = self.remove_param
+            # Absent means neither the bare flag nor a name=value form remains.
+            name = param.split('=', 1)[0]
+            param_ok = not validate_grub_parameter(param) and not validate_grub_parameter(name)
+            ok_msg = f"Kernel parameter '{param}' has been removed"
+            bad_msg = f"Kernel parameter '{param}' is still present in GRUB_CMDLINE_LINUX"
         else:
-            param_ok = validate_grub_parameter(self.extra_param)
+            param_ok = True
+            ok_msg = "No kernel parameter change required"
+            bad_msg = ""
 
         if param_ok:
             checks.append(ValidationCheck(
                 name="extra_param_present",
                 passed=True,
                 points=3,
-                message=f"Kernel parameter '{self.extra_param}' is present"
+                message=ok_msg
             ))
             total_points += 3
         else:
@@ -657,7 +689,7 @@ class BootTroubleshootingTask(BaseTask):
                 passed=False,
                 points=0,
                 max_points=3,
-                message=f"Kernel parameter '{self.extra_param}' not found in GRUB_CMDLINE_LINUX"
+                message=bad_msg
             ))
 
         # Check 4: GRUB config regenerated (3 points)

--- a/tools/rhcsa-fstab-guard.service
+++ b/tools/rhcsa-fstab-guard.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=RHCSA Simulator fstab guard (strip leftover practice entries so the system always boots)
+Documentation=file:///opt/rhcsa-simulator/tools/rhcsa-fstab-guard.sh
+DefaultDependencies=no
+# Run early at boot, before anything tries to mount from /etc/fstab, and again
+# right before the system goes down.
+Before=local-fs-pre.target shutdown.target
+Conflicts=shutdown.target
+After=systemd-remount-fs.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/rhcsa-fstab-guard.sh boot
+ExecStop=/usr/local/sbin/rhcsa-fstab-guard.sh shutdown
+TimeoutSec=30
+
+[Install]
+WantedBy=local-fs-pre.target

--- a/tools/rhcsa-fstab-guard.sh
+++ b/tools/rhcsa-fstab-guard.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+#
+# rhcsa-fstab-guard.sh — keep /etc/fstab bootable across simulator sessions.
+#
+# The RHCSA simulator (and the candidate, while practising) adds entries to
+# /etc/fstab for swap, LVM/filesystem mounts, and fault-injection scenarios
+# (bad UUIDs, missing-device mounts). If a session is interrupted — the
+# simulator crashes, the VM is reset, or the box is rebooted mid-exam — those
+# entries are left behind and the NEXT boot can drop to an emergency shell.
+#
+# This guard restores /etc/fstab to a known-good baseline so the system always
+# boots clean. It is wired to run:
+#   * at shutdown/reboot (ExecStop)  — the primary guarantee: the persisted
+#     fstab is clean before the machine goes down, so the next boot is safe.
+#   * early at boot (ExecStart, before local-fs-pre.target) — self-heal after a
+#     crash/power-loss; daemon-reload re-runs the fstab generator so the bad
+#     mount units are dropped for the current boot too.
+#
+# SAFETY: this script never deletes baseline entries and never writes a fstab it
+# cannot verify. Extra (non-baseline) entries are COMMENTED OUT, not removed, so
+# nothing is lost and the change is auditable. The candidate fstab is validated
+# with `findmnt --verify` before it replaces /etc/fstab; on any error the
+# original file is left untouched. Timestamped backups are kept.
+#
+# Usage: rhcsa-fstab-guard.sh [boot|shutdown|init|status]
+#   init      capture the current fstab as the baseline (run once, when clean)
+#   boot      sanitize early at boot, then daemon-reload
+#   shutdown  sanitize before the system goes down
+#   status    show what would be changed (dry run)
+#
+set -u
+
+FSTAB="/etc/fstab"
+STATE_DIR="/var/lib/rhcsa-simulator"
+BASELINE="${STATE_DIR}/fstab.baseline"
+BACKUP_DIR="${STATE_DIR}/fstab-backups"
+TAG="rhcsa-guard"
+MODE="${1:-status}"
+
+log() {
+    # Log to journal/syslog when available, always echo for interactive runs.
+    if command -v logger >/dev/null 2>&1; then
+        logger -t "$TAG" -- "$*"
+    fi
+    echo "[$TAG] $*"
+}
+
+mkdir -p "$STATE_DIR" "$BACKUP_DIR" 2>/dev/null
+
+# Normalise an fstab line for comparison: drop a trailing inline comment, then
+# collapse all whitespace to single spaces and trim. Blank/comment lines map to
+# the empty string and are ignored by callers.
+normalise() {
+    local line="$1"
+    line="${line%%#*}"
+    # shellcheck disable=SC2086
+    echo $line
+}
+
+# Capture the current fstab as the baseline — only if it is currently valid.
+do_init() {
+    if findmnt --verify --quiet >/dev/null 2>&1 || findmnt --verify >/dev/null 2>&1; then
+        cp -f "$FSTAB" "$BASELINE"
+        log "Captured baseline fstab ($(grep -cvE '^\s*(#|$)' "$BASELINE") entries) -> $BASELINE"
+        return 0
+    fi
+    log "Refusing to capture baseline: current /etc/fstab fails 'findmnt --verify'"
+    return 1
+}
+
+# Produce a sanitized fstab on stdout: every non-baseline data line is commented
+# out with an explanatory marker. Baseline lines, comments and blanks pass through.
+sanitize_to_stdout() {
+    awk -v baseline="$BASELINE" '
+        function norm(s,   t) {
+            sub(/#.*/, "", s)         # strip inline comment
+            gsub(/[ \t]+/, " ", s)    # collapse whitespace
+            gsub(/^ | $/, "", s)      # trim
+            return s
+        }
+        BEGIN {
+            while ((getline bl < baseline) > 0) {
+                n = norm(bl)
+                if (n != "") keep[n] = 1
+            }
+            close(baseline)
+        }
+        {
+            line = $0
+            n = norm(line)
+            if (n == "") { print line; next }            # comment / blank
+            if (n in keep) { print line; next }          # baseline entry
+            print "# [rhcsa-guard removed " strftime("%Y-%m-%d %H:%M:%S") "] " line
+            changed++
+        }
+        END { exit (changed > 0 ? 10 : 0) }
+    ' "$FSTAB"
+}
+
+do_sanitize() {
+    local why="$1"
+
+    if [ ! -f "$BASELINE" ]; then
+        # First ever run with no baseline: try to establish one from a clean
+        # fstab, then there is nothing to strip.
+        do_init || log "No baseline and current fstab invalid — leaving fstab untouched ($why)"
+        return 0
+    fi
+
+    local tmp rc
+    tmp="$(mktemp /tmp/fstab.guard.XXXXXX)" || { log "mktemp failed"; return 1; }
+    sanitize_to_stdout > "$tmp"
+    rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        rm -f "$tmp"
+        return 0                       # nothing to change
+    fi
+    if [ "$rc" -ne 10 ]; then
+        log "sanitize aborted (awk rc=$rc) — fstab untouched ($why)"
+        rm -f "$tmp"
+        return 1
+    fi
+
+    # We have changes. Verify the candidate parses before swapping it in.
+    if ! findmnt --verify --fstab "$tmp" >/dev/null 2>&1; then
+        # --fstab flag may be unavailable on very old util-linux; fall back to a
+        # structural check (root entry still present, file non-empty).
+        if ! grep -qE '[[:space:]]/[[:space:]]' "$tmp" || [ ! -s "$tmp" ]; then
+            log "Candidate fstab failed validation — refusing to apply ($why)"
+            rm -f "$tmp"
+            return 1
+        fi
+    fi
+
+    local stamp backup
+    stamp="$(date +%Y%m%d-%H%M%S)"
+    backup="${BACKUP_DIR}/fstab.${stamp}"
+    cp -f "$FSTAB" "$backup"
+    cat "$tmp" > "$FSTAB"
+    rm -f "$tmp"
+
+    local n
+    n="$(grep -c '\[rhcsa-guard removed' "$FSTAB")"
+    log "Commented out $n leftover fstab entry/entries ($why). Backup: $backup"
+    return 10
+}
+
+case "$MODE" in
+    init)
+        do_init
+        ;;
+    ensure)
+        # Capture a baseline only if we don't already have one. Safe to call on
+        # every simulator start; it refuses to capture a dirty fstab.
+        if [ -f "$BASELINE" ]; then
+            exit 0
+        fi
+        do_init
+        ;;
+    status)
+        if [ ! -f "$BASELINE" ]; then
+            echo "No baseline captured yet (run: $0 init on a clean system)."
+            exit 0
+        fi
+        diff <(sanitize_to_stdout) "$FSTAB" >/dev/null 2>&1 \
+            && echo "fstab is clean — nothing to strip." \
+            || { echo "The following entries would be commented out:"; \
+                 sanitize_to_stdout | grep '\[rhcsa-guard removed'; }
+        ;;
+    boot)
+        do_sanitize "boot"
+        if [ $? -eq 10 ]; then
+            # Re-run the fstab generator so the current boot ignores the bad
+            # mount units we just commented out.
+            systemctl daemon-reload >/dev/null 2>&1 || true
+        fi
+        ;;
+    shutdown)
+        do_sanitize "shutdown"
+        ;;
+    *)
+        echo "Usage: $0 [init|boot|shutdown|status]" >&2
+        exit 2
+        ;;
+esac
+exit 0


### PR DESCRIPTION
## Summary

Two fixes that came out of taking the exam end-to-end on a real RHEL 10.2 VM.

### 1. fstab safety guard (the emergency-recovery fix)
The simulator and the candidate add `/etc/fstab` entries during an exam (swap, LVM/filesystem mounts, and the `boot_fstab_001` fault injection that deliberately writes bad entries). If a session is interrupted — simulator crash, VM reset, or a mid-exam reboot — those entries are left behind and the **next boot drops to an emergency shell**.

- `tools/rhcsa-fstab-guard.sh` + `tools/rhcsa-fstab-guard.service` restore a known-good baseline by **commenting out** any non-baseline entry.
- Runs at **shutdown** (primary guarantee: the persisted fstab is clean before the box goes down) and **early at boot** before `local-fs-pre.target` (self-heal after a crash), then `daemon-reload`.
- Safe by construction: comment-only (never deletes/corrupts), validates the candidate file with `findmnt --verify` before applying, keeps timestamped backups.
- `install.sh` installs the script/unit, captures the baseline from the clean fstab, and enables the unit.
- Simulator startup runs `guard ensure` so existing installs also get a baseline (only when fstab is clean and none exists yet).

### 2. `boot_troubleshoot_001` kernel-parameter check
- The required kernel-parameter change was **never stated in the task description**, and `validate()` always checked for the parameter's **presence**. For `remove_param` scenarios (e.g. dropping `rhgb` for a text-mode server) the correct end state is the parameter **absent**, so a perfect answer still lost 3 points.
- The description now states whether the parameter must be present or absent, and `validate()` checks presence for `add_param` scenarios and absence for `remove_param` scenarios.

## Testing
- Full suite: `152 passed`.
- Guard tested end-to-end on the live VM: dirtied `/etc/fstab` with a leftover practice entry, ran the guard, confirmed the entry was neutralized, fstab stayed valid, and a backup was kept. `systemd-analyze verify` passes; unit is `enabled`/`active`.
- Boot task verified to emit the correct requirement line and presence/absence check across all three scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)