### PR TITLE
Fix partition naming: /dev/sda1 not /dev/sdap1

### DIFF
--- a/tasks/partitioning.py
+++ b/tasks/partitioning.py
@@ -38,10 +38,11 @@ def _random_device():
 
 
 def _partition_dev(device, number):
-    """Build partition device path, handling NVMe naming convention."""
-    if 'nvme' in device or 'loop' in device:
-        return f"{device}p{number}"
-    return f"{device}{number}"
+    """Build partition device path. Inserts a 'p' before the number only when
+    the device name ends in a digit (loop0p1, nvme0n1p1, mmcblk0p1) but not for
+    sd*/vd*/hd* (sda1). Delegates to the shared helper."""
+    from utils.helpers import partition_device
+    return partition_device(device, number)
 
 
 # ===== 1. CreateMBRPartitionTask ==========================================

--- a/tasks/swap.py
+++ b/tasks/swap.py
@@ -8,7 +8,7 @@ from tasks.base import BaseTask
 from tasks.registry import TaskRegistry
 from core.validator import ValidationCheck, ValidationResult
 from validators.safe_executor import execute_safe
-from utils.helpers import get_swap_practice_device
+from utils.helpers import get_swap_practice_device, partition_device
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +45,8 @@ class CreateSwapPartitionTask(BaseTask):
         # usable after the 1MiB alignment offset). Keep sizes comfortably below.
         self.size_mb = params.get('size_mb', random.choice([256, 400]))
         self.loop_device = params.get('loop_device') or get_swap_practice_device() or '/dev/sdb'
-        # Partition 1 on the loop device (e.g. /dev/loop2p1)
-        self.device = params.get('device') or f"{self.loop_device}p1"
+        # Partition 1 on the disk: /dev/loop2p1 but /dev/sda1 (no 'p' for sd*).
+        self.device = params.get('device') or partition_device(self.loop_device, 1)
 
         self.description = (
             f"Use {self.loop_device} to create a {self.size_mb}MB swap partition "

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -527,6 +527,22 @@ def get_available_block_devices():
         return []
 
 
+def partition_device(device, number):
+    """Build the partition device path for `device` using the kernel's naming
+    rule: insert a 'p' before the partition number only when the device name
+    ends in a digit.
+
+        /dev/sda      -> /dev/sda1       (sd*/vd*/hd* end in a letter)
+        /dev/loop0    -> /dev/loop0p1    (ends in a digit)
+        /dev/nvme0n1  -> /dev/nvme0n1p1
+        /dev/mmcblk0  -> /dev/mmcblk0p1
+
+    The old code appended 'p1' unconditionally, producing bogus paths like
+    /dev/sdap1 for real SCSI/SATA/virtio disks.
+    """
+    dev = device.rstrip('/')
+    sep = 'p' if dev[-1:].isdigit() else ''
+    return f"{dev}{sep}{number}"
 
 
 def get_loop_devices():


### PR DESCRIPTION
## Problem

The swap task showed a bogus partition device on real disks:

```
Use /dev/sda to create a 400MB swap partition and configure it as persistent swap.
  ✗ Swap not active on /dev/sdap1 — run: mkswap /dev/sdap1 && swapon /dev/sdap1
  ✗ /dev/sdap1 not formatted as swap — run: mkswap /dev/sdap1
  ✗ No fstab entry for swap on /dev/sdap1 ...
```

`/dev/sdap1` isn't a thing. `tasks/swap.py` built the partition path as `f"{device}p1"` unconditionally.

## Fix

The kernel inserts a `p` before the partition number **only when the device name ends in a digit**:

| Device | Partition 1 |
|--------|-------------|
| `/dev/sda` (sd*/vd*/hd*) | `/dev/sda1` |
| `/dev/loop2` | `/dev/loop2p1` |
| `/dev/nvme0n1` | `/dev/nvme0n1p1` |
| `/dev/mmcblk0` | `/dev/mmcblk0p1` |

- Add `utils.helpers.partition_device(device, number)` implementing the ends-in-a-digit rule.
- Use it in `swap.py`.
- Route `partitioning._partition_dev` through it too — its old `'nvme'/'loop'` substring check would mis-name `mmcblk*` devices.

## Verification

All device styles produce correct names; swap task on `/dev/sda` now says `/dev/sda1`. `152 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8UPKdjDoBoVJCfwzSec5a