### PR TITLE
Dispute: no-auth browser fallback when gh can't file the issue

### DIFF
--- a/core/dispute.py
+++ b/core/dispute.py
@@ -22,6 +22,7 @@ Nothing here changes system state; it only reads it.
 import os
 import shutil
 import subprocess
+import urllib.parse
 from datetime import datetime
 
 from utils import formatters as fmt  # noqa: F401  (kept for callers/consistency)
@@ -31,6 +32,10 @@ from utils import formatters as fmt  # noqa: F401  (kept for callers/consistency
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DISPUTE_DIR = os.path.join(REPO_ROOT, 'data', 'disputes')
 DISPUTE_LABEL = 'checker-dispute'
+
+# Used to build the browser fallback URL when the git remote can't be read
+# (e.g. a tarball copy on an exam box with no origin remote).
+GITHUB_REPO_FALLBACK = 'justbest23/rhcsa-simulator'
 
 _MAX_OUTPUT = 4000  # chars kept per command, to keep issues readable
 
@@ -101,6 +106,63 @@ def gh_available():
         return res.returncode == 0
     except Exception:
         return False
+
+
+def repo_slug():
+    """Return 'owner/repo' from the git origin remote, or a sensible fallback.
+
+    Works for both SSH (git@github.com:owner/repo.git) and HTTPS remotes; falls
+    back to GITHUB_REPO_FALLBACK when there's no git remote (tarball copy).
+    """
+    try:
+        res = subprocess.run(['git', 'remote', 'get-url', 'origin'],
+                             capture_output=True, text=True, cwd=REPO_ROOT, timeout=10)
+        url = (res.stdout or '').strip()
+        if url:
+            if url.startswith('git@') or ('@' in url and '://' not in url):
+                path = url.split(':', 1)[1] if ':' in url else url
+            else:
+                path = urllib.parse.urlsplit(url).path
+            path = path.strip('/')
+            if path.endswith('.git'):
+                path = path[:-4]
+            if path and '/' in path:
+                return path
+    except Exception:
+        pass
+    return GITHUB_REPO_FALLBACK
+
+
+def issue_url(tr, body, max_url=7000):
+    """Build a pre-filled GitHub 'new issue' URL — no gh, no auth on this box.
+
+    The candidate opens it in any browser where they're logged into GitHub and
+    just clicks 'Submit'. GitHub truncates very long GET URLs, so if the full
+    report doesn't fit the body is trimmed (the complete report is always kept
+    locally by save_report()).
+    """
+    title = f"[checker dispute] {tr.get('task_id', 'task')}: scored " \
+            f"{tr.get('score', '?')}/{tr.get('max_score', '?')}"
+    base = f"https://github.com/{repo_slug()}/issues/new"
+
+    def build(b):
+        q = urllib.parse.urlencode(
+            {'title': title, 'body': b, 'labels': DISPUTE_LABEL})
+        return f"{base}?{q}"
+
+    url = build(body)
+    if len(url) <= max_url:
+        return url
+
+    note = ("\n\n_(Evidence truncated to fit the URL — the full report is saved "
+            "on the exam host; paste it in if you can.)_")
+    budget = len(body)
+    while budget > 400:
+        budget = int(budget * 0.8)
+        url = build(body[:budget] + note)
+        if len(url) <= max_url:
+            return url
+    return build(title)  # extreme fallback: title only
 
 
 def collect_evidence(category, extra_commands=None):

--- a/core/menu.py
+++ b/core/menu.py
@@ -1063,20 +1063,19 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
         path = dispute.save_report(tr, body)
         print(fmt.success(f"Saved dispute report: {path}"))
 
-        # 5. Submit via gh (or fall back to local-only with instructions).
+        # 5. Submit via gh (or fall back to a no-auth browser URL).
         if not dispute.gh_available():
             print()
-            print(fmt.warning("GitHub CLI ('gh') is not installed or not authenticated, so the"))
-            print(fmt.warning("issue could not be opened automatically."))
-            print("The full report was saved at the path above. To file it:")
-            print(fmt.dim(f"  gh issue create --label {dispute.DISPUTE_LABEL} "
-                          f"--title '[checker dispute] {tr.get('task_id')}' --body-file {path}"))
+            print(fmt.warning("GitHub CLI ('gh') isn't installed/authenticated on this host, so"))
+            print(fmt.warning("the issue can't be opened automatically from here."))
+            self._offer_manual_dispute(dispute, tr, path, body)
             input("\nPress Enter to return to session view...")
             return
 
         print()
         if not confirm_action("Open the GitHub issue now?", default=True):
             print(fmt.dim(f"Not sent. Report kept at {path}."))
+            self._offer_manual_dispute(dispute, tr, path, body)
             input("\nPress Enter to return to session view...")
             return
 
@@ -1089,9 +1088,29 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             print(fmt.info("An AI reviewer will inspect the validator and, if the checker is"))
             print(fmt.info("wrong, open a fix PR. Watch the issue for its verdict."))
         else:
-            print(fmt.error(f"Could not open the issue: {info}"))
-            print(fmt.dim(f"The report is saved at {path} — you can file it manually."))
+            print(fmt.error(f"Could not open the issue via gh: {info}"))
+            self._offer_manual_dispute(dispute, tr, path, body)
         input("\nPress Enter to return to session view...")
+
+    def _offer_manual_dispute(self, dispute, tr, path, body):
+        """Show no-auth ways to file the dispute when gh can't do it here:
+        a pre-filled browser URL (open on any machine logged into GitHub) plus
+        the exact gh command, with the full report kept locally either way."""
+        print()
+        print(fmt.bold("File it without gh — open this URL in any browser where you're"))
+        print(fmt.bold("logged into GitHub, then click 'Submit new issue':"))
+        print()
+        try:
+            print(dispute.issue_url(tr, body))
+        except Exception:
+            print(fmt.dim("  (could not build issue URL)"))
+        print()
+        print(fmt.dim("The label is pre-set, so the AI reviewer triggers automatically."))
+        print(fmt.dim(f"Full report saved locally: {path}"))
+        print(fmt.dim("Or, on a host with gh authenticated:"))
+        print(fmt.dim(f"  gh issue create --repo {dispute.repo_slug()} "
+                      f"--label {dispute.DISPUTE_LABEL} "
+                      f"--title '[checker dispute] {tr.get('task_id')}' --body-file {path}"))
 
     def populate_practice_environment(self):
         """Install/remove lightweight packages to build up DNF transaction history."""


### PR DESCRIPTION
## The bug
Filing a checker dispute failed on the RHEL exam box: *\"couldn't open an issue from the environment.\"* The dispute path depended on the `gh` CLI, which is usually **not installed or authenticated** on the machine where the simulator actually runs. Filing works fine on a dev box with `gh` — but not where candidates use it.

## The fix
Add a fallback that needs **no `gh` and no auth on the exam host**: a pre-filled GitHub *new issue* URL you open in any browser where you're logged into GitHub, then click **Submit**. Title, body, and the `checker-dispute` label are all pre-set, so the AI reviewer still triggers automatically.

Shown whenever `gh` is missing, declined, or errors:
- `dispute.repo_slug()` — owner/repo from the git remote (SSH or HTTPS), fallback `justbest23/rhcsa-simulator` for tarball copies with no remote.
- `dispute.issue_url()` — builds the pre-filled URL, trimming the body under GitHub's GET-URL limit. The **full** evidence report is always saved locally regardless.
- `menu._offer_manual_dispute()` — one shared fallback (browser URL + local path + exact `gh` command) used by all three non-gh paths.

## Test
- `152 passed`
- Verified `repo_slug()` resolves the remote, `issue_url()` produces a valid labelled URL, and an oversized body is trimmed to ≤7000 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)