### PR TITLE
Unmount client NFS mounts before removing server exports

### DIFF
--- a/core/exam.py
+++ b/core/exam.py
@@ -228,6 +228,11 @@ class ExamSession:
         if not nfs_server.load_config():
             return
         try:
+            # Unmount our client-side NFS mounts FIRST, while the server is
+            # still exporting, so they can't become stale when exports go away.
+            n = nfs_server.unmount_client_mounts()
+            if n:
+                print(fmt.dim(f"  Unmounted {n} client NFS mount(s)."))
             ok, _ = nfs_server.remove_exports()
             if ok:
                 print(fmt.dim("  NFS exports removed from server."))

--- a/core/nfs_server.py
+++ b/core/nfs_server.py
@@ -270,6 +270,47 @@ def provision(host, user='root', password=None, batch=False):
     return _parse(rc, out)
 
 
+def unmount_client_mounts(host=None):
+    """Unmount LOCAL nfs mounts served by our configured server BEFORE the
+    server's exports are removed, so they never become stale (a stale NFS mount
+    makes stat()/cleanup hang on the next exam). Matches by server host or by an
+    export path we own (handles name-vs-IP mismatches). Returns the count.
+
+    All operations are timeout-bounded; a 'umount -l' is lazy so it returns
+    immediately even if a mount is already unreachable.
+    """
+    cfg = load_config()
+    if host is None:
+        host = cfg.get('host') if cfg else None
+    exports = set(cfg.get('exports', [])) if cfg else set()
+    if not host and not exports:
+        return 0
+
+    try:
+        res = subprocess.run(
+            ['findmnt', '-rno', 'TARGET,SOURCE', '-t', 'nfs,nfs4'],
+            capture_output=True, text=True, timeout=15
+        )
+    except Exception:
+        return 0
+
+    count = 0
+    for line in res.stdout.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        target, source = parts[0], parts[1]
+        src_host, _, src_path = source.partition(':')
+        if (host and src_host == host) or (src_path and src_path in exports):
+            try:
+                subprocess.run(['umount', '-l', '--', target],
+                               capture_output=True, timeout=15)
+                count += 1
+            except Exception:
+                pass
+    return count
+
+
 def remove_exports(host=None, user='root', password=None, batch=True):
     """Tear our exports down on the server. Returns (ok, output)."""
     cfg = load_config()


### PR DESCRIPTION
Follow-up to #20: stop the stale NFS mount from forming in the first place.

## Problem
The per-exam NFS teardown removed the server's exports **while the client was still mounted**, so the mount went stale — which is what later hung the exam at start.

## Fix
At exam end, unmount our client-side NFS mounts **first**, while the server is still exporting (so the unmount is clean), then remove the exports.

- `core/nfs_server.py`: `unmount_client_mounts()` — finds local `nfs`/`nfs4` mounts served by the configured host (or whose export path we own, to handle name-vs-IP) via `findmnt` and lazily unmounts them. All `subprocess` calls are timeout-bounded.
- `core/exam.py`: `_teardown_nfs()` calls it before `remove_exports()`.

Together with #20 (cleanup resilient to a stale mount if one ever does occur), the stale-mount hang is addressed at both ends.

`152 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8UPKdjDoBoVJCfwzSec5a