### PR TITLE
Harden NFS provisioning: error-correction, saved creds, per-exam refresh

### DIFF
--- a/core/exam.py
+++ b/core/exam.py
@@ -97,6 +97,9 @@ class ExamSession:
         # can't pass on pre-existing/default state.
         self._setup_task_environments()
 
+        # Refresh the remote NFS server's exports so this exam starts clean.
+        self._reprovision_nfs()
+
         self._display_tasks()
 
         # Start timer
@@ -171,8 +174,56 @@ class ExamSession:
             except Exception as e:
                 print(fmt.warning(f"  ✗ {task.id}: setup error ({e})"))
 
+    def _has_nfs_tasks(self):
+        return any(getattr(t, 'category', '') == 'network_storage' for t in self.tasks)
+
+    def _reprovision_nfs(self):
+        """If a remote NFS server is configured and this exam has NFS tasks,
+        refresh its exports so the run starts from clean, seeded shares."""
+        if not self._has_nfs_tasks():
+            return
+        try:
+            from core import nfs_server
+        except Exception:
+            return
+        if not nfs_server.load_config():
+            return
+        print(fmt.bold("\nRefreshing NFS server exports..."))
+        try:
+            ok, exports, output = nfs_server.reprovision_from_config()
+        except Exception as e:
+            print(fmt.warning(f"  ✗ NFS re-provision error ({e})"))
+            return
+        if ok:
+            print(fmt.success(f"  ✓ NFS exports refreshed ({len(exports)} shares)"))
+        else:
+            print(fmt.warning("  ✗ Could not refresh NFS exports (NFS tasks may not be testable):"))
+            tail = (output or '').strip().splitlines()[-2:]
+            for line in tail:
+                print(fmt.dim(f"      {line}"))
+            print(fmt.dim("      Fix via Setup → Configure remote NFS server → Test connection."))
+
+    def _teardown_nfs(self):
+        """Tear our exports off the remote NFS server after the exam."""
+        if not self._has_nfs_tasks():
+            return
+        try:
+            from core import nfs_server
+        except Exception:
+            return
+        if not nfs_server.load_config():
+            return
+        try:
+            ok, _ = nfs_server.remove_exports()
+            if ok:
+                print(fmt.dim("  NFS exports removed from server."))
+        except Exception:
+            pass
+
     def _restore_exam_faults(self):
         """Restore any environments that were set up for the exam."""
+        # NFS teardown runs independently of local fault/setup state.
+        self._teardown_nfs()
         if not self._injected_tasks and not self._setup_tasks:
             return
         print(fmt.dim("\nCleaning up exam environment..."))

--- a/core/menu.py
+++ b/core/menu.py
@@ -241,6 +241,7 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
     def configure_nfs_server(self):
         """SSH into a user-named RHEL box and provision it as a real NFS server
         for the NFS practice tasks (or remove an existing configuration)."""
+        import getpass
         from core import nfs_server
         from utils.helpers import confirm_action
 
@@ -249,21 +250,40 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
 
         existing = nfs_server.load_config()
         if existing:
+            saved_pw = 'yes' if existing.get('password') else 'no (key-based)'
             print(f"Currently configured: {fmt.bold(existing['host'])} "
-                  f"(user: {existing.get('user', 'root')})")
+                  f"(user: {existing.get('user', 'root')}, saved password: {saved_pw})")
             print("Exports:")
             for e in existing.get('exports', []):
                 print(f"  - {e}")
             print()
             print("  R. Re-provision / change server")
-            print("  X. Remove this NFS configuration (local only)")
+            print("  T. Test connection now (re-provision + showmount)")
+            print("  X. Remove config (and tear exports off the server)")
             print("  0. Back")
             print()
             sub = input("Select: ").strip().lower()
             if sub == 'x':
+                print("Removing exports from the server…")
+                rok, rout = nfs_server.remove_exports()
+                print(fmt.success("Exports removed from server.") if rok
+                      else fmt.warning(f"Could not remove remote exports (removing local config anyway): {rout[-300:]}"))
                 nfs_server.clear_config()
-                print(fmt.success("NFS server configuration removed. NFS tasks revert "
-                                   "to placeholder servers."))
+                print(fmt.success("NFS configuration removed. NFS tasks revert to placeholders."))
+                input("\nPress Enter to return...")
+                return
+            if sub == 't':
+                print("\nRe-provisioning with saved settings…")
+                ok, exports, output = nfs_server.reprovision_from_config()
+                if ok:
+                    print(fmt.success("OK — exports active:"))
+                    for e in exports:
+                        print(f"  - {existing['host']}:{e}")
+                    vok, vout = nfs_server.verify_from_client(existing['host'])
+                    print(fmt.dim(vout) if vok else fmt.warning(vout))
+                else:
+                    print(fmt.error("Failed:"))
+                    print((output or '')[-1500:])
                 input("\nPress Enter to return...")
                 return
             if sub not in ('r',):
@@ -274,10 +294,10 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
         print("This will SSH into a RHEL machine you specify and set it up as an")
         print("NFS server: install nfs-utils, create and populate exports under")
         print(f"{fmt.bold(nfs_server.EXPORT_BASE)}, write /etc/exports.d, run exportfs,")
-        print("enable nfs-server, and open the firewall.")
+        print("enable nfs-server, and open the firewall. Exports are refreshed at the")
+        print("start of every exam and torn down afterwards, so each run is clean.")
         print()
         print(fmt.warning("This MODIFIES the remote machine. Use a practice box you control."))
-        print(fmt.dim("ssh will prompt for a password or key passphrase if needed; nothing is stored."))
         print()
 
         host = input("NFS server hostname or IP: ").strip()
@@ -287,9 +307,25 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             return
         user = input("SSH login user [root]: ").strip() or 'root'
 
-        if confirm_action(f"Set up passwordless SSH to {user}@{host} first (ssh-copy-id)?",
-                          default=False):
-            nfs_server.copy_ssh_key(host, user)
+        # Credentials — needed so exams can re-provision unattended.
+        password = None
+        print()
+        print(fmt.bold("Authentication"))
+        print("  k. Key-based (run ssh-copy-id now; nothing stored)  [recommended]")
+        print("  p. Save a password for unattended re-provisioning")
+        auth = input("Choose [k]: ").strip().lower() or 'k'
+        if auth == 'p':
+            if not nfs_server.sshpass_available():
+                print(fmt.warning("sshpass is not installed on this machine; saved-password"))
+                print(fmt.warning("auth needs it. Install with: dnf install sshpass"))
+                if not confirm_action("Continue and save the password anyway?", default=False):
+                    print(fmt.dim("Cancelled.")); input("\nPress Enter to return..."); return
+            password = getpass.getpass(f"Password for {user}@{host}: ") or None
+            if password:
+                print(fmt.dim("Stored locally in /var/lib/rhcsa-simulator/nfs_server.conf (root-only, 0600)."))
+        else:
+            if confirm_action(f"Run ssh-copy-id to {user}@{host} now?", default=True):
+                nfs_server.copy_ssh_key(host, user)
 
         print()
         if not confirm_action(f"Provision {user}@{host} as an NFS server now?", default=True):
@@ -299,16 +335,19 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
 
         print()
         print(f"Connecting to {user}@{host}… (enter password/passphrase if prompted)")
-        ok, exports, output = nfs_server.provision(host, user)
+        ok, exports, output = nfs_server.provision(host, user, password=password)
 
         print()
         if not ok:
-            print(fmt.error("Provisioning failed. Output:"))
-            print(output[-2000:] if output else "(no output)")
+            print(fmt.error("Provisioning failed:"))
+            print((output or "(no output)")[-2000:])
+            print()
+            print(fmt.dim("Common causes: SSH/root login refused, server has no repo "
+                          "access for nfs-utils, or firewall blocking. Fix and retry."))
             input("\nPress Enter to return...")
             return
 
-        print(fmt.success("NFS server provisioned. Exports created:"))
+        print(fmt.success("NFS server provisioned. Exports active:"))
         for e in exports:
             print(f"  - {host}:{e}")
 
@@ -323,9 +362,9 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             print(fmt.warning(f"Could not confirm via showmount: {vout}"))
             print(fmt.dim("(The server may still be fine — check the firewall on the server.)"))
 
-        nfs_server.save_config(host, user, exports)
+        nfs_server.save_config(host, user, exports, password=password)
         print()
-        print(fmt.success("Saved. NFS practice tasks will now use this server and its exports."))
+        print(fmt.success("Saved. NFS tasks will use this server; exports auto-refresh each exam."))
         print(fmt.info(f"Try it: showmount -e {host}  then  mount -t nfs {host}:{exports[0]} /mnt/test"))
         input("\nPress Enter to return...")
 

--- a/core/nfs_server.py
+++ b/core/nfs_server.py
@@ -3,18 +3,25 @@ Remote NFS server provisioning for NFS practice tasks.
 
 The NFS tasks (tasks/network_storage.py) need a *real* NFS server to mount
 from, otherwise the candidate can't actually complete or test them. This module
-lets Setup SSH into a RHEL box the user names, provision it as an NFS server
+lets Setup SSH into a RHEL box the user names and provision it as an NFS server
 (install nfs-utils, create + populate exports, write /etc/exports.d, run
-exportfs, enable nfs-server, open the firewall), and record it so the NFS tasks
-point at the real server and exports.
+exportfs, enable nfs-server, open the firewall), record it, and re-provision /
+tear the exports down around each exam so every run starts clean.
 
-Auth is delegated to the system `ssh` (it prompts for a password or key
-passphrase on the terminal as needed); no credentials are stored. Only the
-server host, login user and export paths are saved.
+Design notes:
+  * The remote scripts are defensive — they do NOT `set -e` and die on the
+    first hiccup. They auto-create missing directories for *pre-existing* stale
+    exports (so a leftover entry like `/nfsdata3` can't abort our run), tolerate
+    unrelated exportfs warnings, and only report success once OUR exports are
+    actually active. Failures come back as a single RHCSA_NFS_FAIL: <reason>.
+  * Auth is delegated to the system `ssh`. Credentials may optionally be saved
+    (root-only 0600 config) so exams can re-provision unattended; otherwise we
+    rely on key-based auth.
 """
 
 import os
 import json
+import shutil
 import subprocess
 
 STATE_DIR = '/var/lib/rhcsa-simulator'
@@ -28,78 +35,123 @@ _EXPORTS = [
     ('public', 'ro,sync'),
 ]
 
-# Sentinels the remote script prints so we can confirm success / read exports.
 _DONE = 'RHCSA_NFS_DONE'
+_FAIL = 'RHCSA_NFS_FAIL:'
 _EXPORTS_LINE = 'RHCSA_NFS_EXPORTS='
 
 
-def _remote_script():
-    """Idempotent bash provisioning script run on the remote server."""
-    exports_paths = [f'{EXPORT_BASE}/{name}' for name, _ in _EXPORTS]
-    mkdirs = ' '.join(exports_paths)
-    export_lines = "\n".join(
-        f'{EXPORT_BASE}/{name} *({opts})' for name, opts in _EXPORTS
-    )
-    # Seed each export with recognisable, relevant content so that cd-ing into a
-    # successful mount obviously shows real files. Every export carries a
-    # MANIFEST stamped with the server hostname + time so it's unmistakable.
-    seed = f"""
+# --------------------------------------------------------------------------
+# Remote scripts
+# --------------------------------------------------------------------------
+
+def _seed_block():
+    """Bash that (re)creates recognisable, relevant content in each export."""
+    return f"""
 stamp="provisioned by rhcsa-simulator on $(hostname -f 2>/dev/null || hostname) at $(date)"
 
-# data/ — looks like an application data share
-mkdir -p {EXPORT_BASE}/data/archive
+rm -rf {EXPORT_BASE}/data {EXPORT_BASE}/shared {EXPORT_BASE}/public
+mkdir -p {EXPORT_BASE}/data/archive {EXPORT_BASE}/shared/projects {EXPORT_BASE}/public
+
 printf 'date,region,units,revenue\\n2026-01-15,EMEA,120,30450\\n2026-02-03,AMER,98,24010\\n2026-03-20,APAC,142,35980\\n' > {EXPORT_BASE}/data/sales-2026-q1.csv
 printf 'widget-a 412\\nwidget-b 87\\nwidget-c 0\\n' > {EXPORT_BASE}/data/inventory.txt
 printf 'old rotated log line 1\\nold rotated log line 2\\n' > {EXPORT_BASE}/data/archive/2025.log
 printf 'NFS export: data (read-write)\\n%s\\n' "$stamp" > {EXPORT_BASE}/data/MANIFEST.txt
 
-# shared/ — looks like a team collaboration share
-mkdir -p {EXPORT_BASE}/shared/projects
 printf '# Team Roster\\nalice - lead\\nbob - sysadmin\\ncarol - dba\\n' > {EXPORT_BASE}/shared/team-roster.md
-printf 'Standup notes 2026-06-30: NFS migration on track.\\n' > {EXPORT_BASE}/shared/meeting-notes.txt
+printf 'Standup notes: NFS migration on track.\\n' > {EXPORT_BASE}/shared/meeting-notes.txt
 printf 'project alpha: active\\nproject beta: planning\\n' > {EXPORT_BASE}/shared/projects/status.txt
 printf 'NFS export: shared (read-write)\\n%s\\n' "$stamp" > {EXPORT_BASE}/shared/MANIFEST.txt
 
-# public/ — read-only share
 printf 'Welcome to the RHCSA practice NFS server.\\nThis share is read-only.\\n' > {EXPORT_BASE}/public/announcement.txt
 printf 'rhcsa-simulator NFS v1\\n' > {EXPORT_BASE}/public/VERSION
 printf 'NFS export: public (read-only)\\n%s\\n' "$stamp" > {EXPORT_BASE}/public/MANIFEST.txt
-"""
-    return f"""set -e
-echo '== rhcsa-simulator: provisioning NFS server =='
-dnf -y install nfs-utils >/dev/null 2>&1 || dnf -y install nfs-utils
-mkdir -p {mkdirs}
-{seed}
+
 chmod -R 0777 {EXPORT_BASE}/data {EXPORT_BASE}/shared 2>/dev/null || true
-# Write our exports to a dedicated drop-in so we never clobber existing ones.
-mkdir -p /etc/exports.d
+chmod -R 0555 {EXPORT_BASE}/public 2>/dev/null || true
+command -v restorecon >/dev/null 2>&1 && restorecon -R {EXPORT_BASE} 2>/dev/null || true
+"""
+
+
+def _provision_script():
+    """Idempotent, self-correcting provisioning script (no `set -e`)."""
+    exports_paths = [f'{EXPORT_BASE}/{name}' for name, _ in _EXPORTS]
+    export_lines = "\n".join(f'{EXPORT_BASE}/{name} *({opts})' for name, opts in _EXPORTS)
+    verify = "\n".join(
+        f'exportfs -v | awk \'{{print $1}}\' | grep -qx {p} || missing="$missing {p}"'
+        for p in exports_paths
+    )
+    return f"""
+fail() {{ echo "{_FAIL} $*"; exit 1; }}
+echo '== rhcsa-simulator: provisioning NFS server =='
+
+# 1. nfs-utils
+if ! rpm -q nfs-utils >/dev/null 2>&1; then
+  echo '  installing nfs-utils...'
+  dnf -y install nfs-utils >/dev/null 2>&1 || dnf -y install nfs-utils || \
+    fail "could not install nfs-utils (check the server's repos/network)"
+fi
+
+# 2. our exports (content reseeded fresh)
+{_seed_block()}
+
+# 3. our exports drop-in (never touches an existing /etc/exports)
+mkdir -p /etc/exports.d || fail "could not write /etc/exports.d"
 cat > /etc/exports.d/rhcsa.exports <<'EOF'
 {export_lines}
 EOF
-# Restore SELinux contexts for the export tree (public_content_t-friendly).
-command -v restorecon >/dev/null 2>&1 && restorecon -R {EXPORT_BASE} 2>/dev/null || true
-systemctl enable --now nfs-server
-exportfs -ra
-# Open the firewall if firewalld is running (ignore if it isn't).
+
+# 4. SELF-CORRECTION: create missing dirs for ANY pre-existing export entry so a
+#    stale line (e.g. /nfsdata3) can't make `exportfs -ra` abort.
+for p in $(awk '!/^#/ && NF {{print $1}}' /etc/exports /etc/exports.d/*.exports 2>/dev/null); do
+  case "$p" in
+    /*) if [ ! -d "$p" ]; then
+          echo "  fixing stale export: creating missing dir $p"
+          mkdir -p "$p" 2>/dev/null && {{ command -v restorecon >/dev/null 2>&1 && restorecon "$p" 2>/dev/null; }} || \
+            echo "  (could not create $p; skipping it)"
+        fi ;;
+  esac
+done
+
+# 5. service + (re-)export, tolerating unrelated stale entries
+systemctl enable --now nfs-server >/dev/null 2>&1 || fail "could not start nfs-server"
+exportfs -ra 2>&1 | sed 's/^/  exportfs: /'
+
+# 6. firewall (only if firewalld is active)
 if systemctl is-active --quiet firewalld; then
-  firewall-cmd --permanent --add-service=nfs >/dev/null 2>&1 || true
-  firewall-cmd --permanent --add-service=mountd >/dev/null 2>&1 || true
-  firewall-cmd --permanent --add-service=rpc-bind >/dev/null 2>&1 || true
-  firewall-cmd --reload >/dev/null 2>&1 || true
+  firewall-cmd --permanent --add-service=nfs >/dev/null 2>&1
+  firewall-cmd --permanent --add-service=mountd >/dev/null 2>&1
+  firewall-cmd --permanent --add-service=rpc-bind >/dev/null 2>&1
+  firewall-cmd --reload >/dev/null 2>&1
 fi
-echo '== current exports =='
+
+# 7. SUCCESS CRITERION: our exports must actually be active
+missing=""
+{verify}
+[ -z "$missing" ] || fail "these exports are not active after exportfs:$missing"
+
+echo '== active exports =='
 exportfs -v || true
 echo '{_EXPORTS_LINE}'{','.join(exports_paths)!r}
-echo '{_DONE}'
+echo {_DONE}
+"""
+
+
+def _remove_script():
+    """Remove ONLY our exports + content; leave everything else alone."""
+    return f"""
+echo '== rhcsa-simulator: removing NFS exports =='
+rm -f /etc/exports.d/rhcsa.exports
+exportfs -ra 2>&1 | sed 's/^/  exportfs: /' || true
+rm -rf {EXPORT_BASE} 2>/dev/null || true
+echo {_DONE}
 """
 
 
 # --------------------------------------------------------------------------
-# Config persistence
+# Config persistence (creds optional, stored root-only)
 # --------------------------------------------------------------------------
 
 def load_config():
-    """Return the saved NFS server config dict, or None."""
     try:
         with open(CONFIG_PATH) as fh:
             return json.load(fh)
@@ -107,11 +159,19 @@ def load_config():
         return None
 
 
-def save_config(host, user, exports):
+def save_config(host, user, exports, password=None):
     os.makedirs(STATE_DIR, exist_ok=True)
     cfg = {'host': host, 'user': user, 'exports': exports}
-    with open(CONFIG_PATH, 'w') as fh:
+    if password:
+        cfg['password'] = password
+    # Open 0600 from the start so a saved password is never world-readable.
+    fd = os.open(CONFIG_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, 'w') as fh:
         json.dump(cfg, fh, indent=2)
+    try:
+        os.chmod(CONFIG_PATH, 0o600)
+    except OSError:
+        pass
     return cfg
 
 
@@ -124,58 +184,69 @@ def clear_config():
 
 
 def get_server():
-    """Configured server host, or None."""
     cfg = load_config()
     return cfg.get('host') if cfg else None
 
 
 def pick_export(cfg=None, index=0):
-    """Return (export_path) from the configured exports by index (stable)."""
     cfg = cfg or load_config()
     if not cfg or not cfg.get('exports'):
         return None
-    exports = cfg['exports']
-    return exports[index % len(exports)]
+    return cfg['exports'][index % len(cfg['exports'])]
 
 
 # --------------------------------------------------------------------------
-# SSH provisioning
+# SSH plumbing
 # --------------------------------------------------------------------------
 
-def copy_ssh_key(host, user):
-    """Best-effort ssh-copy-id so subsequent runs are passwordless. Interactive."""
-    try:
-        return subprocess.run(['ssh-copy-id', f'{user}@{host}']).returncode == 0
-    except FileNotFoundError:
-        return False
+def _ssh_cmd(host, user, password=None, batch=False):
+    """Build the ssh command. With a password, route through sshpass and force
+    password auth; with batch=True (unattended), fail fast instead of hanging on
+    a prompt."""
+    cmd = []
+    if password:
+        cmd += ['sshpass', '-p', password]
+    cmd += ['ssh', '-o', 'StrictHostKeyChecking=accept-new',
+            '-o', 'ConnectTimeout=15']
+    if password:
+        cmd += ['-o', 'PreferredAuthentications=password',
+                '-o', 'PubkeyAuthentication=no']
+    elif batch:
+        cmd += ['-o', 'BatchMode=yes']
+    cmd += [f'{user}@{host}', 'bash -s']
+    return cmd
 
 
-def provision(host, user='root'):
-    """Run the provisioning script on the remote over interactive ssh.
-
-    Returns (ok, exports, output). ssh prompts for password/passphrase on the
-    terminal as needed; the script is fed on stdin (ssh reads auth from the tty,
-    not stdin, so this is safe).
-    """
-    script = _remote_script()
-    # BatchMode is NOT set, so ssh can prompt. StrictHostKeyChecking=accept-new
-    # avoids a separate interactive yes/no for first-time hosts.
-    cmd = ['ssh', '-o', 'StrictHostKeyChecking=accept-new',
-           f'{user}@{host}', 'bash -s']
+def _run_remote(script, host, user, password=None, batch=False, timeout=600):
+    """Feed `script` to the remote shell. ssh reads auth from the tty (not
+    stdin), so piping the script in is safe even for interactive password entry.
+    Returns (returncode, combined_output) or (None, message) on launch error."""
+    cmd = _ssh_cmd(host, user, password, batch)
     try:
         res = subprocess.run(cmd, input=script, text=True,
-                             capture_output=True, timeout=600)
-    except subprocess.TimeoutExpired:
-        return False, [], 'Timed out talking to the server (10 min).'
+                             capture_output=True, timeout=timeout)
+        return res.returncode, (res.stdout or '') + (res.stderr or '')
     except FileNotFoundError:
-        return False, [], "'ssh' not found on this machine."
+        missing = 'sshpass' if password else 'ssh'
+        return None, (f"'{missing}' not found on this machine."
+                      + (" Install it (dnf install sshpass) or use key-based auth."
+                         if password else ''))
+    except subprocess.TimeoutExpired:
+        return None, f'Timed out talking to {host}.'
 
-    output = (res.stdout or '') + (res.stderr or '')
-    if res.returncode != 0 or _DONE not in (res.stdout or ''):
+
+def _parse(rc, output):
+    """Interpret remote output: (ok, exports, output)."""
+    if rc is None:
         return False, [], output
-
+    if _DONE not in output:
+        reason = next((ln[len(_FAIL):].strip()
+                       for ln in output.splitlines() if ln.startswith(_FAIL)), '')
+        if reason:
+            return False, [], f"{reason}\n\n--- full output ---\n{output}"
+        return False, [], output
     exports = []
-    for line in res.stdout.splitlines():
+    for line in output.splitlines():
         if line.startswith(_EXPORTS_LINE):
             raw = line[len(_EXPORTS_LINE):].strip().strip("'\"")
             exports = [p for p in raw.split(',') if p]
@@ -185,8 +256,51 @@ def provision(host, user='root'):
     return True, exports, output
 
 
+def copy_ssh_key(host, user):
+    """Best-effort ssh-copy-id so subsequent runs are passwordless. Interactive."""
+    try:
+        return subprocess.run(['ssh-copy-id', f'{user}@{host}']).returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def provision(host, user='root', password=None, batch=False):
+    """Provision (or re-provision) the server. Returns (ok, exports, output)."""
+    rc, out = _run_remote(_provision_script(), host, user, password, batch=batch)
+    return _parse(rc, out)
+
+
+def remove_exports(host=None, user='root', password=None, batch=True):
+    """Tear our exports down on the server. Returns (ok, output)."""
+    cfg = load_config()
+    if host is None:
+        if not cfg:
+            return False, 'no NFS server configured'
+        host, user = cfg['host'], cfg.get('user', 'root')
+        password = password or cfg.get('password')
+    rc, out = _run_remote(_remove_script(), host, user, password, batch=batch)
+    return (rc == 0 and _DONE in out), out
+
+
+def reprovision_from_config(batch=True):
+    """Re-provision using saved creds (unattended exam refresh).
+    Returns (ok, exports_or_None, output) or (None, None, reason) if unusable."""
+    cfg = load_config()
+    if not cfg:
+        return None, None, 'no NFS server configured'
+    pw = cfg.get('password')
+    # Unattended: needs a saved password OR key-based auth (batch mode).
+    ok, exports, out = provision(cfg['host'], cfg.get('user', 'root'),
+                                 password=pw, batch=(pw is None))
+    return ok, (exports if ok else None), out
+
+
+def sshpass_available():
+    return shutil.which('sshpass') is not None
+
+
 def verify_from_client(host):
-    """Run showmount -e against the server from this machine. (ok, output)."""
+    """showmount -e against the server from this machine. (ok, output)."""
     try:
         res = subprocess.run(['showmount', '-e', host],
                              capture_output=True, text=True, timeout=30)


### PR DESCRIPTION
Fixes the weak NFS setup flagged while provisioning a real server.

## 1. Error-correcting provisioning
The old script used `set -e` + `exportfs -ra`, so a **pre-existing** stale export on the server (e.g. `/nfsdata3` whose directory was gone) aborted the entire run:
```
exportfs: Failed to stat /nfsdata3: No such file or directory
Provisioning failed.
```
Now the remote script:
- drops `set -e`; reports one clean `RHCSA_NFS_FAIL: <reason>` instead of dumping raw failures
- **self-corrects**: creates missing directories for *any* pre-existing export entry so a stale line can't break `exportfs`
- tolerates unrelated `exportfs` warnings
- only reports success once **our** exports are verified active (`exportfs -v`)

## 2. Saved credentials
Setup now offers **key-based** auth (`ssh-copy-id`) or **saving a password** (used via `sshpass`) so exams can re-provision unattended. Stored in `/var/lib/rhcsa-simulator/nfs_server.conf`, created `0600`.

## 3. Per-exam lifecycle
Exports are **refreshed at the start of every exam** with NFS tasks (fresh, reseeded shares) and **torn off the server afterwards** (`core/exam.py` hooks). Setup also gains **Test connection** and a remove action that unexports the server.

## Tests
`152 passed`; both remote scripts pass `bash -n`; `_parse` handles FAIL/DONE; config verified `0600` with password round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8UPKdjDoBoVJCfwzSec5a