### PR TITLE
Full System Reset: strip box back to a basic RHEL install

### DIFF
--- a/core/full_reset.py
+++ b/core/full_reset.py
@@ -1,0 +1,480 @@
+"""
+Full system reset — return a RHEL box to a near-blank, exam-ready state.
+
+Unlike the lighter "System Reset" (which removes only known practice
+artifacts), this strips the machine of the extra software and configuration a
+box accumulates — third-party DNF repos, Flatpak apps/remotes, leftover lab
+files, practice users, scheduled jobs, autofs maps, tuned changes, NFS exports
+— so what remains is a basic RHEL install.
+
+Deliberately PRESERVED (never touched here):
+  * the rhcsa-simulator itself (its repo directory and data)
+  * GitHub/SSH connectivity: ~/.config/gh, ~/.ssh, git config, and the
+    subscription-manager RHEL system repos (rhel-*, redhat-*, redhat.repo)
+  * networking, firewall, SELinux, and the system disk / system swap
+  * login users below UID 1000 and any non-practice accounts
+
+Everything is best-effort and guarded: one failing step never aborts the rest.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+
+logger_prefix = "full_reset"
+
+# The simulator's own tree — must survive the reset.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# RHEL system repo files kept as-is (managed by subscription-manager).
+_KEEP_REPO_FILES = {'redhat.repo'}
+_KEEP_REPO_PREFIXES = ('rhel-', 'redhat-')
+
+# Practice user/group name patterns — must mirror the generators in tasks/.
+# Prefix + 1-2 digit suffix, or a small set of fixed names. Never matches a
+# plain word without the numeric/fixed marker, so real accounts are safe.
+_USER_PAT_NUMBERED = re.compile(
+    r'^('
+    r'alice|bob|carol|dave|eve|frank|grace|hank|'
+    r'anna|ben|clara|dan|ella|finn|gina|hugo|iris|jake|'
+    r'staffuser|ageuser|operator|locktest|removeuser|shelluser|troubleuser|'
+    r'(?:nginx|redis|tomcat|grafana|prometheus|elasticsearch|kafka|rabbitmq|consul|vault)svc|'
+    r'appsvc|mailsvc|websvc|dbsvc|ftpsvc|logsvc|'
+    r'loginuser|sudouser|'
+    r'user'
+    r')\d{1,2}$'
+)
+_USER_PAT_FIXED = re.compile(r'^sudopractice$')
+_GROUP_PAT = re.compile(
+    r'^(devteam|qagroup|opsgroup|infrateam|secteam|datateam|cloudops)\d{2}$'
+)
+
+# fstab lines that belong to practice artifacts (removed with a backup kept).
+_FSTAB_PATTERNS = [
+    re.compile(r'/var/lib/rhcsa-simulator/loops/'),
+    re.compile(r'/dev/loop\d+'),
+    re.compile(r'\s/swapfile\b'),
+    re.compile(r'\s/var/swap\b'),
+    re.compile(r'\s/swap\.img\b'),
+    re.compile(r'\s/tmp/swap\S*'),
+    re.compile(r'\s/opt/swap\S*'),
+    re.compile(r'RHCSA-FAULT'),
+]
+
+
+def _run(cmd, timeout=180):
+    """Run a command, returning (rc, combined_output). Never raises."""
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return r.returncode, ((r.stdout or '') + (r.stderr or '')).strip()
+    except FileNotFoundError:
+        return 127, '(command not found)'
+    except subprocess.TimeoutExpired:
+        return 124, '(timed out)'
+    except Exception as e:  # pragma: no cover - defensive
+        return 1, f'(error: {e})'
+
+
+def _noop(_msg):
+    pass
+
+
+# ── Repos ────────────────────────────────────────────────────────────────────
+
+def list_nondefault_repos():
+    """Third-party .repo files under /etc/yum.repos.d (RHEL system repos kept)."""
+    out, d = [], '/etc/yum.repos.d'
+    try:
+        for f in sorted(os.listdir(d)):
+            if not f.endswith('.repo'):
+                continue
+            if f in _KEEP_REPO_FILES or f.startswith(_KEEP_REPO_PREFIXES):
+                continue
+            out.append(os.path.join(d, f))
+    except Exception:
+        pass
+    return out
+
+
+def remove_repos(progress=_noop):
+    repos = list_nondefault_repos()
+    removed = 0
+    for rf in repos:
+        try:
+            os.remove(rf)
+            removed += 1
+            progress(f"  removed repo {os.path.basename(rf)}")
+        except OSError as e:
+            progress(f"  could not remove {rf}: {e}")
+    if not repos:
+        progress("  no third-party repos")
+    return removed
+
+
+# ── Flatpak ──────────────────────────────────────────────────────────────────
+
+def flatpak_available():
+    return shutil.which('flatpak') is not None
+
+
+def _flatpak_column(kind):
+    """Return names from `flatpak <kind> --columns=…`, header-stripped."""
+    if kind == 'apps':
+        rc, out = _run(['flatpak', 'list', '--app', '--columns=application'])
+    else:
+        rc, out = _run(['flatpak', 'remotes', '--columns=name'])
+    if rc != 0:
+        return []
+    names = []
+    for line in out.splitlines():
+        s = line.strip()
+        if not s or s.lower() in ('application', 'name'):
+            continue
+        names.append(s.split()[0])
+    return names
+
+
+def list_flatpak_apps():
+    return _flatpak_column('apps') if flatpak_available() else []
+
+
+def list_flatpak_remotes():
+    return _flatpak_column('remotes') if flatpak_available() else []
+
+
+def remove_flatpak(progress=_noop):
+    """Uninstall every Flatpak app + unused runtimes, then drop all remotes."""
+    if not flatpak_available():
+        progress("  flatpak not installed")
+        return 0
+    count = 0
+    apps = list_flatpak_apps()
+    for app in apps:
+        rc, out = _run(['flatpak', 'uninstall', '-y', '--noninteractive', app])
+        if rc == 0:
+            count += 1
+            progress(f"  uninstalled app {app}")
+        else:
+            progress(f"  could not uninstall {app}: {out.splitlines()[-1] if out else rc}")
+    # Remove now-unused runtimes/extensions left behind.
+    _run(['flatpak', 'uninstall', '-y', '--unused', '--noninteractive'])
+    for remote in list_flatpak_remotes():
+        rc, _ = _run(['flatpak', 'remote-delete', '--force', remote])
+        if rc == 0:
+            progress(f"  removed remote {remote}")
+    return count
+
+
+# ── DNF cache ────────────────────────────────────────────────────────────────
+
+def clean_dnf(progress=_noop):
+    rc, _ = _run(['dnf', 'clean', 'all'])
+    progress("  dnf cache cleaned" if rc == 0 else "  dnf clean reported an error")
+    return rc == 0
+
+
+# ── /usr/local/bin scripts ───────────────────────────────────────────────────
+
+def list_local_scripts():
+    d = '/usr/local/bin'
+    try:
+        return [os.path.join(d, f) for f in os.listdir(d)
+                if f.endswith('.sh') and os.path.isfile(os.path.join(d, f))]
+    except Exception:
+        return []
+
+
+def remove_local_scripts(progress=_noop):
+    removed = 0
+    for s in list_local_scripts():
+        try:
+            os.remove(s)
+            removed += 1
+            progress(f"  removed script {s}")
+        except OSError as e:
+            progress(f"  could not remove {s}: {e}")
+    return removed
+
+
+# ── Scheduled work ───────────────────────────────────────────────────────────
+
+def clear_scheduled(progress=_noop):
+    # root crontab
+    rc, out = _run(['crontab', '-l', '-u', 'root'])
+    if rc == 0 and out.strip():
+        _run(['crontab', '-r', '-u', 'root'])
+        progress("  cleared root crontab")
+    # at jobs
+    rc, out = _run(['atq'])
+    if rc == 0 and out.strip():
+        for line in out.splitlines():
+            parts = line.split()
+            if parts:
+                _run(['atrm', parts[0]])
+        progress("  removed pending at jobs")
+
+
+# ── Tuned ────────────────────────────────────────────────────────────────────
+
+def reset_tuned(progress=_noop):
+    rc, rec = _run(['tuned-adm', 'recommend'])
+    profile = rec.strip() if rc == 0 and rec.strip() else 'balanced'
+    rc, _ = _run(['tuned-adm', 'profile', profile])
+    if rc == 0:
+        progress(f"  tuned profile reset to '{profile}'")
+
+
+# ── Autofs ───────────────────────────────────────────────────────────────────
+
+def clean_autofs(progress=_noop):
+    changed = False
+    if _run(['systemctl', 'is-active', '--quiet', 'autofs'])[0] == 0:
+        _run(['systemctl', 'stop', 'autofs'])
+    # auto.master non-default lines
+    auto_master = '/etc/auto.master'
+    defaults = {'+dir:/etc/auto.master.d', '+auto.master'}
+    try:
+        with open(auto_master) as f:
+            lines = f.readlines()
+        keep = [ln for ln in lines
+                if not ln.strip() or ln.strip().startswith('#')
+                or ln.strip() in defaults]
+        if len(keep) != len(lines):
+            with open(auto_master, 'w') as f:
+                f.writelines(keep)
+            changed = True
+            progress("  cleaned /etc/auto.master")
+    except FileNotFoundError:
+        pass
+    except Exception as e:
+        progress(f"  auto.master error: {e}")
+    # drop-ins + extra maps
+    for di in _glob('/etc/auto.master.d/*.autofs'):
+        try:
+            os.remove(di); changed = True; progress(f"  removed {di}")
+        except OSError:
+            pass
+    try:
+        for f in os.listdir('/etc'):
+            if (f.startswith('auto.') and f not in
+                    ('auto.master', 'auto.misc', 'auto.master.d')
+                    and os.path.isfile(f'/etc/{f}')):
+                os.remove(f'/etc/{f}'); changed = True
+                progress(f"  removed /etc/{f}")
+    except Exception:
+        pass
+    return changed
+
+
+def _glob(pattern):
+    import glob
+    return glob.glob(pattern)
+
+
+# ── Practice users / groups ──────────────────────────────────────────────────
+
+def _is_practice_user(name):
+    return bool(_USER_PAT_NUMBERED.match(name) or _USER_PAT_FIXED.match(name))
+
+
+def list_practice_users():
+    users = []
+    try:
+        import pwd
+        for pw in pwd.getpwall():
+            if pw.pw_uid >= 1000 and _is_practice_user(pw.pw_name):
+                users.append(pw.pw_name)
+    except Exception:
+        pass
+    return users
+
+
+def list_practice_groups():
+    groups = []
+    try:
+        import grp
+        for gr in grp.getgrall():
+            if gr.gr_gid >= 1000 and _GROUP_PAT.match(gr.gr_name):
+                groups.append(gr.gr_name)
+    except Exception:
+        pass
+    return groups
+
+
+def remove_practice_users_groups(progress=_noop):
+    n = 0
+    for u in list_practice_users():
+        _run(['userdel', '-r', u])
+        n += 1
+        progress(f"  deleted user {u}")
+    for g in list_practice_groups():
+        _run(['groupdel', g])
+        progress(f"  deleted group {g}")
+    return n
+
+
+# ── Practice swap + fstab ────────────────────────────────────────────────────
+
+def _system_swap(device):
+    return any(x in device for x in ('/dev/nvme', 'rhel', 'dm-'))
+
+
+def remove_practice_swap(progress=_noop):
+    entries = []
+    try:
+        with open('/proc/swaps') as f:
+            for line in f.readlines()[1:]:
+                parts = line.split()
+                if len(parts) >= 2 and not _system_swap(parts[0]):
+                    entries.append((parts[0], parts[1]))
+    except Exception:
+        pass
+    for device, stype in entries:
+        _run(['swapoff', device])
+        if stype == 'file' and os.path.exists(device):
+            try:
+                os.remove(device)
+                progress(f"  removed swap file {device}")
+            except OSError:
+                pass
+        else:
+            progress(f"  deactivated swap {device}")
+    return len(entries)
+
+
+def clean_fstab(progress=_noop):
+    """Strip practice lines from /etc/fstab, keeping a one-shot backup."""
+    try:
+        with open('/etc/fstab') as f:
+            lines = f.readlines()
+    except Exception:
+        return False
+    keep, dropped = [], 0
+    for line in lines:
+        s = line.strip()
+        if not s or s.startswith('#'):
+            keep.append(line); continue
+        if any(p.search(line) for p in _FSTAB_PATTERNS):
+            dropped += 1
+        else:
+            keep.append(line)
+    if dropped:
+        try:
+            shutil.copy2('/etc/fstab', '/etc/fstab.rhcsa-bak')
+            with open('/etc/fstab', 'w') as f:
+                f.writelines(keep)
+            progress(f"  removed {dropped} practice fstab line(s) (backup: /etc/fstab.rhcsa-bak)")
+        except Exception as e:
+            progress(f"  fstab cleanup error: {e}")
+            return False
+    return dropped > 0
+
+
+# ── Preview + orchestration ──────────────────────────────────────────────────
+
+def preview():
+    """Return a dict of enumerable things this reset would remove, for a
+    confirmation screen. Non-enumerable steps (dnf clean, tuned) are omitted."""
+    from core import lab_cleanup
+    data = {
+        'Third-party repos': list_nondefault_repos(),
+        'Flatpak apps': list_flatpak_apps(),
+        'Flatpak remotes': list_flatpak_remotes(),
+        'Scripts (/usr/local/bin)': list_local_scripts(),
+        'Practice users': list_practice_users(),
+        'Practice groups': list_practice_groups(),
+    }
+    try:
+        data['Lab files/dirs'] = lab_cleanup.clean(dry_run=True)
+    except Exception:
+        data['Lab files/dirs'] = []
+    return data
+
+
+def run_all(progress=_noop, remove_users=True):
+    """Execute the full reset. Returns a summary dict. Never raises."""
+    summary = {}
+
+    def step(name, fn):
+        progress("")
+        progress(name)
+        try:
+            summary[name] = fn()
+        except Exception as e:
+            progress(f"  step failed: {e}")
+            summary[name] = None
+
+    # 1. Known lab artifacts (files, dirs, mounts).
+    def _lab():
+        from core import lab_cleanup
+        done = lab_cleanup.clean(dry_run=False)
+        progress(f"  removed {len(done)} lab artifact(s)")
+        return len(done)
+    step("Lab leftover files", _lab)
+
+    # 2. Practice disks / LVM (loop images + structures).
+    def _disks():
+        from utils import helpers
+        # Unmount any mounted loop partitions first.
+        rc, out = _run(['lsblk', '-rno', 'NAME,MOUNTPOINT'])
+        for line in out.splitlines():
+            parts = line.split()
+            if len(parts) == 2 and 'loop' in parts[0] and parts[1].startswith('/'):
+                _run(['umount', '-f', f"/dev/{parts[0]}"])
+        ok = helpers.cleanup_practice_devices()
+        progress("  practice disks removed" if ok else "  no practice disks / cleanup errors")
+        return ok
+    step("Practice disks / LVM", _disks)
+
+    # 3. Practice swap + fstab.
+    step("Practice swap", lambda: remove_practice_swap(progress))
+    step("fstab cleanup", lambda: clean_fstab(progress))
+
+    # 4. Third-party repos + dnf cache.
+    step("Third-party DNF repos", lambda: remove_repos(progress))
+    step("DNF cache", lambda: clean_dnf(progress))
+
+    # 5. Flatpak apps + remotes.
+    step("Flatpak apps / remotes", lambda: remove_flatpak(progress))
+
+    # 6. Scripts, scheduled work, tuned, autofs.
+    step("Scripts in /usr/local/bin", lambda: remove_local_scripts(progress))
+    step("Scheduled jobs (cron/at)", lambda: clear_scheduled(progress))
+    step("Tuned profile", lambda: reset_tuned(progress))
+    step("Autofs maps", lambda: clean_autofs(progress))
+
+    # 7. Remote NFS exports we provisioned.
+    def _nfs():
+        try:
+            from core import nfs_server
+            if not nfs_server.load_config():
+                progress("  no NFS server configured")
+                return 0
+            n = nfs_server.unmount_client_mounts()
+            nfs_server.remove_exports()
+            progress(f"  NFS exports removed (unmounted {n} client mount(s))")
+            return 1
+        except Exception as e:
+            progress(f"  NFS teardown error: {e}")
+            return 0
+    step("Remote NFS exports", _nfs)
+
+    # 8. Practice users / groups (optional).
+    if remove_users:
+        step("Practice users / groups",
+             lambda: remove_practice_users_groups(progress))
+
+    # 9. Restore any active troubleshooting fault.
+    def _fault():
+        try:
+            from tasks.troubleshooting import restore_any_active_fault
+            had, msg = restore_any_active_fault()
+            if had:
+                progress(f"  restored: {msg}")
+            return had
+        except Exception:
+            return False
+    step("Active fault restore", _fault)
+
+    return summary

--- a/core/menu.py
+++ b/core/menu.py
@@ -221,6 +221,7 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
         print("  5. Populate Practice Environment (DNF history)")
         print(f"  6. Configure remote NFS server for NFS tasks ({nfs_status})")
         print("  7. Clean lab leftover files (remove task artifacts)")
+        print("  8. Full System Reset (strip box back to a basic RHEL install)")
         print("  0. Return to Menu")
         print()
 
@@ -240,6 +241,8 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             self.configure_nfs_server()
         elif choice == '7':
             self.clean_lab_leftovers()
+        elif choice == '8':
+            self.full_system_reset()
 
     def clean_lab_leftovers(self):
         """Preview and remove leftover task artifacts (files/dirs/mounts the
@@ -274,6 +277,70 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             if line.startswith('FAILED'):
                 print(fmt.warning(f"  {line}"))
         input("\nPress Enter to return...")
+
+    def full_system_reset(self):
+        """Strip the box back to a basic RHEL install: remove third-party repos,
+        Flatpak apps/remotes, lab files, practice users, scheduled jobs, autofs
+        maps, tuned changes, practice disks/swap and NFS exports. Preserves the
+        simulator, GitHub/SSH connectivity, networking, SELinux and the OS."""
+        from core import full_reset
+        from utils.helpers import confirm_action
+
+        fmt.clear_screen()
+        fmt.print_header("FULL SYSTEM RESET")
+
+        print(fmt.warning("This returns the machine to a BASIC RHEL install. It removes:"))
+        print("  - all third-party DNF repos (RHEL system repos are kept)")
+        print("  - all Flatpak apps and remotes")
+        print("  - leftover lab files, practice users/groups, practice disks & swap")
+        print("  - scheduled jobs, autofs maps, tuned changes, remote NFS exports")
+        print()
+        print(fmt.success("PRESERVED: the rhcsa-simulator, GitHub/SSH auth (gh, ~/.ssh,"))
+        print(fmt.success("git config), networking, firewall, SELinux, and the OS itself."))
+        print()
+
+        # Show exactly what will go before asking.
+        print(fmt.dim("Scanning system..."))
+        data = full_reset.preview()
+        total = 0
+        print()
+        print(fmt.bold("Will remove:"))
+        for label, items in data.items():
+            print(f"  {label}: {len(items)}")
+            for it in items[:8]:
+                print(fmt.dim(f"      {it}"))
+            if len(items) > 8:
+                print(fmt.dim(f"      … and {len(items) - 8} more"))
+            total += len(items)
+        print(fmt.dim("  (plus dnf cache, cron/at jobs, autofs, tuned, NFS exports)"))
+        print()
+
+        remove_users = confirm_action(
+            "Also delete practice users/groups (UID/GID >= 1000)?", default=True)
+
+        print()
+        print(fmt.warning("This is destructive and cannot be undone."))
+        confirm = input("Type 'RESET' to proceed (anything else cancels): ").strip()
+        if confirm != 'RESET':
+            print(fmt.dim("Cancelled — nothing changed."))
+            input("\nPress Enter to return...")
+            return
+
+        print()
+        print(fmt.bold("Running full system reset..."))
+
+        def progress(msg):
+            print(msg)
+
+        summary = full_reset.run_all(progress=progress, remove_users=remove_users)
+
+        print()
+        print("=" * 50)
+        print(fmt.success("Full system reset complete."))
+        print(fmt.info("The box is back to a basic RHEL state; simulator and GitHub"))
+        print(fmt.info("connectivity were left intact."))
+        print()
+        input("Press Enter to return...")
 
     def configure_nfs_server(self):
         """SSH into a user-named RHEL box and provision it as a real NFS server

--- a/tests/unit/test_full_reset.py
+++ b/tests/unit/test_full_reset.py
@@ -1,0 +1,62 @@
+"""
+Safety tests for core.full_reset — this reset is destructive, so the
+classification logic that decides what gets removed must never match real
+system repos, real accounts, or system swap.
+"""
+
+from core import full_reset as fr
+
+
+class TestPracticeUserMatching:
+    def test_matches_generated_practice_users(self):
+        for name in ('user5', 'user12', 'alice7', 'bob10', 'nginxsvc3',
+                     'sudopractice', 'operator4'):
+            assert fr._is_practice_user(name), name
+
+    def test_never_matches_real_accounts(self):
+        for name in ('root', 'justbest23', 'admin', 'alice', 'bob',
+                     'nginx', 'postgres', 'user', 'user123'):
+            assert not fr._is_practice_user(name), name
+
+
+class TestPracticeGroupMatching:
+    def test_matches_generated_groups(self):
+        for name in ('devteam03', 'qagroup12', 'opsgroup99'):
+            assert fr._GROUP_PAT.match(name), name
+
+    def test_never_matches_system_groups(self):
+        for name in ('wheel', 'root', 'users', 'devteam', 'devteam3'):
+            assert not fr._GROUP_PAT.match(name), name
+
+
+class TestRepoKeepList:
+    def test_system_repos_are_kept(self, tmp_path, monkeypatch):
+        repo_dir = tmp_path
+        for f in ('redhat.repo', 'rhel-baseos.repo', 'redhat-extra.repo',
+                  'docker-ce.repo', 'epel.repo', 'notes.txt'):
+            (repo_dir / f).write_text('[x]\n')
+
+        real_listdir = fr.os.listdir
+        monkeypatch.setattr(fr.os, 'listdir',
+                            lambda d: real_listdir(repo_dir) if d == '/etc/yum.repos.d' else real_listdir(d))
+        found = {fr.os.path.basename(p) for p in fr.list_nondefault_repos()}
+        assert found == {'docker-ce.repo', 'epel.repo'}
+
+
+class TestSystemSwapGuard:
+    def test_system_swap_devices_are_protected(self):
+        for dev in ('/dev/nvme0n1p3', '/dev/mapper/rhel-swap', '/dev/dm-1'):
+            assert fr._system_swap(dev), dev
+
+    def test_practice_swap_is_not_protected(self):
+        for dev in ('/swapfile', '/var/swap', '/dev/loop2p1'):
+            assert not fr._system_swap(dev), dev
+
+
+class TestPreviewShape:
+    def test_preview_returns_expected_categories(self):
+        data = fr.preview()
+        for key in ('Third-party repos', 'Flatpak apps', 'Practice users',
+                    'Lab files/dirs'):
+            assert key in data
+            assert isinstance(data[key], list)


### PR DESCRIPTION
## What
New **Setup → 8. Full System Reset** that returns a RHEL box to a near-blank, exam-ready state. The existing "System Reset" only clears known practice artifacts; this goes further.

## Removes
- **All third-party DNF repos** (RHEL system repos `rhel-*`, `redhat-*`, `redhat.repo` kept) + `dnf clean all`
- **All Flatpak apps and remotes** (+ unused runtimes)
- Leftover lab files/dirs/mounts
- Practice disks/LVM and practice swap (keeps a `/etc/fstab.rhcsa-bak` backup)
- Practice users/groups (optional prompt; only UID/GID ≥ 1000 matching a generator pattern)
- Root cron + at jobs, autofs maps, tuned changes
- Any remote NFS exports we provisioned

## Preserves (never touched)
The **rhcsa-simulator itself**, **GitHub/SSH connectivity** (`~/.config/gh`, `~/.ssh`, git config), networking, firewall, SELinux, the OS, and all non-practice accounts.

## Safety
- `preview()` lists exactly what will be removed before anything happens.
- Requires typing **`RESET`** to proceed.
- Every step is guarded — one failure never aborts the rest.
- New `tests/unit/test_full_reset.py` locks down the destructive classifiers: they must never match real repos (`redhat.repo`, `rhel-*`), real accounts (`root`, `nginx`, `user123`), or system swap (`rhel-swap`, `nvme…`).

## Test
`160 passed` (152 existing + 8 new).

> Pushed from an environment with a skewed clock (TLS cert briefly read as "not yet valid"); commit contents are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)