### PR TITLE
Reset + prepare the system in practice/adaptive modes; adaptive task count

### DIFF
--- a/core/adaptive.py
+++ b/core/adaptive.py
@@ -9,6 +9,7 @@ import logging
 from tasks.registry import TaskRegistry
 from core.validator import get_validator
 from core.results_db import get_results_db
+from core import task_env
 from utils import formatters as fmt
 from utils.helpers import confirm_action
 from config import settings
@@ -34,6 +35,9 @@ class AdaptiveMode:
         print("Adaptive mode selects tasks based on your performance history.")
         print("It focuses on weak areas and categories due for review.")
         print()
+
+        # Let the candidate size the session (no more 4/5-task cap).
+        self.tasks_per_session = self._select_task_count()
 
         # Determine target categories
         categories, source = self._select_categories()
@@ -64,6 +68,11 @@ class AdaptiveMode:
         if not confirm_action("Ready to start?", default=True):
             return
 
+        # Reset the box to a clean, practice-ready state (fresh loop disks +
+        # remove leftover artifacts) just like exam mode does at start.
+        print(fmt.dim("Preparing a clean practice environment..."))
+        task_env.session_reset()
+
         # Run session
         results = []
         try:
@@ -76,6 +85,26 @@ class AdaptiveMode:
         # Show session summary
         if results:
             self._show_summary(results, source)
+
+    def _select_task_count(self):
+        """Ask how many tasks this session should include (default 5, no cap)."""
+        print(fmt.bold("How many tasks this session?"))
+        print(fmt.dim("  Enter a number (e.g. 5, 10, 15). Default 5."))
+        while True:
+            raw = input("\nNumber of tasks [5]: ").strip() or '5'
+            try:
+                n = int(raw)
+            except ValueError:
+                print(fmt.error("Please enter a whole number."))
+                continue
+            if n < 1:
+                print(fmt.error("Enter at least 1."))
+                continue
+            if n > 40:
+                print(fmt.warning("Capping at 40 tasks for one session."))
+                n = 40
+            print()
+            return n
 
     def _select_categories(self):
         """Select categories based on SM-2 data. Returns (categories, source_label)."""
@@ -119,28 +148,67 @@ class AdaptiveMode:
             return 'hard'
 
     def _generate_tasks(self, categories):
-        """Generate tasks distributed across selected categories."""
+        """Generate up to tasks_per_session tasks across the focus categories.
+
+        Prefers distinct task templates from the focus categories; if the
+        requested count exceeds what those categories hold, it overflows into
+        the remaining categories, and as a last resort re-draws fresh randomized
+        instances so a large count (e.g. 15-20) is always honored.
+        """
+        import random
+
+        target = self.tasks_per_session
         tasks = []
-        exclude_ids = []
-        per_cat = max(1, self.tasks_per_session // len(categories))
-        remainder = self.tasks_per_session - (per_cat * len(categories))
+        seen_ids = set()
 
-        for i, cat in enumerate(categories):
-            count = per_cat + (1 if i < remainder else 0)
+        # Focus categories first, then everything else for overflow.
+        overflow = [c for c in TaskRegistry.get_all_categories() if c not in categories]
+        random.shuffle(overflow)
+        pool = list(categories) + overflow
+
+        def draw(cat):
             difficulty = self._get_adaptive_difficulty(cat)
+            t = TaskRegistry.get_random_task(category=cat, difficulty=difficulty)
+            if not t:
+                t = TaskRegistry.get_random_task(category=cat)
+            return t
 
-            for _ in range(count):
-                task = TaskRegistry.get_random_task(category=cat, difficulty=difficulty)
-                if not task:
-                    task = TaskRegistry.get_random_task(category=cat)
-                if task and task.id not in exclude_ids:
+        # Pass 1: round-robin distinct tasks across the pool.
+        progressed = True
+        while len(tasks) < target and progressed:
+            progressed = False
+            for cat in pool:
+                if len(tasks) >= target:
+                    break
+                task = draw(cat)
+                if task and task.id not in seen_ids:
                     tasks.append(task)
-                    exclude_ids.append(task.id)
+                    seen_ids.add(task.id)
+                    progressed = True
+
+        # Pass 2: if the distinct pool is exhausted but the candidate asked for
+        # more, top up with fresh randomized instances from the focus categories.
+        guard = 0
+        while len(tasks) < target and guard < target * 20:
+            guard += 1
+            cat = random.choice(categories if categories else pool)
+            task = draw(cat)
+            if task:
+                tasks.append(task)
 
         return tasks
 
     def _run_task(self, task, current, total):
         """Run a single adaptive task. Returns ValidationResult."""
+        import time
+
+        # Change the system for this task (inject fault + establish any negative
+        # precondition) so it requires real work — same setup exam mode runs.
+        fmt.clear_screen()
+        print(fmt.bold("Preparing task environment..."))
+        env_state = task_env.setup_task(task)
+        time.sleep(1)
+
         fmt.clear_screen()
         print(f"Adaptive Practice - Task {current}/{total}")
         print("=" * 60)
@@ -217,6 +285,12 @@ class AdaptiveMode:
         if result.passed:
             print(fmt.success("\nGreat job!"))
         print()
+
+        # Reverse this task's system changes, then wipe practice disks if it
+        # consumed one so the next task starts clean.
+        print(fmt.dim("Restoring system..."))
+        task_env.teardown_task(task, env_state)
+        task_env.reset_after_task(task)
 
         if current < total:
             if not confirm_action("Continue to next task?", default=True):

--- a/core/practice.py
+++ b/core/practice.py
@@ -14,6 +14,7 @@ from contextlib import redirect_stdout
 from tasks.registry import TaskRegistry
 from core.validator import get_validator
 from core.results_db import get_results_db
+from core import task_env
 from utils import formatters as fmt
 from utils.helpers import confirm_action
 from config import settings
@@ -89,6 +90,12 @@ class PracticeSession:
             break  # 's' or Enter
 
         print(fmt.info(f"\nStarting session…"))
+
+        # Reset the box to a clean, practice-ready state (fresh loop disks +
+        # remove leftover artifacts) exactly like exam mode does at start, so
+        # tasks aren't polluted by a previous session.
+        print(fmt.dim("Preparing a clean practice environment..."))
+        task_env.session_reset()
 
         # Practice each task
         try:
@@ -174,21 +181,15 @@ class PracticeSession:
         import time
         attempt = 1
         db = get_results_db()
-        fault_injected = False
 
-        # Inject a real fault before showing the task (if the task supports it)
-        if getattr(task, 'has_fault_injection', False):
-            fmt.clear_screen()
-            print(fmt.bold("Injecting fault..."))
-            ok, msg = task.inject_fault()
-            if ok:
-                fault_injected = True
-                print(fmt.success(f"  Fault active: {msg}"))
-            else:
-                print(fmt.error(f"  Fault injection failed: {msg}"))
-                print(fmt.warning("  Proceeding in descriptive mode only."))
-            print()
-            time.sleep(1)
+        # Change the system for this task (inject fault + establish any negative
+        # precondition) — the same setup exam mode runs, so positive-config
+        # tasks require real work instead of passing on default state.
+        fmt.clear_screen()
+        print(fmt.bold("Preparing task environment..."))
+        env_state = task_env.setup_task(task)
+        print()
+        time.sleep(1)
 
         stop_requested = False
         while True:
@@ -302,16 +303,13 @@ class PracticeSession:
                 input("Press Enter to continue...")
                 break
 
-        # Restore fault regardless of outcome
-        if fault_injected:
-            print()
-            print(fmt.dim("Restoring system..."))
-            ok, msg = task.restore_fault()
-            if ok:
-                print(fmt.dim(f"  {msg}"))
-            else:
-                print(fmt.error(f"  Restore error: {msg}"))
-            time.sleep(1)
+        # Reverse the per-task system changes regardless of outcome, then wipe
+        # practice disks if this task consumed one so the next task starts clean.
+        print()
+        print(fmt.dim("Restoring system..."))
+        task_env.teardown_task(task, env_state)
+        task_env.reset_after_task(task)
+        time.sleep(1)
 
         if stop_requested:
             raise StopIteration

--- a/core/task_env.py
+++ b/core/task_env.py
@@ -1,0 +1,109 @@
+"""
+Shared task-environment lifecycle for training sessions (practice + adaptive).
+
+Exam mode already resets the box and prepares each task's preconditions
+(reset practice disks + clean lab leftovers at start; inject_fault /
+setup_environment per task; restore_fault / teardown_environment after). These
+helpers expose that exact behavior so practice and adaptive modes get the same
+real system changes and per-iteration reset — otherwise positive-config tasks
+pass on default state and leftover artifacts from the previous task pollute the
+next one.
+
+Nothing new is invented here; it just calls the same functions exam.py uses.
+"""
+
+import logging
+from utils import formatters as fmt
+
+logger = logging.getLogger(__name__)
+
+
+def session_reset(verbose=True):
+    """Start-of-session reset: fresh practice disks + remove leftover artifacts.
+
+    Mirrors ExamSession.start(): helpers.reset_practice_loops() followed by
+    lab_cleanup.clean(). Safe to call when there are no loop devices or no
+    leftovers — both operations no-op cleanly.
+    """
+    from utils import helpers
+    try:
+        helpers.reset_practice_loops()
+    except Exception:
+        pass
+    done = []
+    try:
+        from core import lab_cleanup
+        done = lab_cleanup.clean(dry_run=False)
+    except Exception:
+        done = []
+    if verbose and done:
+        print(fmt.dim(f"Cleaned {len(done)} leftover lab artifact(s) from a previous session."))
+    return done
+
+
+def setup_task(task, verbose=True):
+    """Change the system for one task before the candidate works on it.
+
+    Runs the task's own inject_fault() (break something to fix) and/or
+    setup_environment() (establish a negative precondition so a positive-config
+    task can't pass on default state) — the same calls exam.py makes. Returns a
+    small state dict for teardown_task() to reverse.
+    """
+    state = {'fault': False, 'setup': False}
+
+    if getattr(task, 'has_fault_injection', False):
+        try:
+            ok, msg = task.inject_fault()
+            state['fault'] = ok
+            if verbose:
+                print(fmt.success(f"  Fault active: {msg}") if ok
+                      else fmt.warning(f"  Fault injection failed: {msg} (descriptive mode only)"))
+        except Exception as e:
+            if verbose:
+                print(fmt.warning(f"  Fault injection error: {e}"))
+
+    if getattr(task, 'has_setup', False):
+        try:
+            ok, msg = task.setup_environment()
+            state['setup'] = ok
+            # A False result just means no precondition was needed; stay quiet.
+            if verbose and ok:
+                print(fmt.dim(f"  Precondition set: {msg}"))
+        except Exception as e:
+            if verbose:
+                print(fmt.warning(f"  Setup error: {e}"))
+
+    return state
+
+
+def teardown_task(task, state, verbose=True):
+    """Reverse setup_task(): restore_fault() + teardown_environment()."""
+    if not state:
+        return
+    if state.get('fault'):
+        try:
+            ok, msg = task.restore_fault()
+            if verbose:
+                print(fmt.dim(f"  {msg}") if ok else fmt.error(f"  Restore error: {msg}"))
+        except Exception:
+            pass
+    if state.get('setup'):
+        try:
+            task.teardown_environment()
+        except Exception:
+            pass
+
+
+def reset_after_task(task):
+    """Between iterations, wipe practice disks if the finished task consumed one,
+    so the next disk task starts from clean, signature-free disks.
+
+    Non-disk tasks skip this (nothing to reset), keeping the session snappy.
+    """
+    if getattr(task, 'disk_slots', 0) <= 0:
+        return
+    from utils import helpers
+    try:
+        helpers.reset_practice_loops()
+    except Exception:
+        pass


### PR DESCRIPTION
## What

Practice and Adaptive modes now change and reset the system per iteration the same way exam mode already does, and Adaptive lets you choose how many tasks to run.

### The problem
Training modes showed tasks but never touched the system:
- Positive-config tasks passed on default state (nothing to actually do).
- Leftover artifacts from a previous task/session polluted the next one.
- Adaptive was hard-capped at 5 tasks with no prompt.

### The fix
New `core/task_env.py` wraps the **existing** exam lifecycle (no new mechanisms):
- `session_reset()` — `reset_practice_loops()` + `lab_cleanup.clean()` at session start.
- `setup_task()` — per-task `inject_fault()` + `setup_environment()` so tasks require real work.
- `teardown_task()` + `reset_after_task()` — reverse the changes and wipe practice disks between disk-consuming tasks so each iteration starts clean.

Wired into both `core/practice.py` and `core/adaptive.py`.

Adaptive also:
- Prompts for task count (default 5, up to 40) — no more 4/5-task cap.
- `_generate_tasks()` overflows into additional categories and re-draws fresh randomized instances so large counts are honored.

## Test
`152 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)