### PR TITLE
Raise dispute review turn cap 30->80 (was killing reviews)

### DIFF
--- a/.github/workflows/checker-dispute.yml
+++ b/.github/workflows/checker-dispute.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -42,7 +42,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: >-
             --allowedTools "Bash,Read,Edit,Write,Grep,Glob"
-            --max-turns 30
+            --max-turns 80
           prompt: |
             A candidate using the RHCSA exam simulator has disputed a validator
             ("checker") result. The dispute is GitHub issue #${{ github.event.issue.number }}


### PR DESCRIPTION
## What happened
The dispute review failed with:
```
Action failed with error: Claude execution failed: Reached maximum number of turns (30)
```
That's the `--max-turns 30` guard I added in #28. "Turns" = individual tool calls, and a real review uses them fast: read the issue, read the checker, post a comment, and — when the checker is wrong — create a branch, edit, run `pytest`, commit, and open a PR. 30 cut it off before it could even post a verdict.

## Fix
- `--max-turns 30 → 80`. The actual credit saver is the scoped, one-file prompt (also from #28) — the cap is only meant to stop a runaway loop, so 80 gives real reviews room without removing the safety net.
- `actions/checkout@v4 → v5` to clear the Node 20 deprecation warning (cosmetic; was not the failure).

## Note
Issue-triggered workflows run from **master**, so merge this before re-labeling. To retry a dispute: remove then re-add the `checker-dispute` label.

> Pushed from an environment with a skewed clock (TLS cert briefly "not yet valid"); commit contents unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)