### PR TITLE
Land NFS server setup on master (fix mis-stacked PR #15)

### DIFF
--- a/core/menu.py
+++ b/core/menu.py
@@ -208,12 +208,18 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
         fmt.clear_screen()
         fmt.print_header("SETUP")
 
+        from core import nfs_server
+        cfg = nfs_server.load_config()
+        nfs_status = (fmt.success(f"configured: {cfg['host']}") if cfg
+                      else fmt.dim("not configured"))
+
         print(fmt.bold("Options"))
         print("  1. Setup Practice Disks (loop devices for LVM)")
         print("  2. View Task Statistics")
         print("  3. Network Backup/Restore")
         print("  4. System Reset (remove practice artifacts)")
         print("  5. Populate Practice Environment (DNF history)")
+        print(f"  6. Configure remote NFS server for NFS tasks ({nfs_status})")
         print("  0. Return to Menu")
         print()
 
@@ -229,6 +235,99 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             self.system_reset()
         elif choice == '5':
             self.populate_practice_environment()
+        elif choice == '6':
+            self.configure_nfs_server()
+
+    def configure_nfs_server(self):
+        """SSH into a user-named RHEL box and provision it as a real NFS server
+        for the NFS practice tasks (or remove an existing configuration)."""
+        from core import nfs_server
+        from utils.helpers import confirm_action
+
+        fmt.clear_screen()
+        fmt.print_header("CONFIGURE REMOTE NFS SERVER")
+
+        existing = nfs_server.load_config()
+        if existing:
+            print(f"Currently configured: {fmt.bold(existing['host'])} "
+                  f"(user: {existing.get('user', 'root')})")
+            print("Exports:")
+            for e in existing.get('exports', []):
+                print(f"  - {e}")
+            print()
+            print("  R. Re-provision / change server")
+            print("  X. Remove this NFS configuration (local only)")
+            print("  0. Back")
+            print()
+            sub = input("Select: ").strip().lower()
+            if sub == 'x':
+                nfs_server.clear_config()
+                print(fmt.success("NFS server configuration removed. NFS tasks revert "
+                                   "to placeholder servers."))
+                input("\nPress Enter to return...")
+                return
+            if sub not in ('r',):
+                return
+            fmt.clear_screen()
+            fmt.print_header("CONFIGURE REMOTE NFS SERVER")
+
+        print("This will SSH into a RHEL machine you specify and set it up as an")
+        print("NFS server: install nfs-utils, create and populate exports under")
+        print(f"{fmt.bold(nfs_server.EXPORT_BASE)}, write /etc/exports.d, run exportfs,")
+        print("enable nfs-server, and open the firewall.")
+        print()
+        print(fmt.warning("This MODIFIES the remote machine. Use a practice box you control."))
+        print(fmt.dim("ssh will prompt for a password or key passphrase if needed; nothing is stored."))
+        print()
+
+        host = input("NFS server hostname or IP: ").strip()
+        if not host:
+            print(fmt.dim("Cancelled."))
+            input("\nPress Enter to return...")
+            return
+        user = input("SSH login user [root]: ").strip() or 'root'
+
+        if confirm_action(f"Set up passwordless SSH to {user}@{host} first (ssh-copy-id)?",
+                          default=False):
+            nfs_server.copy_ssh_key(host, user)
+
+        print()
+        if not confirm_action(f"Provision {user}@{host} as an NFS server now?", default=True):
+            print(fmt.dim("Cancelled."))
+            input("\nPress Enter to return...")
+            return
+
+        print()
+        print(f"Connecting to {user}@{host}… (enter password/passphrase if prompted)")
+        ok, exports, output = nfs_server.provision(host, user)
+
+        print()
+        if not ok:
+            print(fmt.error("Provisioning failed. Output:"))
+            print(output[-2000:] if output else "(no output)")
+            input("\nPress Enter to return...")
+            return
+
+        print(fmt.success("NFS server provisioned. Exports created:"))
+        for e in exports:
+            print(f"  - {host}:{e}")
+
+        # Confirm the exports are visible from this client.
+        print()
+        print("Verifying from this machine (showmount -e)…")
+        vok, vout = nfs_server.verify_from_client(host)
+        if vok:
+            print(fmt.success("showmount sees the exports:"))
+            print(fmt.dim(vout))
+        else:
+            print(fmt.warning(f"Could not confirm via showmount: {vout}"))
+            print(fmt.dim("(The server may still be fine — check the firewall on the server.)"))
+
+        nfs_server.save_config(host, user, exports)
+        print()
+        print(fmt.success("Saved. NFS practice tasks will now use this server and its exports."))
+        print(fmt.info(f"Try it: showmount -e {host}  then  mount -t nfs {host}:{exports[0]} /mnt/test"))
+        input("\nPress Enter to return...")
 
     def show_stats(self):
         """Show task statistics."""

--- a/core/nfs_server.py
+++ b/core/nfs_server.py
@@ -1,0 +1,197 @@
+"""
+Remote NFS server provisioning for NFS practice tasks.
+
+The NFS tasks (tasks/network_storage.py) need a *real* NFS server to mount
+from, otherwise the candidate can't actually complete or test them. This module
+lets Setup SSH into a RHEL box the user names, provision it as an NFS server
+(install nfs-utils, create + populate exports, write /etc/exports.d, run
+exportfs, enable nfs-server, open the firewall), and record it so the NFS tasks
+point at the real server and exports.
+
+Auth is delegated to the system `ssh` (it prompts for a password or key
+passphrase on the terminal as needed); no credentials are stored. Only the
+server host, login user and export paths are saved.
+"""
+
+import os
+import json
+import subprocess
+
+STATE_DIR = '/var/lib/rhcsa-simulator'
+CONFIG_PATH = os.path.join(STATE_DIR, 'nfs_server.conf')
+
+EXPORT_BASE = '/exports/rhcsa'
+# (relative-name, export-options) — populated read/write so candidates can test.
+_EXPORTS = [
+    ('data', 'rw,sync,no_root_squash'),
+    ('shared', 'rw,sync,no_root_squash'),
+    ('public', 'ro,sync'),
+]
+
+# Sentinels the remote script prints so we can confirm success / read exports.
+_DONE = 'RHCSA_NFS_DONE'
+_EXPORTS_LINE = 'RHCSA_NFS_EXPORTS='
+
+
+def _remote_script():
+    """Idempotent bash provisioning script run on the remote server."""
+    exports_paths = [f'{EXPORT_BASE}/{name}' for name, _ in _EXPORTS]
+    mkdirs = ' '.join(exports_paths)
+    export_lines = "\n".join(
+        f'{EXPORT_BASE}/{name} *({opts})' for name, opts in _EXPORTS
+    )
+    # Seed each export with recognisable, relevant content so that cd-ing into a
+    # successful mount obviously shows real files. Every export carries a
+    # MANIFEST stamped with the server hostname + time so it's unmistakable.
+    seed = f"""
+stamp="provisioned by rhcsa-simulator on $(hostname -f 2>/dev/null || hostname) at $(date)"
+
+# data/ — looks like an application data share
+mkdir -p {EXPORT_BASE}/data/archive
+printf 'date,region,units,revenue\\n2026-01-15,EMEA,120,30450\\n2026-02-03,AMER,98,24010\\n2026-03-20,APAC,142,35980\\n' > {EXPORT_BASE}/data/sales-2026-q1.csv
+printf 'widget-a 412\\nwidget-b 87\\nwidget-c 0\\n' > {EXPORT_BASE}/data/inventory.txt
+printf 'old rotated log line 1\\nold rotated log line 2\\n' > {EXPORT_BASE}/data/archive/2025.log
+printf 'NFS export: data (read-write)\\n%s\\n' "$stamp" > {EXPORT_BASE}/data/MANIFEST.txt
+
+# shared/ — looks like a team collaboration share
+mkdir -p {EXPORT_BASE}/shared/projects
+printf '# Team Roster\\nalice - lead\\nbob - sysadmin\\ncarol - dba\\n' > {EXPORT_BASE}/shared/team-roster.md
+printf 'Standup notes 2026-06-30: NFS migration on track.\\n' > {EXPORT_BASE}/shared/meeting-notes.txt
+printf 'project alpha: active\\nproject beta: planning\\n' > {EXPORT_BASE}/shared/projects/status.txt
+printf 'NFS export: shared (read-write)\\n%s\\n' "$stamp" > {EXPORT_BASE}/shared/MANIFEST.txt
+
+# public/ — read-only share
+printf 'Welcome to the RHCSA practice NFS server.\\nThis share is read-only.\\n' > {EXPORT_BASE}/public/announcement.txt
+printf 'rhcsa-simulator NFS v1\\n' > {EXPORT_BASE}/public/VERSION
+printf 'NFS export: public (read-only)\\n%s\\n' "$stamp" > {EXPORT_BASE}/public/MANIFEST.txt
+"""
+    return f"""set -e
+echo '== rhcsa-simulator: provisioning NFS server =='
+dnf -y install nfs-utils >/dev/null 2>&1 || dnf -y install nfs-utils
+mkdir -p {mkdirs}
+{seed}
+chmod -R 0777 {EXPORT_BASE}/data {EXPORT_BASE}/shared 2>/dev/null || true
+# Write our exports to a dedicated drop-in so we never clobber existing ones.
+mkdir -p /etc/exports.d
+cat > /etc/exports.d/rhcsa.exports <<'EOF'
+{export_lines}
+EOF
+# Restore SELinux contexts for the export tree (public_content_t-friendly).
+command -v restorecon >/dev/null 2>&1 && restorecon -R {EXPORT_BASE} 2>/dev/null || true
+systemctl enable --now nfs-server
+exportfs -ra
+# Open the firewall if firewalld is running (ignore if it isn't).
+if systemctl is-active --quiet firewalld; then
+  firewall-cmd --permanent --add-service=nfs >/dev/null 2>&1 || true
+  firewall-cmd --permanent --add-service=mountd >/dev/null 2>&1 || true
+  firewall-cmd --permanent --add-service=rpc-bind >/dev/null 2>&1 || true
+  firewall-cmd --reload >/dev/null 2>&1 || true
+fi
+echo '== current exports =='
+exportfs -v || true
+echo '{_EXPORTS_LINE}'{','.join(exports_paths)!r}
+echo '{_DONE}'
+"""
+
+
+# --------------------------------------------------------------------------
+# Config persistence
+# --------------------------------------------------------------------------
+
+def load_config():
+    """Return the saved NFS server config dict, or None."""
+    try:
+        with open(CONFIG_PATH) as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def save_config(host, user, exports):
+    os.makedirs(STATE_DIR, exist_ok=True)
+    cfg = {'host': host, 'user': user, 'exports': exports}
+    with open(CONFIG_PATH, 'w') as fh:
+        json.dump(cfg, fh, indent=2)
+    return cfg
+
+
+def clear_config():
+    try:
+        os.remove(CONFIG_PATH)
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def get_server():
+    """Configured server host, or None."""
+    cfg = load_config()
+    return cfg.get('host') if cfg else None
+
+
+def pick_export(cfg=None, index=0):
+    """Return (export_path) from the configured exports by index (stable)."""
+    cfg = cfg or load_config()
+    if not cfg or not cfg.get('exports'):
+        return None
+    exports = cfg['exports']
+    return exports[index % len(exports)]
+
+
+# --------------------------------------------------------------------------
+# SSH provisioning
+# --------------------------------------------------------------------------
+
+def copy_ssh_key(host, user):
+    """Best-effort ssh-copy-id so subsequent runs are passwordless. Interactive."""
+    try:
+        return subprocess.run(['ssh-copy-id', f'{user}@{host}']).returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def provision(host, user='root'):
+    """Run the provisioning script on the remote over interactive ssh.
+
+    Returns (ok, exports, output). ssh prompts for password/passphrase on the
+    terminal as needed; the script is fed on stdin (ssh reads auth from the tty,
+    not stdin, so this is safe).
+    """
+    script = _remote_script()
+    # BatchMode is NOT set, so ssh can prompt. StrictHostKeyChecking=accept-new
+    # avoids a separate interactive yes/no for first-time hosts.
+    cmd = ['ssh', '-o', 'StrictHostKeyChecking=accept-new',
+           f'{user}@{host}', 'bash -s']
+    try:
+        res = subprocess.run(cmd, input=script, text=True,
+                             capture_output=True, timeout=600)
+    except subprocess.TimeoutExpired:
+        return False, [], 'Timed out talking to the server (10 min).'
+    except FileNotFoundError:
+        return False, [], "'ssh' not found on this machine."
+
+    output = (res.stdout or '') + (res.stderr or '')
+    if res.returncode != 0 or _DONE not in (res.stdout or ''):
+        return False, [], output
+
+    exports = []
+    for line in res.stdout.splitlines():
+        if line.startswith(_EXPORTS_LINE):
+            raw = line[len(_EXPORTS_LINE):].strip().strip("'\"")
+            exports = [p for p in raw.split(',') if p]
+            break
+    if not exports:
+        exports = [f'{EXPORT_BASE}/{name}' for name, _ in _EXPORTS]
+    return True, exports, output
+
+
+def verify_from_client(host):
+    """Run showmount -e against the server from this machine. (ok, output)."""
+    try:
+        res = subprocess.run(['showmount', '-e', host],
+                             capture_output=True, text=True, timeout=30)
+        return res.returncode == 0, (res.stdout or res.stderr).strip()
+    except FileNotFoundError:
+        return False, "'showmount' not installed (dnf install nfs-utils)."
+    except subprocess.TimeoutExpired:
+        return False, 'showmount timed out (firewall? nfs-server not running?).'

--- a/tasks/network_storage.py
+++ b/tasks/network_storage.py
@@ -14,6 +14,25 @@ from validators.file_validators import validate_file_exists, validate_file_conta
 logger = logging.getLogger(__name__)
 
 
+def _nfs_config():
+    """Return the configured remote NFS server dict, or None."""
+    try:
+        from core import nfs_server
+        return nfs_server.load_config()
+    except Exception:
+        return None
+
+
+def _nfs_source(mount_point):
+    """(source, fstype) for an exact mountpoint via findmnt, else (None, None)."""
+    res = execute_safe(['findmnt', '-n', '-o', 'SOURCE,FSTYPE', mount_point])
+    if res.success and res.stdout.strip():
+        parts = res.stdout.split()
+        if len(parts) >= 2:
+            return parts[0], parts[1]
+    return None, None
+
+
 @TaskRegistry.register("network_storage")
 class MountNFSShareTask(BaseTask):
     """Mount an NFS share manually."""
@@ -37,9 +56,15 @@ class MountNFSShareTask(BaseTask):
         self.mount_point = None
 
     def generate(self, **params):
-        """Generate NFS mount task."""
-        self.nfs_server = params.get('server', 'server1.example.com')
-        self.nfs_export = params.get('export', '/share/data')
+        """Generate NFS mount task. Uses the real configured NFS server/export
+        when Setup has provisioned one, otherwise a placeholder."""
+        cfg = _nfs_config()
+        if cfg and cfg.get('exports'):
+            self.nfs_server = params.get('server', cfg['host'])
+            self.nfs_export = params.get('export', cfg['exports'][0])
+        else:
+            self.nfs_server = params.get('server', 'server1.example.com')
+            self.nfs_export = params.get('export', '/share/data')
         self.mount_point = params.get('mount_point', '/mnt/nfsdata')
 
         self.description = (
@@ -87,35 +112,40 @@ class MountNFSShareTask(BaseTask):
             ))
             return ValidationResult(self.id, False, total_points, self.points, checks)
 
-        # Check 2: NFS is mounted (7 points)
-        result = execute_safe(['mount'])
-        if result.success and self.mount_point in result.stdout and 'nfs' in result.stdout:
+        # Check 2: NFS is mounted (7 points). With a real configured server we
+        # verify the mount actually originates from server:export; otherwise we
+        # fall back to a looser "an NFS filesystem is mounted here" check.
+        source, fstype = _nfs_source(self.mount_point)
+        is_nfs = bool(fstype) and fstype.startswith('nfs')
+        expected = f"{self.nfs_server}:{self.nfs_export}"
+
+        if is_nfs and source and source.endswith(f":{self.nfs_export}"):
             checks.append(ValidationCheck(
                 name="nfs_mounted",
                 passed=True,
                 points=7,
-                message=f"NFS share is mounted at {self.mount_point}"
+                message=f"{source} ({fstype}) is mounted at {self.mount_point}"
             ))
             total_points += 7
+        elif is_nfs:
+            checks.append(ValidationCheck(
+                name="nfs_mounted",
+                passed=False,
+                points=4,
+                max_points=7,
+                message=f"An NFS mount is present but its source ({source}) is not "
+                        f"the expected {expected}"
+            ))
+            total_points += 4
         else:
-            # Check /proc/mounts as backup
-            result2 = execute_safe(['cat', '/proc/mounts'])
-            if result2.success and self.mount_point in result2.stdout:
-                checks.append(ValidationCheck(
-                    name="nfs_mounted",
-                    passed=True,
-                    points=5,
-                    message="Something is mounted (may not be NFS)"
-                ))
-                total_points += 5
-            else:
-                checks.append(ValidationCheck(
-                    name="nfs_mounted",
-                    passed=False,
-                    points=0,
-                    max_points=7,
-                    message=f"NFS share is not mounted at {self.mount_point}"
-                ))
+            checks.append(ValidationCheck(
+                name="nfs_mounted",
+                passed=False,
+                points=0,
+                max_points=7,
+                message=f"No NFS filesystem is mounted at {self.mount_point} "
+                        f"(expected {expected})"
+            ))
 
         passed = total_points >= (self.points * 0.7)
         return ValidationResult(self.id, passed, total_points, self.points, checks)
@@ -146,9 +176,18 @@ class PersistentNFSMountTask(BaseTask):
         self.mount_point = None
 
     def generate(self, **params):
-        """Generate persistent NFS mount task."""
-        self.nfs_server = params.get('server', 'nfsserver.example.com')
-        self.nfs_export = params.get('export', '/exports/shared')
+        """Generate persistent NFS mount task (uses the real configured server
+        and export when available)."""
+        cfg = _nfs_config()
+        if cfg and cfg.get('exports'):
+            self.nfs_server = params.get('server', cfg['host'])
+            # Prefer the second export ('shared') so it differs from the basic
+            # mount task; fall back to the first.
+            default_export = cfg['exports'][1] if len(cfg['exports']) > 1 else cfg['exports'][0]
+            self.nfs_export = params.get('export', default_export)
+        else:
+            self.nfs_server = params.get('server', 'nfsserver.example.com')
+            self.nfs_export = params.get('export', '/exports/shared')
         self.mount_point = params.get('mount_point', '/mnt/shared')
 
         self.description = (
@@ -238,16 +277,27 @@ class PersistentNFSMountTask(BaseTask):
                 message="No fstab entry for this mount"
             ))
 
-        # Check 3: Actually mounted (4 points)
-        result = execute_safe(['mount'])
-        if result.success and self.mount_point in result.stdout:
+        # Check 3: Actually mounted (4 points) — verify it's really NFS from the
+        # expected export when we can, else accept any mount at the point.
+        source, fstype = _nfs_source(self.mount_point)
+        if source and fstype and fstype.startswith('nfs') and source.endswith(f":{self.nfs_export}"):
             checks.append(ValidationCheck(
                 name="is_mounted",
                 passed=True,
                 points=4,
-                message="Mount is active"
+                message=f"Mount is active: {source} ({fstype})"
             ))
             total_points += 4
+        elif source:
+            checks.append(ValidationCheck(
+                name="is_mounted",
+                passed=True,
+                points=2,
+                max_points=4,
+                message=f"Mounted ({source}) but not the expected "
+                        f"{self.nfs_server}:{self.nfs_export}"
+            ))
+            total_points += 2
         else:
             checks.append(ValidationCheck(
                 name="is_mounted",
@@ -290,8 +340,13 @@ class ConfigureAutofsTask(BaseTask):
 
     def generate(self, **params):
         """Generate autofs configuration task."""
-        self.nfs_server = params.get('server', 'nfs.example.com')
-        self.nfs_export = params.get('export', '/export/data')
+        cfg = _nfs_config()
+        if cfg and cfg.get('exports'):
+            self.nfs_server = params.get('server', cfg['host'])
+            self.nfs_export = params.get('export', cfg['exports'][0])
+        else:
+            self.nfs_server = params.get('server', 'nfs.example.com')
+            self.nfs_export = params.get('export', '/export/data')
         self.autofs_mount = params.get('mount', '/data')
         self.map_name = params.get('map', 'auto.data')
 
@@ -445,8 +500,13 @@ class AutofsHomeDirectoriesTask(BaseTask):
 
     def generate(self, **params):
         """Generate autofs home directories task."""
-        self.nfs_server = params.get('server', 'ldap.example.com')
-        self.home_export = params.get('export', '/home/guests')
+        cfg = _nfs_config()
+        if cfg and cfg.get('exports'):
+            self.nfs_server = params.get('server', cfg['host'])
+            self.home_export = params.get('export', cfg['exports'][0])
+        else:
+            self.nfs_server = params.get('server', 'ldap.example.com')
+            self.home_export = params.get('export', '/home/guests')
 
         self.description = (
             f"Configure autofs for user home directories:\n"


### PR DESCRIPTION
PR #15 was based on the `feature/checker-disputes-20260630` branch, so when it merged it went **into that branch, not master** — the NFS feature never reached master (that's why there was no NFS option after pulling).

This re-lands the NFS feature on top of current master, **keeping** the `checker-dispute.yml` workflow that landed on master afterwards (a direct merge of the old NFS branch would have deleted it).

Adds:
- `Setup → 6. Configure remote NFS server`
- `core/nfs_server.py` (SSH provisioning + seeded exports)
- real-server wiring + `findmnt` mount verification in `tasks/network_storage.py`

`152 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8UPKdjDoBoVJCfwzSec5a