### PR TITLE
Fix ACL vs autofs collision (both fought over /data)

### DIFF
--- a/core/lab_cleanup.py
+++ b/core/lab_cleanup.py
@@ -30,7 +30,7 @@ DIR_ARTIFACTS = [
     '/mnt/lvm*',
     '/opt/appdata', '/opt/webdata',
     '/srv/nfs', '/srv/samba', '/srv/website', '/srv/web', '/srv/webapp',
-    '/srv/shares', '/srv/ftp',
+    '/srv/shares', '/srv/ftp', '/srv/acltest*',
     '/home/guests',
 ]
 

--- a/tasks/permissions.py
+++ b/tasks/permissions.py
@@ -602,7 +602,10 @@ class DefaultACLTask(BaseTask):
     def generate(self, **params):
         """Generate default ACL task."""
         dir_suffix = random.randint(1, 99)
-        self.dir_path = params.get('dir', f'/data/acltest{dir_suffix}')
+        # Use /srv (never a mount point in this sim) rather than /data — the
+        # autofs and boot-recovery tasks claim /data as an auto/rescue mount,
+        # which would shadow an ACL directory nested under it.
+        self.dir_path = params.get('dir', f'/srv/acltest{dir_suffix}')
         self.acl_user = params.get('user', random.choice(['webadmin', 'developer', 'operator']))
         self.acl_perms = params.get('perms', random.choice(['rwx', 'rw-', 'r-x']))
 


### PR DESCRIPTION
## The bug
In one exam, two tasks fought in the validator because they shared `/data`:
- **DefaultACLTask** created its inheritance directory at `/data/acltestN`.
- **ConfigureAutofsTask** (and a boot-recovery task) claim `/data` as an auto/rescue **mount point**.

Once autofs mounts over `/data`, anything nested under it — the ACL directory — is shadowed, so the ACL checks can't see it.

## The fix
- `DefaultACLTask` now uses **`/srv/acltestN`**. `/srv` is never a mount point in this sim, so nothing shadows it. Description, hints, and validators all key off `self.dir_path`, so the change propagates cleanly.
- Added `/srv/acltest*` to `lab_cleanup` `DIR_ARTIFACTS`. Bonus: the old `/data/acltest*` dirs were **never cleanable** (`/data` isn't an allowed cleanup prefix), so they leaked between sessions; `/srv` *is* allowed, so they're now removed on reset.

## Test
- `152 passed`
- Verified generation yields `/srv/acltestNN` and `lab_cleanup._is_safe()` accepts it.

> Note: pushed from an environment with a skewed clock (TLS cert briefly read as "not yet valid"); commit contents are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)