### PR TITLE
Make positive-config tasks require real work + fix apache/XFS/swap bugs

### DIFF
--- a/core/exam.py
+++ b/core/exam.py
@@ -44,6 +44,7 @@ class ExamSession:
         self.exam_id = generate_id("exam")
         self.timer = None
         self._injected_tasks = []
+        self._setup_tasks = []
 
     def start(self):
         """Start the exam session."""
@@ -80,6 +81,10 @@ class ExamSession:
 
         # Inject faults / set up environments for tasks that require it
         self._inject_exam_faults()
+
+        # Establish negative preconditions for positive-config tasks so they
+        # can't pass on pre-existing/default state.
+        self._setup_task_environments()
 
         self._display_tasks()
 
@@ -137,14 +142,37 @@ class ExamSession:
         time.sleep(1)
         print()
 
+    def _setup_task_environments(self):
+        """Run setup_environment() for positive-config tasks so they establish a
+        negative precondition (stop a default-on service, move an artifact aside)
+        and therefore require real work to pass."""
+        setup_tasks = [t for t in self.tasks if getattr(t, 'has_setup', False)]
+        if not setup_tasks:
+            return
+        for task in setup_tasks:
+            try:
+                ok, msg = task.setup_environment()
+                if ok:
+                    print(fmt.success(f"  ✓ {task.id}: {msg}"))
+                    self._setup_tasks.append(task)
+                # A False result just means no precondition was needed; the task
+                # is still valid, so stay quiet to avoid alarming the candidate.
+            except Exception as e:
+                print(fmt.warning(f"  ✗ {task.id}: setup error ({e})"))
+
     def _restore_exam_faults(self):
         """Restore any environments that were set up for the exam."""
-        if not self._injected_tasks:
+        if not self._injected_tasks and not self._setup_tasks:
             return
         print(fmt.dim("\nCleaning up exam environment..."))
         for task in self._injected_tasks:
             try:
                 task.restore_fault()
+            except Exception:
+                pass
+        for task in self._setup_tasks:
+            try:
+                task.teardown_environment()
             except Exception:
                 pass
 

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -26,6 +26,13 @@ class BaseTask(ABC):
     # hands each one a *distinct* device so they never collide on the same disk.
     disk_slots = 0
 
+    # True if this task establishes a "negative precondition" at exam start so
+    # the candidate must actually do the work (e.g. stop a default-on service,
+    # move an existing artifact aside). The exam loop calls setup_environment()
+    # during preparation and teardown_environment() during cleanup. Without this,
+    # positive-config tasks can pass on pre-existing/default state.
+    has_setup = False
+
     def __init__(self, id, category, difficulty, points):
         self.id = id
         self.category = category
@@ -66,6 +73,24 @@ class BaseTask(ABC):
         """
         if self.disk_slots:
             self.generate()
+
+    def setup_environment(self):
+        """Establish the negative precondition for this task at exam start.
+
+        Override in tasks that would otherwise pass on pre-existing/default
+        state. Return (ok: bool, message: str). Default: no-op.
+        """
+        return True, "no setup needed"
+
+    def teardown_environment(self):
+        """Restore whatever setup_environment() changed.
+
+        The default replays the restore record saved via tasks/env_setup.py
+        helpers (resilient to interruption — System Reset and startup recovery
+        use the same record).
+        """
+        from tasks import env_setup
+        return env_setup.restore_and_clear(self.id)
 
     def validate_persistence(self):
         """

--- a/tasks/env_setup.py
+++ b/tasks/env_setup.py
@@ -1,0 +1,179 @@
+"""
+Environment setup helpers for positive-configuration tasks.
+
+Fault-injection (troubleshooting) tasks break the system so the candidate has
+something to fix. Positive-configuration tasks ("enable crond", "install X",
+"generate an SSH key") had no equivalent: if the system already satisfied the
+goal — a default-on service, a leftover artifact from a previous session — the
+task validated as PASS without the candidate doing any work.
+
+These helpers let a positive task establish the *negative precondition* at exam
+start (stop/disable a default-on service, move an existing key aside, …) so the
+work is actually required, and restore the original state afterwards.
+
+State is recorded in the same active-fault file the troubleshooting tasks use,
+so an interrupted session is cleaned up by System Reset / startup recovery.
+Each restore record carries a ``restore_type`` that ``_dispatch_restore`` knows
+how to undo generically.
+"""
+
+import os
+import shutil
+import subprocess
+
+
+# Never stop/disable these — doing so could lock the candidate out of the box.
+CRITICAL_SERVICES = {'sshd', 'sshd.service', 'NetworkManager', 'NetworkManager.service'}
+
+
+def _run(cmd, timeout=120):
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except Exception as e:  # pragma: no cover - defensive
+        class _R:
+            returncode = 1
+            stdout = ''
+            stderr = str(e)
+        return _R()
+
+
+def _save(task_id, info):
+    from tasks.troubleshooting import save_fault_state
+    save_fault_state(task_id, info)
+
+
+def restore_and_clear(task_id):
+    """Generic teardown: replay the saved restore record for this task, then
+    drop it. Used as the default BaseTask.teardown_environment()."""
+    from tasks.troubleshooting import load_fault_state, clear_fault_state, _dispatch_restore
+    st = load_fault_state(task_id)
+    if not st:
+        return True, ""
+    msgs = []
+    _dispatch_restore(task_id, st['restore_info'], msgs)
+    clear_fault_state(task_id)
+    return True, '; '.join(msgs)
+
+
+# ── service / timer preconditions ─────────────────────────────────────────────
+
+def _unit_state(unit):
+    active = _run(['systemctl', 'is-active', unit]).stdout.strip() == 'active'
+    enabled = _run(['systemctl', 'is-enabled', unit]).stdout.strip() == 'enabled'
+    return active, enabled
+
+
+def make_service_absent(task_id, service):
+    """Stop and disable a service so an 'enable/start it' task requires work."""
+    if service in CRITICAL_SERVICES:
+        return False, f"skipped critical service {service}"
+    if _run(['systemctl', 'cat', service]).returncode != 0:
+        return False, f"{service} not installed (nothing to do)"
+    active, enabled = _unit_state(service)
+    if not active and not enabled:
+        return False, f"{service} already stopped+disabled"
+    _save(task_id, {'restore_type': 'unit', 'unit': service,
+                    'was_active': active, 'was_enabled': enabled})
+    _run(['systemctl', 'disable', service])
+    _run(['systemctl', 'stop', service])
+    return True, f"stopped+disabled {service} (was active={active}, enabled={enabled})"
+
+
+def make_service_present(task_id, service):
+    """Start and enable a service so a 'stop/disable it' task requires work."""
+    if service in CRITICAL_SERVICES:
+        return False, f"skipped critical service {service}"
+    if _run(['systemctl', 'cat', service]).returncode != 0:
+        return False, f"{service} not installed (nothing to do)"
+    active, enabled = _unit_state(service)
+    if active and enabled:
+        return False, f"{service} already running+enabled"
+    _save(task_id, {'restore_type': 'unit', 'unit': service,
+                    'was_active': active, 'was_enabled': enabled})
+    _run(['systemctl', 'enable', service])
+    _run(['systemctl', 'start', service])
+    return True, f"started+enabled {service} (was active={active}, enabled={enabled})"
+
+
+def make_timer_absent(task_id, timer):
+    """Stop and disable a timer so an 'enable it' task requires work."""
+    unit = timer if timer.endswith('.timer') else f'{timer}.timer'
+    if _run(['systemctl', 'cat', unit]).returncode != 0:
+        return False, f"{unit} not present (nothing to do)"
+    active, enabled = _unit_state(unit)
+    if not active and not enabled:
+        return False, f"{unit} already stopped+disabled"
+    _save(task_id, {'restore_type': 'unit', 'unit': unit,
+                    'was_active': active, 'was_enabled': enabled})
+    _run(['systemctl', 'disable', unit])
+    _run(['systemctl', 'stop', unit])
+    return True, f"stopped+disabled {unit} (was active={active}, enabled={enabled})"
+
+
+# ── filesystem preconditions ──────────────────────────────────────────────────
+
+def backup_paths(task_id, paths):
+    """Move existing files aside (restored on teardown) so a 'create X' task
+    can't pass on a leftover from a previous session."""
+    moved = []
+    for p in paths:
+        if os.path.lexists(p):
+            bak = p + '.rhcsa-bak'
+            try:
+                if os.path.lexists(bak):
+                    os.remove(bak)
+                shutil.move(p, bak)
+                moved.append(p)
+            except OSError:
+                pass
+    if not moved:
+        return False, "nothing to move aside"
+    _save(task_id, {'restore_type': 'file_backup', 'paths': moved})
+    return True, f"moved aside {moved}"
+
+
+def remove_paths(task_id, paths):
+    """Delete leftover artifacts (no restore needed — e.g. a /tmp output file)."""
+    removed = []
+    for p in paths:
+        try:
+            os.remove(p)
+            removed.append(p)
+        except (FileNotFoundError, IsADirectoryError, OSError):
+            pass
+    return True, (f"removed {removed}" if removed else "nothing to remove")
+
+
+# ── package / flatpak preconditions (best-effort; may need network) ───────────
+
+def ensure_package_installed(task_id, pkg):
+    """Install a package so a 'remove it' task requires work. Best-effort."""
+    if _run(['rpm', '-q', pkg], timeout=20).returncode == 0:
+        return False, f"{pkg} already installed"
+    r = _run(['dnf', '-y', 'install', pkg], timeout=180)
+    if r.returncode != 0:
+        return False, f"could not install {pkg} (no repo access?)"
+    _save(task_id, {'restore_type': 'pkg_remove', 'pkg': pkg})
+    return True, f"installed {pkg}"
+
+
+def ensure_package_absent(task_id, pkg):
+    """Remove a package so an 'install it' task requires work."""
+    if _run(['rpm', '-q', pkg], timeout=20).returncode != 0:
+        return False, f"{pkg} already absent"
+    r = _run(['dnf', '-y', 'remove', pkg], timeout=180)
+    if r.returncode != 0:
+        return False, f"could not remove {pkg}"
+    _save(task_id, {'restore_type': 'pkg_install', 'pkg': pkg})
+    return True, f"removed {pkg}"
+
+
+def ensure_flatpak_app_absent(task_id, app_id):
+    """Uninstall a Flatpak app so an 'install it' task requires work."""
+    if _run(['flatpak', 'info', app_id], timeout=20).returncode != 0:
+        return False, f"{app_id} already absent"
+    r = _run(['flatpak', 'uninstall', '-y', app_id], timeout=120)
+    if r.returncode != 0:
+        return False, f"could not uninstall {app_id}"
+    _save(task_id, {'restore_type': 'flatpak_install', 'app_id': app_id})
+    return True, f"uninstalled flatpak {app_id}"

--- a/tasks/essential_tools.py
+++ b/tasks/essential_tools.py
@@ -19,6 +19,12 @@ logger = logging.getLogger(__name__)
 class FindFilesTask(BaseTask):
     """Find files using the find command."""
 
+    has_setup = True
+
+    def setup_environment(self):
+        from tasks import env_setup
+        return env_setup.remove_paths(self.id, [self.output_file])
+
     def __init__(self):
         super().__init__(
             id="tools_find_001",
@@ -436,6 +442,14 @@ class ExtractArchiveTask(BaseTask):
 @TaskRegistry.register("essential_tools")
 class IORedirectionTask(BaseTask):
     """Use I/O redirection and pipes."""
+
+    has_setup = True
+
+    def setup_environment(self):
+        # Remove a leftover output file from a previous session so the task
+        # can't pass without the candidate regenerating it.
+        from tasks import env_setup
+        return env_setup.remove_paths(self.id, [self.output_file])
 
     def __init__(self):
         super().__init__(

--- a/tasks/flatpak.py
+++ b/tasks/flatpak.py
@@ -256,6 +256,14 @@ class AddFlathubRepoTask(BaseTask):
 class InstallFlatpakAppTask(BaseTask):
     """Install a Flatpak application from a remote."""
 
+    has_setup = True
+
+    def setup_environment(self):
+        # Uninstall the app first (no network needed) so installing it is real
+        # work; teardown reinstalls best-effort.
+        from tasks import env_setup
+        return env_setup.ensure_flatpak_app_absent(self.id, self.app_id)
+
     def __init__(self):
         super().__init__(
             id="flatpak_install_app_001",

--- a/tasks/packages.py
+++ b/tasks/packages.py
@@ -17,6 +17,14 @@ logger = logging.getLogger(__name__)
 class InstallPackageTask(BaseTask):
     """Install a package using dnf."""
 
+    has_setup = True
+
+    def setup_environment(self):
+        # Remove the package first so installing it is real work (needs repo
+        # access; degrades gracefully if unavailable).
+        from tasks import env_setup
+        return env_setup.ensure_package_absent(self.id, self.package_name)
+
     def __init__(self):
         super().__init__(id="pkg_install_001", category="packages", difficulty="easy", points=6)
         self.tags = []
@@ -56,6 +64,13 @@ class InstallPackageTask(BaseTask):
 @TaskRegistry.register("packages")
 class RemovePackageTask(BaseTask):
     """Remove a package using dnf."""
+
+    has_setup = True
+
+    def setup_environment(self):
+        # Install the package first so removing it is real work.
+        from tasks import env_setup
+        return env_setup.ensure_package_installed(self.id, self.package_name)
 
     def __init__(self):
         super().__init__(id="pkg_remove_001", category="packages", difficulty="easy", points=6)

--- a/tasks/partitioning.py
+++ b/tasks/partitioning.py
@@ -448,8 +448,14 @@ class PartitionAndFormatTask(BaseTask):
     def generate(self, **params):
         self.params["device"] = params.get("device", _random_device())
         self.params["part_num"] = params.get("part_num", 1)
-        self.params["size_mb"] = params.get("size", random.choice([100, 150, 200, 300]))
+        # Pick fstype first: RHEL 10 mkfs.xfs refuses filesystems <= 300MB, so an
+        # XFS partition must be larger than that. Loop practice disks are 500MB,
+        # so 350-450MB fits. ext4 has no such floor.
         self.params["fstype"] = params.get("fstype", random.choice(["xfs", "ext4"]))
+        if self.params["fstype"] == "xfs":
+            self.params["size_mb"] = params.get("size", random.choice([350, 400, 450]))
+        else:
+            self.params["size_mb"] = params.get("size", random.choice([100, 150, 200, 300]))
         self.params["mount_point"] = params.get("mount_point", f"/mnt/{random.choice(['data', 'apps', 'backup', 'extra'])}{random.randint(1, 99)}")
 
         dev = self.params["device"]

--- a/tasks/processes.py
+++ b/tasks/processes.py
@@ -350,7 +350,11 @@ class FindProcessByUserTask(BaseTask):
 
     def generate(self, **params):
         """Generate find process by user task."""
-        self.username = params.get('username', 'apache')
+        # Use a dedicated practice account, never a real service user. 'apache'
+        # is the httpd runtime user: if httpd is running (several fault tasks
+        # start it), its workers are owned by apache and the master respawns any
+        # the candidate kills, making the kill action impossible to complete.
+        self.username = params.get('username', 'pracproc')
         actions = ['list', 'count', 'kill']
         self.action = params.get('action', random.choice(actions))
 

--- a/tasks/services.py
+++ b/tasks/services.py
@@ -31,6 +31,12 @@ _TROUBLESHOOT_SERVICES = ['httpd', 'nginx', 'mariadb', 'named', 'vsftpd']
 class StartServiceTask(BaseTask):
     """Start a systemd service (without enabling)."""
 
+    has_setup = True
+
+    def setup_environment(self):
+        from tasks import env_setup
+        return env_setup.make_service_absent(self.id, self.service_name)
+
     def __init__(self):
         super().__init__(
             id="svc_start_001",
@@ -94,6 +100,12 @@ class StartServiceTask(BaseTask):
 class EnableServiceTask(BaseTask):
     """Enable a systemd service at boot."""
 
+    has_setup = True
+
+    def setup_environment(self):
+        from tasks import env_setup
+        return env_setup.make_service_absent(self.id, self.service_name)
+
     def __init__(self):
         super().__init__(
             id="svc_enable_001",
@@ -155,6 +167,12 @@ class EnableServiceTask(BaseTask):
 @TaskRegistry.register("services")
 class StartAndEnableServiceTask(BaseTask):
     """Start AND enable a systemd service (the most common exam task)."""
+
+    has_setup = True
+
+    def setup_environment(self):
+        from tasks import env_setup
+        return env_setup.make_service_absent(self.id, self.service_name)
 
     def __init__(self):
         super().__init__(
@@ -237,6 +255,12 @@ class StartAndEnableServiceTask(BaseTask):
 @TaskRegistry.register("services")
 class StopAndDisableServiceTask(BaseTask):
     """Stop a service and disable it from starting at boot."""
+
+    has_setup = True
+
+    def setup_environment(self):
+        from tasks import env_setup
+        return env_setup.make_service_present(self.id, self.service_name)
 
     def __init__(self):
         super().__init__(

--- a/tasks/ssh.py
+++ b/tasks/ssh.py
@@ -19,6 +19,14 @@ logger = logging.getLogger(__name__)
 class GenerateSSHKeyTask(BaseTask):
     """Generate an SSH key pair."""
 
+    has_setup = True
+
+    def setup_environment(self):
+        # Move any existing key (the user's real key, or a leftover) aside so the
+        # candidate must actually generate one; teardown restores the original.
+        from tasks import env_setup
+        return env_setup.backup_paths(self.id, [self.key_path, f'{self.key_path}.pub'])
+
     def __init__(self):
         super().__init__(
             id="ssh_keygen_001",

--- a/tasks/swap.py
+++ b/tasks/swap.py
@@ -41,7 +41,9 @@ class CreateSwapPartitionTask(BaseTask):
         self.size_mb = None
 
     def generate(self, **params):
-        self.size_mb = params.get('size_mb', random.choice([256, 512]))
+        # Practice loop disks are 500MB; a 512MB partition can't fit (≈498MB
+        # usable after the 1MiB alignment offset). Keep sizes comfortably below.
+        self.size_mb = params.get('size_mb', random.choice([256, 400]))
         self.loop_device = params.get('loop_device') or get_swap_practice_device() or '/dev/sdb'
         # Partition 1 on the loop device (e.g. /dev/loop2p1)
         self.device = params.get('device') or f"{self.loop_device}p1"

--- a/tasks/systemd_timers.py
+++ b/tasks/systemd_timers.py
@@ -718,6 +718,12 @@ class ListActiveTimersTask(BaseTask):
 class EnableTimerTask(BaseTask):
     """Enable and start an existing systemd timer."""
 
+    has_setup = True
+
+    def setup_environment(self):
+        from tasks import env_setup
+        return env_setup.make_timer_absent(self.id, self.timer_name)
+
     def __init__(self):
         super().__init__(
             id="timer_enable_001",

--- a/tasks/troubleshooting.py
+++ b/tasks/troubleshooting.py
@@ -106,6 +106,12 @@ def restore_any_active_fault():
 
 def _dispatch_restore(task_id, info, msgs):
     """Restore a single fault by task_id (crash-recovery dispatcher)."""
+    # Generic environment-setup records (from positive-config tasks that
+    # establish a negative precondition at exam start) carry a restore_type and
+    # are undone independently of their task_id.
+    if isinstance(info, dict) and info.get('restore_type'):
+        _restore_env_setup(info, msgs)
+        return
     # Dispatch to the right restorer
     if task_id.startswith('fault_selinux_context'):
         _restore_selinux_context(info, msgs)
@@ -329,6 +335,50 @@ def _restore_fstab(info, msgs):
         with open('/etc/fstab', 'w') as f:
             f.writelines(cleaned)
         msgs.append("Removed injected fstab line")
+
+
+def _restore_env_setup(info, msgs):
+    """Undo a positive-task environment setup (see tasks/env_setup.py)."""
+    rt = info.get('restore_type')
+    if rt == 'unit':
+        unit = info.get('unit')
+        if not unit:
+            return
+        if info.get('was_enabled'):
+            subprocess.run(['systemctl', 'enable', unit], capture_output=True)
+        else:
+            subprocess.run(['systemctl', 'disable', unit], capture_output=True)
+        if info.get('was_active'):
+            subprocess.run(['systemctl', 'start', unit], capture_output=True)
+        else:
+            subprocess.run(['systemctl', 'stop', unit], capture_output=True)
+        msgs.append(f"Restored {unit} (active={info.get('was_active')}, "
+                    f"enabled={info.get('was_enabled')})")
+    elif rt == 'file_backup':
+        import shutil as _shutil
+        for p in info.get('paths', []):
+            bak = p + '.rhcsa-bak'
+            if os.path.exists(bak):
+                try:
+                    _shutil.move(bak, p)
+                except OSError:
+                    pass
+        msgs.append(f"Restored original file(s): {info.get('paths')}")
+    elif rt == 'pkg_remove':
+        pkg = info.get('pkg')
+        if pkg:
+            subprocess.run(['dnf', '-y', 'remove', pkg], capture_output=True)
+            msgs.append(f"Removed setup package {pkg}")
+    elif rt == 'pkg_install':
+        pkg = info.get('pkg')
+        if pkg:
+            subprocess.run(['dnf', '-y', 'install', pkg], capture_output=True)
+            msgs.append(f"Reinstalled package {pkg}")
+    elif rt == 'flatpak_install':
+        app = info.get('app_id')
+        if app:
+            subprocess.run(['flatpak', 'install', '-y', 'flathub', app], capture_output=True)
+            msgs.append(f"Reinstalled flatpak {app}")
 
 
 # ── Base class ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the **pre-pass gap** (positive-config tasks passing with zero candidate work) and fixes three exam-breaking bugs found while taking the exam on a live RHEL 10.2 VM. Independent of #8/#9.

### 1. Pre-pass fix (main change)
Tasks like "enable crond", "generate an SSH key", "install X" validated as **PASS without any candidate work** when the system already satisfied the goal — a default-on unit (`fstrim.timer`, `crond` are enabled by default), or a leftover artifact from a previous session. Only fault-injection tasks established any state.

New setup/teardown hook, mirroring `inject_fault`/`restore_fault`:
- `BaseTask.has_setup` + `setup_environment()` / `teardown_environment()`.
- `ExamSession` runs setups during "Preparing exam environment" and tears them down during cleanup.
- `tasks/env_setup.py` helpers establish the negative precondition and record it in the active-fault file, so an interrupted session is cleaned up by **System Reset / startup recovery** (new generic `restore_type` dispatcher in `_dispatch_restore`).

Wired up: service start/enable/stop tasks (**`sshd` and `NetworkManager` are never touched**), the timer-enable task, ssh keygen (original key backed up and restored), the find/IO output-file tasks, and package install/remove + flatpak install (best-effort; degrade gracefully without repo/network).

Verified live — each offender now goes **PASS → (setup) FAIL → (real work) PASS → (teardown) original state restored** (confirmed for `fstrim.timer`, `crond`, ssh key).

### 2. Apache process task respawn (unwinnable task)
`proc_find_user_001` used the **`apache`** account. If httpd is running (several fault tasks start it), its workers are owned by `apache` and the master **respawns** any the candidate kills — the kill action could never complete ("kill 4, 4 more appear"). Now uses a dedicated **`pracproc`** account.

### 3. XFS on a sub-300MB partition (impossible)
`part_format_mount` could format **XFS on a ≤300MB partition**; RHEL 10 `mkfs.xfs` refuses that. Now picks fstype first, then size **≥350MB for XFS** (ext4 unchanged). (The earlier XFS-size PR fixed the LVM tasks but missed this one.)

### 4. 512MB swap partition on a 500MB disk (impossible)
`swap_partition_001` could request a **512MB swap partition on a 500MB** practice disk. Capped to sizes that fit.

## Testing
- `152 passed`.
- 200 generations each: zero XFS partitions ≤300MB, zero swap sizes >500MB.
- Live setup/teardown behavioral test passed; system state restored afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)