### PR TITLE
Full reset: unmount all exam/practice mounts first

### DIFF
--- a/core/full_reset.py
+++ b/core/full_reset.py
@@ -314,6 +314,91 @@ def remove_practice_users_groups(progress=_noop):
     return n
 
 
+# ── Unmount everything practice-related ──────────────────────────────────────
+
+# Never unmount these — the OS/login/simulator depend on them.
+_PROTECTED_TARGETS = {
+    '/', '/boot', '/boot/efi', '/home', '/var', '/usr', '/opt', '/etc',
+    '/proc', '/sys', '/run', '/dev', '/dev/shm', '/tmp', '/var/tmp',
+}
+_PROTECTED_PREFIXES = ('/proc', '/sys', '/run', '/dev', '/boot', '/usr',
+                       '/var/lib/nfs', '/etc')
+# Targets where exam/practice filesystems get mounted.
+_PRACTICE_TARGET_PREFIXES = ('/mnt/', '/media/', '/srv/', '/data', '/export',
+                             '/shares', '/misc/', '/autofs')
+
+# System volume groups whose LVs must never be unmounted (mirror helpers).
+try:
+    from utils.helpers import _SYSTEM_VGS as _SYS_VGS
+except Exception:  # pragma: no cover - fallback if helpers changes
+    _SYS_VGS = {'rl', 'rl00', 'rhel', 'centos', 'fedora', 'almalinux', 'rocky'}
+
+
+def _dm_vg(source):
+    """Extract the VG name from a /dev/mapper/vg-lv or /dev/dm-* source."""
+    name = source.rsplit('/', 1)[-1]
+    # device-mapper doubles literal dashes; split on a single dash only.
+    vg = re.split(r'(?<!-)-(?!-)', name)[0].replace('--', '-')
+    return vg
+
+
+def _is_practice_mount(target, source, fstype):
+    if target in _PROTECTED_TARGETS or target.startswith(_PROTECTED_PREFIXES):
+        return False
+    if target == REPO_ROOT or target.startswith(REPO_ROOT + '/'):
+        return False
+    if fstype in ('nfs', 'nfs4'):
+        return True
+    if re.match(r'^/dev/loop\d+', source or ''):
+        return True
+    if (source or '').startswith(('/dev/mapper/', '/dev/dm-')):
+        return _dm_vg(source) not in _SYS_VGS
+    if target.startswith(_PRACTICE_TARGET_PREFIXES):
+        return True
+    return False
+
+
+def list_practice_mounts():
+    """Return [(target, source, fstype)] for non-system mounts, deepest first."""
+    rc, out = _run(['findmnt', '-rno', 'TARGET,SOURCE,FSTYPE'], timeout=15)
+    if rc != 0:
+        return []
+    mounts = []
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        target, source, fstype = parts[0], parts[1], parts[2]
+        if _is_practice_mount(target, source, fstype):
+            mounts.append((target, source, fstype))
+    # Unmount the deepest paths first so nested mounts come off cleanly.
+    mounts.sort(key=lambda m: m[0].count('/'), reverse=True)
+    return mounts
+
+
+def unmount_practice_mounts(progress=_noop):
+    """Unmount all exam/practice mounts (NFS, loop/LVM filesystems, practice
+    mount points) before disks are torn down. NFS goes straight to force+lazy so
+    a stale server can't hang us; others try a clean umount then fall back."""
+    mounts = list_practice_mounts()
+    n = 0
+    for target, source, fstype in mounts:
+        if fstype in ('nfs', 'nfs4'):
+            rc, _ = _run(['umount', '-f', '-l', '--', target], timeout=30)
+        else:
+            rc, _ = _run(['umount', '--', target], timeout=30)
+            if rc != 0:
+                rc, _ = _run(['umount', '-l', '--', target], timeout=30)
+        if rc == 0:
+            n += 1
+            progress(f"  unmounted {target} ({fstype} <- {source})")
+        else:
+            progress(f"  could not unmount {target}")
+    if not mounts:
+        progress("  no practice mounts active")
+    return n
+
+
 # ── Practice swap + fstab ────────────────────────────────────────────────────
 
 def _system_swap(device):
@@ -378,6 +463,7 @@ def preview():
     confirmation screen. Non-enumerable steps (dnf clean, tuned) are omitted."""
     from core import lab_cleanup
     data = {
+        'Active mounts to unmount': [f"{t}  ({fs})" for t, s, fs in list_practice_mounts()],
         'Third-party repos': list_nondefault_repos(),
         'Flatpak apps': list_flatpak_apps(),
         'Flatpak remotes': list_flatpak_remotes(),
@@ -404,6 +490,10 @@ def run_all(progress=_noop, remove_users=True):
         except Exception as e:
             progress(f"  step failed: {e}")
             summary[name] = None
+
+    # 0. Unmount every exam/practice mount first (NFS, loop/LVM filesystems,
+    #    practice mount points) so later steps aren't blocked by busy devices.
+    step("Unmount practice mounts", lambda: unmount_practice_mounts(progress))
 
     # 1. Known lab artifacts (files, dirs, mounts).
     def _lab():

--- a/tests/unit/test_full_reset.py
+++ b/tests/unit/test_full_reset.py
@@ -53,6 +53,29 @@ class TestSystemSwapGuard:
             assert not fr._system_swap(dev), dev
 
 
+class TestMountClassification:
+    def test_nfs_and_practice_filesystems_are_unmounted(self):
+        assert fr._is_practice_mount('/mnt/nfsdata', 'nfsserver:/exports/x', 'nfs4')
+        assert fr._is_practice_mount('/mnt/shared', 'nfsserver:/exports/y', 'nfs')
+        assert fr._is_practice_mount('/mnt/data', '/dev/loop2p1', 'xfs')
+        assert fr._is_practice_mount('/srv/acltest5', '/dev/loop3', 'ext4')
+        # non-system VG-backed LVM mount
+        assert fr._is_practice_mount('/mnt/lvm', '/dev/mapper/vg_test-lv_data', 'xfs')
+
+    def test_system_mounts_are_never_unmounted(self):
+        assert not fr._is_practice_mount('/', '/dev/mapper/rhel-root', 'xfs')
+        assert not fr._is_practice_mount('/boot', '/dev/nvme0n1p2', 'xfs')
+        assert not fr._is_practice_mount('/home', '/dev/mapper/rhel-home', 'xfs')
+        assert not fr._is_practice_mount('/boot/efi', '/dev/nvme0n1p1', 'vfat')
+        # a system-VG LV mounted somewhere odd must still be protected
+        assert not fr._is_practice_mount('/mnt/whatever', '/dev/mapper/rhel-var', 'xfs')
+
+    def test_dm_vg_parsing_handles_escaped_dashes(self):
+        assert fr._dm_vg('/dev/mapper/rhel-root') == 'rhel'
+        assert fr._dm_vg('/dev/mapper/vg_test-lv_data') == 'vg_test'
+        assert fr._dm_vg('/dev/mapper/vg--x-lv') == 'vg-x'
+
+
 class TestPreviewShape:
     def test_preview_returns_expected_categories(self):
         data = fr.preview()


### PR DESCRIPTION
## The bug
Full System Reset didn't unmount leftovers from a previous exam sim. `lab_cleanup` only unmounts *known manifest* paths and the disk step only unmounted loop *partitions*, so NFS client mounts and loop/LVM filesystems mounted at custom points survived — and could also block disk teardown.

## Fix
New `unmount_practice_mounts()` runs as **step 0** of `run_all()`. It enumerates mounts with `findmnt` and unmounts everything clearly non-system:
- `nfs` / `nfs4`
- `/dev/loopN`-backed filesystems
- non-system-VG LVM volumes
- anything mounted under practice prefixes (`/mnt`, `/srv`, `/data`, `/media`, `/export`, `/shares`, `/misc`)

Deepest paths are unmounted first (nested mounts); NFS uses **force + lazy** so a stale/dead server can't hang the reset.

## Safety
Hard guards — **never** unmounts `/`, `/boot`, `/home`, `/var`, `/usr`, `/etc`, the simulator's own tree, or any **system-VG** (`rhel`/`rl`/…) volume even if it's mounted at an odd path. Mounts now also appear in `preview()`.

New tests: NFS/loop/LVM get unmounted; system mounts and system-VG LVs never do; device-mapper dash-escaping (`vg--x-lv` → `vg-x`) parses correctly.

## Test
`163 passed` (11 in the full_reset suite).

> Pushed from an environment with a skewed clock (TLS cert briefly "not yet valid"); commit contents unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)