### PR TITLE
Scope dispute review to one file (less credit per dispute)

### DIFF
--- a/.github/workflows/checker-dispute.yml
+++ b/.github/workflows/checker-dispute.yml
@@ -42,19 +42,25 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: >-
             --allowedTools "Bash,Read,Edit,Write,Grep,Glob"
+            --max-turns 30
           prompt: |
             A candidate using the RHCSA exam simulator has disputed a validator
             ("checker") result. The dispute is GitHub issue #${{ github.event.issue.number }}
             in this repository. Its body contains: the task as presented, the
             specific check(s) the candidate says are wrong, the candidate's
-            written argument, and captured live system-state evidence.
+            written argument, captured live system-state evidence, and a
+            **"Checker source"** line naming the exact file, class and
+            `validate()` line to inspect.
+
+            Work narrowly to keep this review cheap — do NOT scan the whole repo.
 
             Your job:
             1. Read the issue:
                  gh issue view ${{ github.event.issue.number }}
-            2. Identify the task by its `task_id` (stated in the issue) and find
-               the corresponding task class and its `validate()` method under
-               tasks/ (and any helpers under validators/).
+            2. Open ONLY the file named in the issue's "Checker source" line and
+               read that task's `validate()` method (plus any single helper it
+               directly imports from validators/ if you must). Do not grep or
+               glob the wider tree unless that line is missing from the issue.
             3. Decide, strictly from the evidence in the issue, whether the
                checker logic is WRONG (e.g. wrong device-naming, wrong path,
                wrong grep pattern, an inverted condition, an off-by-one, a bad
@@ -65,7 +71,7 @@ jobs:
                  gh issue comment ${{ github.event.issue.number }} --body "..."
             5. If — and only if — the checker is genuinely wrong:
                  - create a branch  fix/dispute-<task_id>-${{ github.event.issue.number }}
-                 - implement the minimal correct fix to the validator/task
+                 - implement the minimal correct fix to that validator/task
                  - run `python3 -m pytest -q` and make sure it passes
                  - commit and open a PR whose body says
                    "Closes #${{ github.event.issue.number }}", explaining the bug

--- a/core/dispute.py
+++ b/core/dispute.py
@@ -165,6 +165,42 @@ def issue_url(tr, body, max_url=7000):
     return build(title)  # extreme fallback: title only
 
 
+def resolve_source(category, task_id):
+    """Locate the task's source so the reviewer opens ONE file, not the repo.
+
+    Returns (relpath, classname, validate_line) or (None, None, None). Task ids
+    are assigned in __init__, so we instantiate candidate classes (cheap; no
+    generate()) and match on .id.
+    """
+    try:
+        import inspect
+        from tasks.registry import TaskRegistry
+        TaskRegistry.initialize()
+
+        classes = list(TaskRegistry.get_tasks_by_category(category) or [])
+        if not classes:  # unknown/blank category — fall back to a full scan
+            for cat in TaskRegistry.get_all_categories():
+                classes.extend(TaskRegistry.get_tasks_by_category(cat))
+
+        for cls in classes:
+            try:
+                if getattr(cls(), 'id', None) != task_id:
+                    continue
+            except Exception:
+                continue
+            src = inspect.getsourcefile(cls) or inspect.getfile(cls)
+            rel = os.path.relpath(src, REPO_ROOT)
+            line = None
+            try:
+                line = inspect.getsourcelines(cls.validate)[1]
+            except Exception:
+                pass
+            return rel, cls.__name__, line
+    except Exception:
+        pass
+    return None, None, None
+
+
 def collect_evidence(category, extra_commands=None):
     """Gather (display, rc, output) tuples for the category + any extra commands."""
     evidence = []
@@ -190,6 +226,14 @@ def build_report(tr, disputed, argument, evidence):
     lines.append(f"- **Scored:** {tr.get('score', '?')}/{tr.get('max_score', '?')} "
                  f"({'PASSED' if tr.get('passed') else 'FAILED'})")
     lines.append(f"- **Filed:** {datetime.now().isoformat(timespec='seconds')}")
+    # Point the reviewer straight at the checker so it reads one file, not the
+    # whole repo (keeps the review cheap).
+    rel, classname, vline = resolve_source(tr.get('category', ''), tr.get('task_id', ''))
+    if rel:
+        loc = f"`{rel}` → class `{classname}`"
+        if vline:
+            loc += f", `validate()` around line {vline}"
+        lines.append(f"- **Checker source:** {loc}")
     lines.append("")
     lines.append("### Task as presented to the candidate")
     lines.append("```")


### PR DESCRIPTION
## What
Make the checker-dispute AI review cheaper by pointing it straight at the disputed checker instead of letting it search `tasks/`.

## Answering the concern
Today the reviewer reads the issue (which already has the task_id, checks, argument, evidence) and then greps/globs to *find* the task's `validate()`. It doesn't read the whole repo, but that discovery step wastes tokens on something we already know when the dispute is filed.

## Change
- `dispute.resolve_source()` — resolve `task_id` → exact **file, class, and `validate()` line** locally (instantiate candidate classes, match on `.id`; no `generate()`), and stamp a **"Checker source"** line into the issue body.
- Workflow prompt now instructs the reviewer to open **only that file** (no repo-wide grep/glob unless the line is missing) and adds `--max-turns 30` as a hard cost cap.

Net: the agent opens one file and comments, instead of exploring the tree — same verdict/fix, much lower credit per dispute.

## Note
The workflow half only takes effect once merged to `master` (issue events run master's copy). The `dispute.py` half takes effect on the exam box after you pull — new issues will carry the "Checker source" line.

## Test
- `152 passed`
- Verified `resolve_source('repos','repo_gpg_001') → tasks/repos.py, ConfigureRepoGPGTask, line 318` and the line appears in the rendered report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)