### PR TITLE
Add checker-dispute feedback flow (issue -> AI review -> fix PR)

### DIFF
--- a/.github/workflows/checker-dispute.yml
+++ b/.github/workflows/checker-dispute.yml
@@ -1,0 +1,76 @@
+name: Checker dispute review
+
+# Triggered when a "checker-dispute" label is added to an issue (the RHCSA
+# simulator does this automatically when a candidate disputes a validator
+# result). An AI reviewer reads the issue — which contains the task, the
+# disputed check(s), the candidate's argument and captured system state —
+# inspects the validator for that task, posts a verdict comment, and opens a
+# fix PR if the checker is genuinely wrong.
+#
+# Auth: set ONE repo secret (Settings → Secrets and variables → Actions):
+#   * CLAUDE_CODE_OAUTH_TOKEN  — from `claude setup-token`, uses your existing
+#     Claude subscription (no per-token API billing), OR
+#   * ANTHROPIC_API_KEY        — pay-as-you-go Anthropic API key.
+# The step below accepts either; set whichever you have.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    if: github.event.label.name == 'checker-dispute'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: AI review of the disputed checker
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: >-
+            --allowedTools "Bash,Read,Edit,Write,Grep,Glob"
+          prompt: |
+            A candidate using the RHCSA exam simulator has disputed a validator
+            ("checker") result. The dispute is GitHub issue #${{ github.event.issue.number }}
+            in this repository. Its body contains: the task as presented, the
+            specific check(s) the candidate says are wrong, the candidate's
+            written argument, and captured live system-state evidence.
+
+            Your job:
+            1. Read the issue:
+                 gh issue view ${{ github.event.issue.number }}
+            2. Identify the task by its `task_id` (stated in the issue) and find
+               the corresponding task class and its `validate()` method under
+               tasks/ (and any helpers under validators/).
+            3. Decide, strictly from the evidence in the issue, whether the
+               checker logic is WRONG (e.g. wrong device-naming, wrong path,
+               wrong grep pattern, an inverted condition, an off-by-one, a bad
+               RHEL10 assumption) versus the candidate simply not having
+               completed the task. Be rigorous and skeptical — the evidence
+               must actually contradict the check.
+            4. Post a comment on the issue with your verdict and reasoning:
+                 gh issue comment ${{ github.event.issue.number }} --body "..."
+            5. If — and only if — the checker is genuinely wrong:
+                 - create a branch  fix/dispute-<task_id>-${{ github.event.issue.number }}
+                 - implement the minimal correct fix to the validator/task
+                 - run `python3 -m pytest -q` and make sure it passes
+                 - commit and open a PR whose body says
+                   "Closes #${{ github.event.issue.number }}", explaining the bug
+                   and citing the evidence, using `gh pr create`.
+               If the checker is correct, do NOT open a PR; just explain in your
+               comment what the candidate likely missed.
+
+            Do not change behaviour beyond the validator/task fix. Keep the PR
+            small and focused.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Thumbs.db
 # Keep data directories but not contents
 !data/results/.gitkeep
 !data/logs/.gitkeep
+
+# Candidate dispute reports (local only)
+data/disputes/

--- a/core/dispute.py
+++ b/core/dispute.py
@@ -1,0 +1,205 @@
+"""
+Checker dispute reporting.
+
+When a candidate reviewing their results believes a validator (the "checker")
+scored a task incorrectly, they can dispute it from the result detail screen.
+A dispute:
+
+  1. captures the relevant LIVE system state as evidence (category-specific
+     diagnostic commands, plus any commands the candidate supplies),
+  2. bundles it with the task, the disputed check(s) and the candidate's
+     written argument into a Markdown report,
+  3. opens a GitHub issue (labelled ``checker-dispute``) via the ``gh`` CLI.
+
+A GitHub Action (.github/workflows/checker-dispute.yml) reacts to that label:
+an AI reviewer inspects the validator for the task, compares it against the
+uploaded evidence, comments its verdict, and — if the checker is genuinely
+wrong — opens a fix PR automatically.
+
+Nothing here changes system state; it only reads it.
+"""
+
+import os
+import shutil
+import subprocess
+from datetime import datetime
+
+from utils import formatters as fmt  # noqa: F401  (kept for callers/consistency)
+
+
+# Repo root = parent of this package directory; gh / git run from here.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DISPUTE_DIR = os.path.join(REPO_ROOT, 'data', 'disputes')
+DISPUTE_LABEL = 'checker-dispute'
+
+_MAX_OUTPUT = 4000  # chars kept per command, to keep issues readable
+
+# Always-captured baseline context.
+_GENERIC_EVIDENCE = [
+    ['uname', '-r'],
+    ['sh', '-c', 'cat /etc/os-release 2>/dev/null | head -5'],
+]
+
+# Category -> read-only diagnostic commands that show the relevant state.
+_CATEGORY_EVIDENCE = {
+    'swap': [['swapon', '--show'], ['cat', '/proc/swaps'], ['lsblk', '-f'],
+             ['blkid'], ['sh', '-c', 'grep -i swap /etc/fstab']],
+    'lvm': [['pvs'], ['vgs'], ['lvs'], ['lsblk'], ['cat', '/etc/fstab']],
+    'partitioning': [['lsblk', '-f'], ['blkid'], ['cat', '/etc/fstab']],
+    'filesystems': [['lsblk', '-f'], ['blkid'], ['findmnt', '--real'],
+                    ['cat', '/etc/fstab']],
+    'repos': [['dnf', 'repolist', '--all'],
+              ['sh', '-c', 'ls -la /etc/yum.repos.d/'],
+              ['sh', '-c', 'tail -n +1 /etc/yum.repos.d/*.repo']],
+    'users_groups': [['sh', '-c', 'getent passwd | tail -20'],
+                     ['sh', '-c', 'getent group | tail -20'],
+                     ['sh', '-c', 'grep -E "PASS_MAX|PASS_MIN|PASS_WARN" /etc/login.defs']],
+    'selinux': [['getenforce'], ['sh', '-c', 'sestatus 2>/dev/null']],
+    'networking': [['sh', '-c', 'nmcli -t con show 2>/dev/null'],
+                   ['sh', '-c', 'ip -br a'], ['cat', '/etc/resolv.conf']],
+    'services': [['sh', '-c', 'systemctl list-units --type=service --no-pager | head -40']],
+    'firewall': [['sh', '-c', 'firewall-cmd --list-all 2>/dev/null']],
+    'boot': [['cat', '/proc/cmdline'], ['sh', '-c', 'ls -la /boot/grub2/ 2>/dev/null']],
+    'scheduling': [['sh', '-c', 'systemctl list-timers --no-pager'],
+                   ['sh', '-c', 'crontab -l 2>/dev/null']],
+    'systemd_timers': [['sh', '-c', 'systemctl list-timers --all --no-pager | head -40']],
+    'ssh': [['sh', '-c', 'sshd -T 2>/dev/null | head -40'],
+            ['sh', '-c', 'ls -la ~/.ssh 2>/dev/null']],
+    'permissions': [['sh', '-c', 'echo "(provide the path with a custom command below)"']],
+    'packages': [['sh', '-c', 'rpm -qa | wc -l']],
+}
+
+
+def _run(cmd, shell=False):
+    """Run a diagnostic command, returning (display, rc, output) truncated."""
+    display = cmd if isinstance(cmd, str) else ' '.join(cmd)
+    try:
+        res = subprocess.run(
+            cmd, shell=shell, capture_output=True, text=True, timeout=25,
+            cwd='/'
+        )
+        out = (res.stdout or '') + (res.stderr or '')
+        out = out.strip()
+        if len(out) > _MAX_OUTPUT:
+            out = out[:_MAX_OUTPUT] + '\n...[truncated]...'
+        return display, res.returncode, out or '(no output)'
+    except FileNotFoundError:
+        return display, 127, '(command not found)'
+    except subprocess.TimeoutExpired:
+        return display, 124, '(timed out)'
+    except Exception as e:
+        return display, 1, f'(error: {e})'
+
+
+def gh_available():
+    """True if the gh CLI is installed and authenticated for this repo."""
+    if not shutil.which('gh'):
+        return False
+    try:
+        res = subprocess.run(['gh', 'auth', 'status'],
+                             capture_output=True, text=True, timeout=15)
+        return res.returncode == 0
+    except Exception:
+        return False
+
+
+def collect_evidence(category, extra_commands=None):
+    """Gather (display, rc, output) tuples for the category + any extra commands."""
+    evidence = []
+    for cmd in _GENERIC_EVIDENCE:
+        evidence.append(_run(cmd))
+    for cmd in _CATEGORY_EVIDENCE.get(category, []):
+        evidence.append(_run(cmd))
+    for raw in (extra_commands or []):
+        raw = raw.strip()
+        if raw:
+            evidence.append(_run(raw, shell=True))
+    return evidence
+
+
+def build_report(tr, disputed, argument, evidence):
+    """Render the dispute as Markdown for the GitHub issue body."""
+    lines = []
+    lines.append(f"## Checker dispute: `{tr.get('task_id', '?')}`")
+    lines.append("")
+    lines.append(f"- **Task ID:** `{tr.get('task_id', '?')}`")
+    lines.append(f"- **Category:** {tr.get('category', '?')}")
+    lines.append(f"- **Difficulty:** {tr.get('difficulty', '?')}")
+    lines.append(f"- **Scored:** {tr.get('score', '?')}/{tr.get('max_score', '?')} "
+                 f"({'PASSED' if tr.get('passed') else 'FAILED'})")
+    lines.append(f"- **Filed:** {datetime.now().isoformat(timespec='seconds')}")
+    lines.append("")
+    lines.append("### Task as presented to the candidate")
+    lines.append("```")
+    lines.append(tr.get('description') or '(no description saved)')
+    lines.append("```")
+    lines.append("")
+    lines.append("### Disputed check(s) — candidate says these are WRONG")
+    for c in disputed:
+        mark = '✓' if c.get('passed') else '✗'
+        lines.append(f"- {mark} [{c.get('points', 0)}/{c.get('max_points', c.get('points', 0))}pt] "
+                     f"{c.get('message', c.get('name', ''))}")
+    lines.append("")
+    lines.append("### Candidate's argument")
+    lines.append("")
+    lines.append(argument.strip() or '(none provided)')
+    lines.append("")
+    lines.append("### Captured system state (evidence)")
+    for display, rc, out in evidence:
+        lines.append("")
+        lines.append(f"<details><summary><code>$ {display}</code> (rc={rc})</summary>")
+        lines.append("")
+        lines.append("```")
+        lines.append(out)
+        lines.append("```")
+        lines.append("</details>")
+    lines.append("")
+    lines.append("---")
+    lines.append(
+        "_Filed automatically from the RHCSA simulator. An AI reviewer will "
+        f"inspect the validator for `{tr.get('task_id', '?')}`, compare it "
+        "against the evidence above, comment a verdict, and open a fix PR if "
+        "the checker is found to be wrong._"
+    )
+    return "\n".join(lines)
+
+
+def save_report(tr, body):
+    """Persist the report locally and return its path."""
+    os.makedirs(DISPUTE_DIR, exist_ok=True)
+    stamp = datetime.now().strftime('%Y%m%d-%H%M%S')
+    path = os.path.join(DISPUTE_DIR, f"{tr.get('task_id', 'task')}-{stamp}.md")
+    with open(path, 'w') as fh:
+        fh.write(body)
+    return path
+
+
+def submit_issue(tr, body_path):
+    """Open a labelled GitHub issue from the saved report. Returns (ok, info)."""
+    title = f"[checker dispute] {tr.get('task_id', 'task')}: scored " \
+            f"{tr.get('score', '?')}/{tr.get('max_score', '?')}"
+
+    # Best-effort: make sure the label exists (ignore "already exists").
+    subprocess.run(
+        ['gh', 'label', 'create', DISPUTE_LABEL, '--color', 'D93F0B',
+         '--description', 'Candidate disputes a validator result',
+         '--force'],
+        capture_output=True, text=True, cwd=REPO_ROOT, timeout=20
+    )
+
+    cmd = ['gh', 'issue', 'create', '--title', title,
+           '--body-file', body_path, '--label', DISPUTE_LABEL]
+    res = subprocess.run(cmd, capture_output=True, text=True,
+                         cwd=REPO_ROOT, timeout=60)
+    if res.returncode == 0:
+        url = res.stdout.strip().splitlines()[-1] if res.stdout.strip() else ''
+        return True, url
+    # Retry without the label in case label creation was not permitted.
+    res2 = subprocess.run(
+        ['gh', 'issue', 'create', '--title', title, '--body-file', body_path],
+        capture_output=True, text=True, cwd=REPO_ROOT, timeout=60
+    )
+    if res2.returncode == 0:
+        url = res2.stdout.strip().splitlines()[-1] if res2.stdout.strip() else ''
+        return True, url + " (label not applied — add it manually to trigger the AI review)"
+    return False, (res.stderr or res2.stderr or 'gh issue create failed').strip()

--- a/core/exam.py
+++ b/core/exam.py
@@ -9,8 +9,10 @@ Features:
 - Domain breakdown in final report
 """
 
+import io
 import time
 import logging
+from contextlib import redirect_stdout
 from datetime import datetime, timedelta
 from config import settings
 from tasks.registry import TaskRegistry
@@ -217,22 +219,25 @@ class ExamSession:
         print()
 
     def _display_tasks(self):
-        """Display all exam tasks."""
-        fmt.print_header("EXAM TASKS")
-
+        """Display all exam tasks through a pager so the full question sheet is
+        scrollable (no tmux copy-mode needed for long exams)."""
         total_points = sum(task.points for task in self.tasks)
 
-        for i, task in enumerate(self.tasks, 1):
-            domain = getattr(task, 'exam_domain', 0)
-            domain_name = settings.EXAM_DOMAINS.get(domain, "")
-            domain_tag = f" [{domain_name}]" if domain_name else ""
-            fmt.print_task(i, task.description, task.points)
-            if domain_tag:
-                print(fmt.dim(f"      Domain {domain}: {domain_name}"))
-
-        print()
-        print(fmt.bold(f"Total Points: {total_points}"))
-        print("=" * 60)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            fmt.print_header("EXAM TASKS")
+            for i, task in enumerate(self.tasks, 1):
+                domain = getattr(task, 'exam_domain', 0)
+                domain_name = settings.EXAM_DOMAINS.get(domain, "")
+                domain_tag = f" [{domain_name}]" if domain_name else ""
+                fmt.print_task(i, task.description, task.points)
+                if domain_tag:
+                    print(fmt.dim(f"      Domain {domain}: {domain_name}"))
+            print()
+            print(fmt.bold(f"Total Points: {total_points}"))
+            print(fmt.dim("(Scroll with ↑/↓ or PageUp/PageDown; press q to start.)"))
+            print("=" * 60)
+        fmt.page_output(buf.getvalue())
 
     def validate_all(self):
         """Validate all tasks, run reboot simulation, save to ResultsDB."""

--- a/core/menu.py
+++ b/core/menu.py
@@ -780,7 +780,132 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
                 print(fmt.dim("(No hints saved for this session — re-run a new exam to get hints)"))
                 print()
 
-        input("Press Enter to return to session view...")
+        # Offer the dispute path when there are checks to dispute.
+        if checks:
+            print(fmt.dim("Think the checker got this wrong? Type 'd' to dispute it "
+                          "(opens a GitHub issue; an AI reviews your evidence and "
+                          "pushes a fix if you're right)."))
+            choice = input("Press Enter to return to session view, or 'd' to dispute: ").strip().lower()
+            if choice == 'd':
+                self._dispute_check_flow(tr, checks)
+        else:
+            input("Press Enter to return to session view...")
+
+    def _dispute_check_flow(self, tr, checks):
+        """Let the candidate dispute a checker result: capture system-state
+        evidence + their argument and open a GitHub issue that triggers an AI
+        review (which pushes a fix PR if the checker is genuinely wrong)."""
+        from core import dispute
+        from utils.helpers import confirm_action
+
+        fmt.clear_screen()
+        print(fmt.bold("DISPUTE A CHECKER RESULT"))
+        print("=" * 60)
+        print()
+        print("If you believe the checker scored this task incorrectly, you can")
+        print("dispute it. Here is exactly what happens when you do:")
+        print()
+        print("  1. Your written argument and the relevant LIVE system state")
+        print("     (command output) are captured as evidence.")
+        print("  2. A GitHub issue is opened on this project containing that")
+        print("     evidence (so review it for anything sensitive first).")
+        print("  3. An AI reviewer inspects the validator for this task, compares")
+        print("     it against your evidence, and comments a verdict.")
+        print("  4. If the checker is wrong, it opens a fix PR automatically.")
+        print()
+        print(fmt.warning("Evidence (file paths, hostnames, command output) becomes public on GitHub."))
+        print()
+
+        if not confirm_action("Open a GitHub dispute for this task?", default=False):
+            print(fmt.dim("Cancelled — nothing was sent."))
+            input("\nPress Enter to return to session view...")
+            return
+
+        # 1. Which checks are being disputed (default: the failed ones).
+        print()
+        print(fmt.bold("Which check(s) are wrong?"))
+        for i, c in enumerate(checks, 1):
+            mark = fmt.success("✓") if c.get('passed') else fmt.error("✗")
+            print(f"  {i}. {mark} {c.get('message', c.get('name', ''))}")
+        print()
+        sel = input("Enter numbers (comma-separated), or Enter for all FAILED checks: ").strip()
+        if sel:
+            disputed = []
+            for tok in sel.replace(',', ' ').split():
+                try:
+                    idx = int(tok) - 1
+                    if 0 <= idx < len(checks):
+                        disputed.append(checks[idx])
+                except ValueError:
+                    pass
+        else:
+            disputed = [c for c in checks if not c.get('passed')]
+        if not disputed:
+            disputed = list(checks)
+
+        # 2. The candidate's argument.
+        print()
+        print(fmt.bold("Why is the checker wrong? (explain your evidence)"))
+        print(fmt.dim("Enter your argument; finish with an empty line."))
+        arg_lines = []
+        while True:
+            line = input("  ")
+            if line == '' and arg_lines:
+                break
+            if line == '' and not arg_lines:
+                continue
+            arg_lines.append(line)
+        argument = "\n".join(arg_lines)
+
+        # 3. Optional extra evidence commands.
+        print()
+        print(fmt.bold("Extra evidence commands (optional)"))
+        print(fmt.dim("Type read-only commands whose output proves your point, one per"))
+        print(fmt.dim("line (e.g. 'blkid /dev/sda1'). Finish with an empty line."))
+        extra_cmds = []
+        while True:
+            line = input("  $ ").strip()
+            if line == '':
+                break
+            extra_cmds.append(line)
+
+        # 4. Capture evidence + build + save the report.
+        print()
+        print("Capturing system state…")
+        evidence = dispute.collect_evidence(tr.get('category', ''), extra_cmds)
+        body = dispute.build_report(tr, disputed, argument, evidence)
+        path = dispute.save_report(tr, body)
+        print(fmt.success(f"Saved dispute report: {path}"))
+
+        # 5. Submit via gh (or fall back to local-only with instructions).
+        if not dispute.gh_available():
+            print()
+            print(fmt.warning("GitHub CLI ('gh') is not installed or not authenticated, so the"))
+            print(fmt.warning("issue could not be opened automatically."))
+            print("The full report was saved at the path above. To file it:")
+            print(fmt.dim(f"  gh issue create --label {dispute.DISPUTE_LABEL} "
+                          f"--title '[checker dispute] {tr.get('task_id')}' --body-file {path}"))
+            input("\nPress Enter to return to session view...")
+            return
+
+        print()
+        if not confirm_action("Open the GitHub issue now?", default=True):
+            print(fmt.dim(f"Not sent. Report kept at {path}."))
+            input("\nPress Enter to return to session view...")
+            return
+
+        ok, info = dispute.submit_issue(tr, path)
+        print()
+        if ok:
+            print(fmt.success("Dispute filed!"))
+            if info:
+                print(f"  {info}")
+            print(fmt.info("An AI reviewer will inspect the validator and, if the checker is"))
+            print(fmt.info("wrong, open a fix PR. Watch the issue for its verdict."))
+        else:
+            print(fmt.error(f"Could not open the issue: {info}"))
+            print(fmt.dim(f"The report is saved at {path} — you can file it manually."))
+        input("\nPress Enter to return to session view...")
 
     def populate_practice_environment(self):
         """Install/remove lightweight packages to build up DNF transaction history."""

--- a/core/menu.py
+++ b/core/menu.py
@@ -715,22 +715,17 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             self._show_task_detail(task_list[tidx][1])
 
     def _show_task_detail(self, tr):
-        """Show full detail for one task result including failed checks and hints."""
+        """Show full detail for one task result including failed checks and hints.
+
+        The (often long) static detail is rendered through a pager so it is
+        scrollable; the interactive dispute prompt runs afterwards."""
+        import io
         import json
+        from contextlib import redirect_stdout
 
         fmt.clear_screen()
-        status = fmt.success("PASSED") if tr['passed'] else fmt.error("FAILED")
-        cat = fmt.format_category_name(tr['category'])
-        print(f"{status}  {tr['score']}/{tr['max_score']} points  [{cat} / {tr['difficulty']}]")
-        print("=" * 60)
-        print()
 
-        # Task description (what was asked)
-        print(fmt.bold("Task:"))
-        print(tr['description'] or "(no description saved)")
-        print()
-
-        # Validation checks (what the system found)
+        # Parse checks once (also used by the dispute prompt below).
         checks = []
         if tr.get('checks_json'):
             try:
@@ -738,47 +733,63 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             except Exception:
                 pass
 
-        if checks:
-            print(fmt.bold("Validation breakdown:"))
-            for c in checks:
-                icon = fmt.success("✓") if c.get('passed') else fmt.error("✗")
-                pts = c.get('points', 0)
-                max_pts = c.get('max_points', pts)
-                msg = c.get('message', c.get('name', ''))
-                print(f"  {icon} [{pts}/{max_pts}pt]  {msg}")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            status = fmt.success("PASSED") if tr['passed'] else fmt.error("FAILED")
+            cat = fmt.format_category_name(tr['category'])
+            print(f"{status}  {tr['score']}/{tr['max_score']} points  [{cat} / {tr['difficulty']}]")
+            print("=" * 60)
             print()
 
-        # Hints / what to study (only if task failed)
-        if not tr['passed']:
-            hints = []
-            if tr.get('hints_json'):
-                try:
-                    hints = json.loads(tr['hints_json'])
-                except Exception:
-                    pass
+            # Task description (what was asked)
+            print(fmt.bold("Task:"))
+            print(tr['description'] or "(no description saved)")
+            print()
 
-            exam_tips = []
-            if tr.get('exam_tips_json'):
-                try:
-                    exam_tips = json.loads(tr['exam_tips_json'])
-                except Exception:
-                    pass
-
-            if hints:
-                print(fmt.bold("What to study / how to fix it:"))
-                for h in hints:
-                    print(f"  • {h}")
+            # Validation checks (what the system found)
+            if checks:
+                print(fmt.bold("Validation breakdown:"))
+                for c in checks:
+                    icon = fmt.success("✓") if c.get('passed') else fmt.error("✗")
+                    pts = c.get('points', 0)
+                    max_pts = c.get('max_points', pts)
+                    msg = c.get('message', c.get('name', ''))
+                    print(f"  {icon} [{pts}/{max_pts}pt]  {msg}")
                 print()
 
-            if exam_tips:
-                print(fmt.bold("Exam tips:"))
-                for t in exam_tips:
-                    print(f"  * {t}")
-                print()
+            # Hints / what to study (only if task failed)
+            if not tr['passed']:
+                hints = []
+                if tr.get('hints_json'):
+                    try:
+                        hints = json.loads(tr['hints_json'])
+                    except Exception:
+                        pass
 
-            if not hints and not exam_tips:
-                print(fmt.dim("(No hints saved for this session — re-run a new exam to get hints)"))
-                print()
+                exam_tips = []
+                if tr.get('exam_tips_json'):
+                    try:
+                        exam_tips = json.loads(tr['exam_tips_json'])
+                    except Exception:
+                        pass
+
+                if hints:
+                    print(fmt.bold("What to study / how to fix it:"))
+                    for h in hints:
+                        print(f"  • {h}")
+                    print()
+
+                if exam_tips:
+                    print(fmt.bold("Exam tips:"))
+                    for t in exam_tips:
+                        print(f"  * {t}")
+                    print()
+
+                if not hints and not exam_tips:
+                    print(fmt.dim("(No hints saved for this session — re-run a new exam to get hints)"))
+                    print()
+
+        fmt.page_output(buf.getvalue())
 
         # Offer the dispute path when there are checks to dispute.
         if checks:


### PR DESCRIPTION
## What

Adds a feedback path so that, when reviewing results, a candidate who believes the **checker is wrong** can dispute it with evidence — and an AI reviews it and pushes a fix PR if they're right.

From the result detail screen (`Result History → a task`), a new **`d` to dispute** option:
1. Captures the candidate's written argument + **relevant live system state** (category-specific read-only commands, plus any commands they add).
2. Bundles task + disputed check(s) + argument + evidence into a Markdown report.
3. Opens a labelled **`checker-dispute`** GitHub issue via `gh` (saves a local copy; degrades gracefully if `gh` is absent).

The UI is **explicit** before anything is sent: it states a public GitHub issue will be opened, an AI will review the evidence, and a fix PR will be opened automatically if the checker is wrong.

## Companion workflow (must be added separately)

`.github/workflows/checker-dispute.yml` couldn't be pushed by this token (needs the `workflow` OAuth scope). On the `checker-dispute` label it runs `anthropics/claude-code-action` to inspect the validator, comment a verdict, and open a fix PR only if the checker is genuinely wrong. Auth via `CLAUDE_CODE_OAUTH_TOKEN` (Claude subscription — no per-token billing) or `ANTHROPIC_API_KEY`. The file content is in the PR discussion / provided to the maintainer to add via the web UI.

## Tests

`152 passed`. Dispute report builds correctly; `gh` path verified available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8UPKdjDoBoVJCfwzSec5a