### PR TITLE
Clean up leftover systemd timers/services after exams

### DIFF
--- a/core/lab_cleanup.py
+++ b/core/lab_cleanup.py
@@ -60,6 +60,33 @@ FILE_ARTIFACTS = [
     '/home/loglink',
 ]
 
+# Candidate-created systemd units. Timer/service tasks ask the learner to build
+# a .timer + .service pair under /etc/systemd/system, so nothing tracks them for
+# teardown and they linger after an exam (the reported "scheduled-rotate"
+# leftovers). Fixed names plus the randomised families the generators emit.
+# Well-known system timers (fstrim, logrotate, dnf-makecache,
+# systemd-tmpfiles-clean) live under /usr/lib and never match these, so they are
+# never touched.
+_UNIT_DIR = '/etc/systemd/system'
+_UNIT_NAMES = ['backup-logs', 'cleanup-tmp', 'sync-data', 'health-check']
+_UNIT_PREFIXES = ['scheduled-', 'post-boot-', 'repeat-', 'converted-cron-']
+
+# Helper scripts those units reference (ExecStart=/usr/local/bin/*.sh). Removed
+# by EXACT match only — /usr/local/bin is not a simulator-owned scratch dir, so
+# we never glob it.
+LOCAL_SCRIPTS = [
+    '/usr/local/bin/backup-logs.sh', '/usr/local/bin/cleanup-tmp.sh',
+    '/usr/local/bin/sync-data.sh', '/usr/local/bin/health-check.sh',
+    '/usr/local/bin/generate-report.sh', '/usr/local/bin/rotate-logs.sh',
+    '/usr/local/bin/audit-check.sh', '/usr/local/bin/daily-digest.sh',
+    '/usr/local/bin/post-boot-init.sh', '/usr/local/bin/system-warmup.sh',
+    '/usr/local/bin/boot-check.sh', '/usr/local/bin/system-monitor.sh',
+    '/usr/local/bin/service-poll.sh', '/usr/local/bin/cache-sweep.sh',
+    '/usr/local/bin/health-ping.sh', '/usr/local/bin/migrated-task.sh',
+    '/usr/local/bin/maintenance.sh',
+]
+_LOCAL_SCRIPT_SET = set(LOCAL_SCRIPTS)
+
 # Hard safety floor: a target must live under one of these and not BE one of
 # them. Guards against a bad glob ever matching '/', '/etc', a top-level dir, etc.
 _ALLOWED_PREFIXES = ('/tmp/', '/mnt/', '/opt/', '/srv/', '/root/', '/home/', '/var/swap')
@@ -109,6 +136,25 @@ def _expand(pattern):
     return [pattern]
 
 
+def _find_units():
+    """Candidate-created unit files (.timer/.service) present under _UNIT_DIR."""
+    found, seen = [], set()
+    for ext in ('timer', 'service'):
+        patterns = [f'{_UNIT_DIR}/{name}.{ext}' for name in _UNIT_NAMES]
+        patterns += [f'{_UNIT_DIR}/{prefix}*.{ext}' for prefix in _UNIT_PREFIXES]
+        for pattern in patterns:
+            for path in _expand(pattern):
+                np = os.path.normpath(path)
+                # Confine to _UNIT_DIR itself (no nested drop-in dirs) and
+                # require the file to actually exist.
+                if np in seen or os.path.dirname(np) != _UNIT_DIR:
+                    continue
+                seen.add(np)
+                if _exists(np):
+                    found.append(np)
+    return sorted(found)
+
+
 def find_leftovers():
     """Existing artifact paths cleanup would act on (timeout-guarded)."""
     found = set()
@@ -116,6 +162,10 @@ def find_leftovers():
         for match in _expand(pattern):
             if _is_safe(match) and _exists(match):
                 found.add(os.path.normpath(match))
+    found.update(_find_units())
+    for path in LOCAL_SCRIPTS:
+        if _exists(path):
+            found.add(os.path.normpath(path))
     return sorted(found)
 
 
@@ -164,5 +214,41 @@ def clean(dry_run=False):
                 actions.append(f"would remove file {path}")
             elif _sh(['rm', '-rf', '--', path], 15) == 0:
                 actions.append(f"removed file {path}")
+
+    # 4. Candidate-created systemd units + their helper scripts.
+    actions.extend(clean_units(dry_run=dry_run))
+
+    return actions
+
+
+def clean_units(dry_run=False):
+    """Stop, disable and remove candidate-created systemd timers/services and
+    the helper scripts they reference, then daemon-reload. Returns action
+    strings. Every step is timeout-killable."""
+    actions = []
+    unit_files = _find_units()
+
+    if dry_run:
+        for path in unit_files:
+            actions.append(f"would remove unit {os.path.basename(path)}")
+    else:
+        for path in unit_files:
+            unit = os.path.basename(path)
+            # --now stops the running unit; disable clears enablement symlinks.
+            _sh(['systemctl', 'disable', '--now', unit], 15)
+            if _sh(['rm', '-f', '--', path], 10) == 0:
+                actions.append(f"removed unit {unit}")
+        if unit_files:
+            _sh(['systemctl', 'daemon-reload'], 20)
+            _sh(['systemctl', 'reset-failed'], 15)
+
+    # Helper scripts (exact-match guard — never glob /usr/local/bin).
+    for path in LOCAL_SCRIPTS:
+        if path not in _LOCAL_SCRIPT_SET or not _exists(path):
+            continue
+        if dry_run:
+            actions.append(f"would remove file {path}")
+        elif _sh(['rm', '-f', '--', path], 10) == 0:
+            actions.append(f"removed file {path}")
 
     return actions

--- a/tests/unit/test_lab_cleanup_units.py
+++ b/tests/unit/test_lab_cleanup_units.py
@@ -1,0 +1,87 @@
+"""
+Tests for candidate-created systemd unit / helper-script cleanup in lab_cleanup.
+
+These tasks build a .timer + .service pair under /etc/systemd/system with no
+per-task teardown, so lab_cleanup must sweep them by name/prefix. We point the
+unit dir and script list at a tmp dir so nothing on the host is touched, and use
+dry_run so no `systemctl` call is needed.
+"""
+
+import pytest
+
+from core import lab_cleanup
+
+
+@pytest.fixture
+def unit_dir(tmp_path, monkeypatch):
+    d = tmp_path / "systemd"
+    d.mkdir()
+    monkeypatch.setattr(lab_cleanup, "_UNIT_DIR", str(d))
+    return d
+
+
+def _touch(path):
+    path.write_text("# unit\n")
+
+
+class TestFindUnits:
+    def test_matches_fixed_names_and_prefixes(self, unit_dir):
+        _touch(unit_dir / "backup-logs.timer")
+        _touch(unit_dir / "backup-logs.service")
+        _touch(unit_dir / "scheduled-rotate.timer")     # reported leftover
+        _touch(unit_dir / "scheduled-rotate.service")
+        _touch(unit_dir / "post-boot-init.timer")
+        _touch(unit_dir / "repeat-poll.service")
+        _touch(unit_dir / "converted-cron-42.timer")
+
+        found = {p.rsplit("/", 1)[1] for p in lab_cleanup._find_units()}
+        assert "scheduled-rotate.timer" in found
+        assert "scheduled-rotate.service" in found
+        assert "backup-logs.timer" in found
+        assert "post-boot-init.timer" in found
+        assert "repeat-poll.service" in found
+        assert "converted-cron-42.timer" in found
+
+    def test_ignores_unrelated_and_wellknown_units(self, unit_dir):
+        _touch(unit_dir / "fstrim.timer")            # well-known system timer
+        _touch(unit_dir / "logrotate.timer")
+        _touch(unit_dir / "my-own-app.service")      # user's real unit
+        found = lab_cleanup._find_units()
+        assert found == []
+
+
+class TestDryRunReporting:
+    def test_reports_units_and_scripts(self, unit_dir, tmp_path, monkeypatch):
+        _touch(unit_dir / "scheduled-rotate.timer")
+        script = tmp_path / "rotate-logs.sh"
+        script.write_text("#!/bin/sh\n")
+        monkeypatch.setattr(lab_cleanup, "LOCAL_SCRIPTS", [str(script)])
+        monkeypatch.setattr(lab_cleanup, "_LOCAL_SCRIPT_SET", {str(script)})
+
+        actions = lab_cleanup.clean_units(dry_run=True)
+        assert any("scheduled-rotate.timer" in a for a in actions)
+        assert any(str(script) in a for a in actions)
+        # Dry run must not delete anything.
+        assert (unit_dir / "scheduled-rotate.timer").exists()
+        assert script.exists()
+
+    def test_find_leftovers_includes_units(self, unit_dir):
+        _touch(unit_dir / "scheduled-rotate.service")
+        leftovers = lab_cleanup.find_leftovers()
+        assert any(p.endswith("scheduled-rotate.service") for p in leftovers)
+
+
+class TestScriptGuard:
+    def test_script_removal_is_exact_match_only(self, tmp_path, monkeypatch):
+        keep = tmp_path / "important.sh"
+        keep.write_text("keep me\n")
+        target = tmp_path / "rotate-logs.sh"
+        target.write_text("#!/bin/sh\n")
+        # Only `target` is in the allowlist; `keep` must never be removed.
+        monkeypatch.setattr(lab_cleanup, "LOCAL_SCRIPTS", [str(target)])
+        monkeypatch.setattr(lab_cleanup, "_LOCAL_SCRIPT_SET", {str(target)})
+        monkeypatch.setattr(lab_cleanup, "_UNIT_DIR", str(tmp_path / "none"))
+
+        lab_cleanup.clean_units(dry_run=False)
+        assert not target.exists()
+        assert keep.exists()


### PR DESCRIPTION
## Problem

After an exam, candidate-created systemd **units and timers** were left behind (reported: `scheduled-rotate.timer`/`.service`). The timer/service tasks ask you to build a `.timer` + `.service` pair under `/etc/systemd/system`, but nothing tracked them for teardown — `lab_cleanup` only swept filesystem scratch paths (`/tmp`, `/mnt`, swap files, etc.), never units.

## Fix

`lab_cleanup.clean()` now also removes candidate-created units and their helper scripts:

- **Units** under `/etc/systemd/system` matching the generator name families: fixed names `backup-logs`, `cleanup-tmp`, `sync-data`, `health-check`, plus the randomised `scheduled-*`, `post-boot-*`, `repeat-*`, `converted-cron-*` families (both `.timer` and `.service`). Each is `systemctl disable --now`'d, the file removed, then a single `daemon-reload` + `reset-failed`.
- **Helper scripts** (`/usr/local/bin/*.sh` referenced by those units) removed by **exact match only** — `/usr/local/bin` is never globbed.

### Safety
- Well-known system timers (`fstrim`, `logrotate`, `dnf-makecache`, `systemd-tmpfiles-clean`) live under `/usr/lib` and don't match the name families, so they're never touched. The "enable a well-known timer" task's fault is still handled by its own env restore.
- Confined to `/etc/systemd/system` itself (no nested drop-in dirs).
- Every step is timeout-killable, matching the existing stale-mount-safe pattern.

Because `clean()` is the single choke point, this reaches **exam teardown, training session reset, menu System Reset, and Full System Reset** alike.

## Tests

New `tests/unit/test_lab_cleanup_units.py`: name/prefix matching, ignores well-known/unrelated units, dry-run reporting, `find_leftovers` inclusion, and the exact-match script guard. **180 pass** (+5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)