### PR TITLE
Remove leftover task artifacts per exam (manifest-based cleanup)

### DIFF
--- a/core/exam.py
+++ b/core/exam.py
@@ -71,6 +71,9 @@ class ExamSession:
             helpers.reset_practice_loops()
         except Exception:
             pass
+        # Remove leftover task artifacts from previous sessions (stray
+        # /tmp/*.txt, old mount points, swap files, etc.) so this exam is clean.
+        self._clean_lab_leftovers()
         try:
             pool = helpers.build_device_pool()
         except Exception:
@@ -173,6 +176,17 @@ class ExamSession:
                 # is still valid, so stay quiet to avoid alarming the candidate.
             except Exception as e:
                 print(fmt.warning(f"  ✗ {task.id}: setup error ({e})"))
+
+    def _clean_lab_leftovers(self):
+        """Remove leftover task artifacts (files/dirs/mounts the tasks ask the
+        candidate to create) so each exam starts from a clean slate."""
+        try:
+            from core import lab_cleanup
+            done = lab_cleanup.clean(dry_run=False)
+        except Exception:
+            return
+        if done:
+            print(fmt.dim(f"Removed {len(done)} leftover lab artifact(s) from a previous session."))
 
     def _has_nfs_tasks(self):
         return any(getattr(t, 'category', '') == 'network_storage' for t in self.tasks)

--- a/core/lab_cleanup.py
+++ b/core/lab_cleanup.py
@@ -1,0 +1,133 @@
+"""
+Lab leftover cleanup.
+
+Tasks ask the candidate to create files, directories, mounts and swap in a known
+set of locations (/tmp scratch outputs, /mnt mount points, /opt, /srv, a couple
+of /root markers, /home/guests, swap files). When a previous lab/session is
+interrupted, those artifacts linger (e.g. a stray /tmp/special_perms.txt) and
+can interfere with the next run.
+
+Rather than snapshot the whole filesystem and diff it (which risks deleting
+unrelated user data), this module removes ONLY the specific paths the
+simulator's own tasks define — a curated manifest derived from the task set.
+It never touches /etc (fstab is handled separately by the fstab guard) and never
+touches shell dotfiles, SSH keys, or anything outside the manifest.
+"""
+
+import os
+import glob
+import shutil
+import subprocess
+
+# Swap files a task may ask the candidate to create (swapoff before removing).
+SWAP_FILES = ['/swapfile', '/var/swap', '/swap.img']
+
+# Mount points / directories tasks create. Unmounted first if mounted, then the
+# directory tree is removed (these are simulator-owned scratch locations).
+DIR_ARTIFACTS = [
+    '/mnt/data', '/mnt/nfsdata', '/mnt/shared', '/mnt/persistent',
+    '/mnt/practice_extend', '/mnt/vfat', '/mnt/external', '/mnt/faulttest',
+    '/mnt/recovery', '/mnt/rescue', '/mnt/sysimage', '/mnt/nonexistent',
+    '/mnt/lvm*',
+    '/opt/appdata', '/opt/webdata',
+    '/srv/nfs', '/srv/samba', '/srv/website', '/srv/web', '/srv/webapp',
+    '/srv/shares', '/srv/ftp',
+    '/home/guests',
+]
+
+# Individual files/dirs under /tmp and a couple of /root, /home markers. Globs
+# cover the randomised name families (journal_*, scp_*, top_*, etc.).
+FILE_ARTIFACTS = [
+    # /tmp scratch outputs
+    '/tmp/special_perms.txt', '/tmp/specialperm*',
+    '/tmp/processed.txt', '/tmp/sorted_output.txt', '/tmp/diff_output.txt',
+    '/tmp/extracted_field.txt', '/tmp/findresults.txt', '/tmp/grepresults.txt',
+    '/tmp/boot_analysis.*', '/tmp/boot_entries.txt', '/tmp/boot_errors.log',
+    '/tmp/boot_issues.txt', '/tmp/grub_entries.txt', '/tmp/journal_*',
+    '/tmp/cron_jobs.txt', '/tmp/cronlog.txt', '/tmp/atjob.log',
+    '/tmp/active-timers-*', '/tmp/failed-services-*', '/tmp/top_*',
+    '/tmp/tuned_profiles.txt', '/tmp/dnf_history.txt', '/tmp/pkg_info.txt',
+    '/tmp/package_provider.txt', '/tmp/rpm_verify.txt',
+    '/tmp/backup.tar*', '/tmp/bg_process.pid', '/tmp/rw_test_passed',
+    '/tmp/hardlink*', '/tmp/passwdlink*', '/tmp/flatpak_*',
+    '/tmp/remote_pull_*', '/tmp/scp_src_*', '/tmp/scp_dst_*',
+    '/tmp/scp_transfer_*',
+    # /tmp dirs
+    '/tmp/extracted', '/tmp/chroot_test', '/tmp/sysroot_sim',
+    '/tmp/acltest*', '/tmp/ownertest*', '/tmp/original', '/tmp/testfile*',
+    # /root markers (NEVER dotfiles)
+    '/root/recovery_marker.txt', '/root/rw_confirmed',
+    # /home symlink lab
+    '/home/loglink',
+]
+
+# Hard safety floor: a target must live under one of these and not BE one of
+# them. Guards against a bad glob ever matching '/', '/etc', a top-level dir, etc.
+_ALLOWED_PREFIXES = ('/tmp/', '/mnt/', '/opt/', '/srv/', '/root/', '/home/', '/var/swap')
+_NEVER = {'/tmp', '/mnt', '/opt', '/srv', '/root', '/home', '/var', '/'}
+# Belt-and-braces: never remove these even if a glob somehow matches them.
+_PROTECT = {'/root/.bashrc', '/root/.bash_profile', '/root/.ssh',
+            '/root/.bash_history'}
+
+
+def _is_safe(path):
+    path = os.path.normpath(path)
+    if path in _NEVER or path in _PROTECT:
+        return False
+    if path in SWAP_FILES:
+        return True
+    return path.startswith(_ALLOWED_PREFIXES)
+
+
+def _is_mounted(path):
+    try:
+        return os.path.ismount(path)
+    except OSError:
+        return False
+
+
+def find_leftovers():
+    """Return the sorted list of existing artifact paths that cleanup would act
+    on (after glob expansion and the safety filter)."""
+    found = set()
+    for pattern in SWAP_FILES + DIR_ARTIFACTS + FILE_ARTIFACTS:
+        for match in (glob.glob(pattern) if any(c in pattern for c in '*?[') else [pattern]):
+            if os.path.lexists(match) and _is_safe(match):
+                found.add(os.path.normpath(match))
+    return sorted(found)
+
+
+def _remove_one(path):
+    """Remove a single artifact (swapoff / unmount as needed). Returns an action
+    string describing what was done, or None on failure."""
+    if not _is_safe(path) or not os.path.lexists(path):
+        return None
+    try:
+        if path in SWAP_FILES:
+            subprocess.run(['swapoff', path], capture_output=True, timeout=15)
+        if _is_mounted(path):
+            subprocess.run(['umount', '-l', path], capture_output=True, timeout=15)
+        if os.path.islink(path) or os.path.isfile(path):
+            os.remove(path)
+            return f"removed file {path}"
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+            return f"removed dir  {path}"
+    except Exception as e:
+        return f"FAILED {path}: {e}"
+    return None
+
+
+def clean(dry_run=False):
+    """Remove all existing lab artifacts. With dry_run, only report them.
+    Returns a list of action strings."""
+    actions = []
+    for path in find_leftovers():
+        if dry_run:
+            kind = 'dir ' if os.path.isdir(path) and not os.path.islink(path) else 'file'
+            actions.append(f"would remove {kind} {path}")
+        else:
+            result = _remove_one(path)
+            if result:
+                actions.append(result)
+    return actions

--- a/core/menu.py
+++ b/core/menu.py
@@ -220,6 +220,7 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
         print("  4. System Reset (remove practice artifacts)")
         print("  5. Populate Practice Environment (DNF history)")
         print(f"  6. Configure remote NFS server for NFS tasks ({nfs_status})")
+        print("  7. Clean lab leftover files (remove task artifacts)")
         print("  0. Return to Menu")
         print()
 
@@ -237,6 +238,42 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             self.populate_practice_environment()
         elif choice == '6':
             self.configure_nfs_server()
+        elif choice == '7':
+            self.clean_lab_leftovers()
+
+    def clean_lab_leftovers(self):
+        """Preview and remove leftover task artifacts (files/dirs/mounts the
+        tasks ask the candidate to create)."""
+        from core import lab_cleanup
+        from utils.helpers import confirm_action
+
+        fmt.clear_screen()
+        fmt.print_header("CLEAN LAB LEFTOVER FILES")
+
+        planned = lab_cleanup.clean(dry_run=True)
+        if not planned:
+            print(fmt.success("Nothing to clean — no known task artifacts present."))
+            input("\nPress Enter to return...")
+            return
+
+        print("These task-created artifacts would be removed "
+              "(/etc and your dotfiles are never touched):")
+        print()
+        for line in planned:
+            print(f"  {line}")
+        print()
+        if not confirm_action(f"Remove these {len(planned)} item(s)?", default=False):
+            print(fmt.dim("Cancelled — nothing removed."))
+            input("\nPress Enter to return...")
+            return
+
+        done = lab_cleanup.clean(dry_run=False)
+        print()
+        print(fmt.success(f"Removed {len(done)} item(s)."))
+        for line in done:
+            if line.startswith('FAILED'):
+                print(fmt.warning(f"  {line}"))
+        input("\nPress Enter to return...")
 
     def configure_nfs_server(self):
         """SSH into a user-named RHEL box and provision it as a real NFS server


### PR DESCRIPTION
## What

A leftover file from a previous lab (your `/tmp/special_perms.txt`) could linger and interfere with the next run. Instead of snapshotting the whole filesystem and diffing it (which risks deleting unrelated user data), this removes **only the specific paths the simulator's own tasks define** — a curated manifest derived from the task set.

- `core/lab_cleanup.py`: the manifest + `clean()`/`find_leftovers()`. Covers `/tmp` scratch outputs (incl. glob families `journal_*`, `scp_*`, `top_*`, `flatpak_*`, …), `/mnt` mount points, `/opt`, `/srv`, two `/root` markers, `/home/guests`, and swap files. Unmounts / `swapoff`s before removing.
- **Auto**: cleans at the start of every exam (clean slate).
- **Manual**: Setup → **7. Clean lab leftover files** — shows a dry-run preview, then confirms.

## Safety

Hard floor: a target must sit under an allowed prefix (`/tmp /mnt /opt /srv /root /home` + swap files) and is rejected if it's a top-level dir, `/etc` (fstab is handled by the fstab guard), or a shell dotfile / SSH key. Manual mode previews and requires confirmation.

## Verified
Removes `/tmp/special_perms.txt` and artifact dirs; safety guards reject `/etc`, `/`, top dirs, and dotfiles; `152 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8UPKdjDoBoVJCfwzSec5a