### PR TITLE
Fix package validators misreporting transient rpm/dnf timeouts (#44)

### DIFF
--- a/tasks/packages.py
+++ b/tasks/packages.py
@@ -13,6 +13,58 @@ from validators.safe_executor import execute_safe
 logger = logging.getLogger(__name__)
 
 
+# --- shared, transient-failure-aware package queries -------------------------
+# execute_safe returns success=False for a *timeout* too (COMMAND_TIMEOUT is 5s),
+# not only for a clean "package absent". rpm/dnf block on the rpmdb lock a
+# just-finished dnf transaction / subscription-manager still holds, so under the
+# 5s cap a transient timeout would otherwise be scored as a definitive verdict —
+# a candidate who did the work gets a false "not installed", and (worse) a
+# remove-task candidate gets a false "removed" for free. These helpers give the
+# query room (30s), retry once, and return a TRI-STATE:
+#   True  = confirmed (installed / matched)
+#   False = query ran cleanly and did not match (genuinely absent / no match)
+#   None  = the query itself could not be trusted (timed out / errored) — callers
+#           must treat this as "cannot grade yet", never as a pass or a fail.
+
+def _package_installed(pkg):
+    """rpm -q tri-state. rpm exits 1 with 'is not installed' only when it truly
+    ran and the package is absent; any other non-zero rc is inconclusive."""
+    for _ in range(2):
+        r = execute_safe(['rpm', '-q', pkg], timeout=30)
+        if r.returncode == 0 and pkg in r.stdout:
+            return True
+        if r.returncode == 1 and 'not installed' in (r.stdout + r.stderr).lower():
+            return False
+    return None
+
+
+def _group_installed(group_name, group_id):
+    """`dnf group list installed` tri-state (rc=0 even with no matches, so rc=0
+    output is authoritative; any non-zero rc is a failed query)."""
+    for _ in range(2):
+        r = execute_safe(['dnf', 'group', 'list', 'installed'], timeout=30)
+        if r.returncode == 0:
+            text = r.stdout.lower()
+            return (group_name.lower() in text) or (bool(group_id) and group_id in text)
+    return None
+
+
+def _downgrade_recorded(pkg):
+    """dnf history tri-state, scoped to pkg. `dnf history list <pkg>` returns
+    rc=0 even with no matches, so 'downgrade'/'undo' in rc=0 output can only come
+    from a transaction that touched this package."""
+    for _ in range(2):
+        r = execute_safe(['dnf', 'history', 'list', pkg], timeout=30)
+        if r.returncode == 0:
+            text = r.stdout.lower()
+            return ('downgrade' in text) or ('undo' in text)
+    return None
+
+
+_INCONCLUSIVE = ("query failed or timed out (rpmdb may be busy right after a dnf "
+                 "transaction). Wait a few seconds and grade again.")
+
+
 @TaskRegistry.register("packages")
 class InstallPackageTask(BaseTask):
     """Install a package using dnf."""
@@ -51,14 +103,16 @@ class InstallPackageTask(BaseTask):
 
     def validate(self):
         checks = []
-        total_points = 0
-        result = execute_safe(['rpm', '-q', self.package_name])
-        if result.success and self.package_name in result.stdout:
+        installed = _package_installed(self.package_name)
+        if installed is None:
+            checks.append(ValidationCheck("package_installed", False, 0,
+                                          f"Could not verify {self.package_name} — {_INCONCLUSIVE}", max_points=6))
+            return ValidationResult(self.id, False, 0, self.points, checks)
+        if installed:
             checks.append(ValidationCheck("package_installed", True, 6, f"Package {self.package_name} is installed"))
-            total_points += 6
-        else:
-            checks.append(ValidationCheck("package_installed", False, 0, f"Package {self.package_name} is not installed", max_points=6))
-        return ValidationResult(self.id, total_points >= 4, total_points, self.points, checks)
+            return ValidationResult(self.id, True, 6, self.points, checks)
+        checks.append(ValidationCheck("package_installed", False, 0, f"Package {self.package_name} is not installed", max_points=6))
+        return ValidationResult(self.id, False, 0, self.points, checks)
 
 
 @TaskRegistry.register("packages")
@@ -97,8 +151,14 @@ class RemovePackageTask(BaseTask):
 
     def validate(self):
         checks = []
-        result = execute_safe(['rpm', '-q', self.package_name])
-        if not result.success or 'not installed' in result.stdout.lower():
+        installed = _package_installed(self.package_name)
+        # None (query failed/timed out) must NOT be scored as "removed" — that
+        # would hand full points for work not done. Only a clean "absent" passes.
+        if installed is None:
+            checks.append(ValidationCheck("package_removed", False, 0,
+                                          f"Could not verify {self.package_name} — {_INCONCLUSIVE}", max_points=6))
+            return ValidationResult(self.id, False, 0, self.points, checks)
+        if installed is False:
             checks.append(ValidationCheck("package_removed", True, 6, f"Package {self.package_name} removed"))
             return ValidationResult(self.id, True, 6, self.points, checks)
         checks.append(ValidationCheck("package_removed", False, 0, f"Package {self.package_name} still installed", max_points=6))
@@ -148,15 +208,16 @@ class InstallPackageGroupTask(BaseTask):
 
     def validate(self):
         checks = []
-        total_points = 0
-        result = execute_safe(['dnf', 'group', 'list', 'installed'])
-        if result.success and (self.group_name.lower() in result.stdout.lower() or
-                               self.group_id in result.stdout.lower()):
+        state = _group_installed(self.group_name, self.group_id)
+        if state is None:
+            checks.append(ValidationCheck("group_installed", False, 0,
+                                          f"Could not verify group '{self.group_name}' — {_INCONCLUSIVE}", max_points=8))
+            return ValidationResult(self.id, False, 0, self.points, checks)
+        if state:
             checks.append(ValidationCheck("group_installed", True, 8, f"Package group '{self.group_name}' installed"))
-            total_points = 8
-        else:
-            checks.append(ValidationCheck("group_installed", False, 0, f"Package group '{self.group_name}' not installed", max_points=8))
-        return ValidationResult(self.id, total_points >= 6, total_points, self.points, checks)
+            return ValidationResult(self.id, True, 8, self.points, checks)
+        checks.append(ValidationCheck("group_installed", False, 0, f"Package group '{self.group_name}' not installed", max_points=8))
+        return ValidationResult(self.id, False, 0, self.points, checks)
 
 
 @TaskRegistry.register("packages")
@@ -355,11 +416,15 @@ class VerifyPackageIntegrityTask(BaseTask):
         checks = []
         total_points = 0
 
-        # Check package is installed
-        result = execute_safe(['rpm', '-q', self.package_name])
-        if result.success:
+        # Check package is installed (transient-failure aware)
+        installed = _package_installed(self.package_name)
+        if installed:
             checks.append(ValidationCheck("pkg_installed", True, 3, f"{self.package_name} is installed"))
             total_points += 3
+        elif installed is None:
+            checks.append(ValidationCheck("pkg_installed", False, 0,
+                                          f"Could not verify {self.package_name} — {_INCONCLUSIVE}", max_points=3))
+            return ValidationResult(self.id, False, 0, self.points, checks)
         else:
             checks.append(ValidationCheck("pkg_installed", False, 0, f"{self.package_name} not installed", max_points=3))
             return ValidationResult(self.id, False, 0, self.points, checks)
@@ -409,55 +474,16 @@ class DowngradePackageTask(BaseTask):
         ]
         return self
 
-    @staticmethod
-    def _package_installed(pkg):
-        """True/False if rpm answers cleanly, None if the query itself could not
-        be trusted (timeout on a busy rpmdb lock, exec error).
-
-        rpm exits 1 *and* prints "is not installed" only when it actually ran and
-        the package is genuinely absent. Any other outcome (the default 5s cap
-        blown by a lock a just-finished `dnf downgrade` / subscription-manager
-        still holds, rc=-1 exec error, rc=127) means the CHECK failed, not that
-        the package is missing — never score that 0 with "not installed". Give
-        rpm room (30s) and retry once before returning inconclusive.
-        """
-        for _ in range(2):
-            r = execute_safe(['rpm', '-q', pkg], timeout=30)
-            if r.returncode == 0:
-                return True
-            if r.returncode == 1 and 'not installed' in (r.stdout + r.stderr).lower():
-                return False
-        return None
-
-    @staticmethod
-    def _downgrade_recorded(pkg):
-        """True/False if dnf history shows a downgrade/undo for THIS package,
-        None if the history query itself could not be run.
-
-        Scoped with `dnf history list <pkg>` (returns rc=0 even with no matches),
-        so "Downgrade"/"Undo" in the output can only come from a transaction that
-        touched this package — unlike grepping all of `dnf history`, which
-        false-passes on any unrelated historical downgrade.
-        """
-        for _ in range(2):
-            r = execute_safe(['dnf', 'history', 'list', pkg], timeout=30)
-            if r.returncode == 0:
-                text = r.stdout.lower()
-                return ('downgrade' in text) or ('undo' in text)
-        return None
-
     def validate(self):
         checks = []
         total_points = 0
 
-        # Check package is installed (transient-failure aware — see helper).
-        installed = self._package_installed(self.package_name)
+        # Check package is installed (transient-failure aware — see module helpers).
+        installed = _package_installed(self.package_name)
         if installed is None:
             checks.append(ValidationCheck(
                 "pkg_installed", False, 0,
-                f"Could not verify {self.package_name} — rpm query failed or timed "
-                f"out (rpmdb may be busy right after a dnf transaction). Wait a few "
-                f"seconds and grade again.", max_points=4))
+                f"Could not verify {self.package_name} — {_INCONCLUSIVE}", max_points=4))
             return ValidationResult(self.id, False, 0, self.points, checks)
         if not installed:
             checks.append(ValidationCheck("pkg_installed", False, 0, f"{self.package_name} not installed", max_points=4))
@@ -467,7 +493,7 @@ class DowngradePackageTask(BaseTask):
         total_points += 4
 
         # Check dnf history for a downgrade action scoped to this package.
-        downgraded = self._downgrade_recorded(self.package_name)
+        downgraded = _downgrade_recorded(self.package_name)
         if downgraded is None:
             checks.append(ValidationCheck(
                 "downgrade_done", False, 0,

--- a/tasks/packages.py
+++ b/tasks/packages.py
@@ -409,24 +409,74 @@ class DowngradePackageTask(BaseTask):
         ]
         return self
 
+    @staticmethod
+    def _package_installed(pkg):
+        """True/False if rpm answers cleanly, None if the query itself could not
+        be trusted (timeout on a busy rpmdb lock, exec error).
+
+        rpm exits 1 *and* prints "is not installed" only when it actually ran and
+        the package is genuinely absent. Any other outcome (the default 5s cap
+        blown by a lock a just-finished `dnf downgrade` / subscription-manager
+        still holds, rc=-1 exec error, rc=127) means the CHECK failed, not that
+        the package is missing — never score that 0 with "not installed". Give
+        rpm room (30s) and retry once before returning inconclusive.
+        """
+        for _ in range(2):
+            r = execute_safe(['rpm', '-q', pkg], timeout=30)
+            if r.returncode == 0:
+                return True
+            if r.returncode == 1 and 'not installed' in (r.stdout + r.stderr).lower():
+                return False
+        return None
+
+    @staticmethod
+    def _downgrade_recorded(pkg):
+        """True/False if dnf history shows a downgrade/undo for THIS package,
+        None if the history query itself could not be run.
+
+        Scoped with `dnf history list <pkg>` (returns rc=0 even with no matches),
+        so "Downgrade"/"Undo" in the output can only come from a transaction that
+        touched this package — unlike grepping all of `dnf history`, which
+        false-passes on any unrelated historical downgrade.
+        """
+        for _ in range(2):
+            r = execute_safe(['dnf', 'history', 'list', pkg], timeout=30)
+            if r.returncode == 0:
+                text = r.stdout.lower()
+                return ('downgrade' in text) or ('undo' in text)
+        return None
+
     def validate(self):
         checks = []
         total_points = 0
 
-        # Check package is installed
-        result = execute_safe(['rpm', '-q', self.package_name])
-        if result.success:
-            checks.append(ValidationCheck("pkg_installed", True, 4, f"{self.package_name} is installed"))
-            total_points += 4
-
-            # Check dnf history for downgrade action
-            result2 = execute_safe(['dnf', 'history'])
-            if result2.success and ('downgrad' in result2.stdout.lower() or 'undo' in result2.stdout.lower()):
-                checks.append(ValidationCheck("downgrade_done", True, 8, "Downgrade action found in history"))
-                total_points += 8
-            else:
-                checks.append(ValidationCheck("downgrade_done", False, 0, "No downgrade action found in dnf history", max_points=8))
-        else:
+        # Check package is installed (transient-failure aware — see helper).
+        installed = self._package_installed(self.package_name)
+        if installed is None:
+            checks.append(ValidationCheck(
+                "pkg_installed", False, 0,
+                f"Could not verify {self.package_name} — rpm query failed or timed "
+                f"out (rpmdb may be busy right after a dnf transaction). Wait a few "
+                f"seconds and grade again.", max_points=4))
+            return ValidationResult(self.id, False, 0, self.points, checks)
+        if not installed:
             checks.append(ValidationCheck("pkg_installed", False, 0, f"{self.package_name} not installed", max_points=4))
+            return ValidationResult(self.id, False, 0, self.points, checks)
+
+        checks.append(ValidationCheck("pkg_installed", True, 4, f"{self.package_name} is installed"))
+        total_points += 4
+
+        # Check dnf history for a downgrade action scoped to this package.
+        downgraded = self._downgrade_recorded(self.package_name)
+        if downgraded is None:
+            checks.append(ValidationCheck(
+                "downgrade_done", False, 0,
+                f"Could not read dnf history for {self.package_name} (query failed "
+                f"or timed out). Wait a few seconds and grade again.", max_points=8))
+        elif downgraded:
+            checks.append(ValidationCheck("downgrade_done", True, 8, f"Downgrade/undo of {self.package_name} found in dnf history"))
+            total_points += 8
+        else:
+            checks.append(ValidationCheck("downgrade_done", False, 0, f"No downgrade of {self.package_name} found in dnf history", max_points=8))
 
         return ValidationResult(self.id, total_points >= 8, total_points, self.points, checks)

--- a/tests/unit/test_downgrade_package_task.py
+++ b/tests/unit/test_downgrade_package_task.py
@@ -1,0 +1,125 @@
+"""
+Tests for DowngradePackageTask.validate() — the checker behind pkg_downgrade_001.
+
+Regression coverage for issue #44: a candidate who genuinely downgraded
+vim-enhanced scored 0/12 with "vim-enhanced not installed" because the checker
+treated ANY execute_safe failure (a 5s timeout on a busy rpmdb lock) as
+"package absent", and the downgrade check substring-grepped ALL of dnf history
+(false-passing on unrelated downgrades). Both are now transient-failure aware
+and scoped to the task's package.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from validators.safe_executor import ExecutionResult
+from tasks.packages import DowngradePackageTask
+
+
+pytestmark = pytest.mark.unit
+
+
+def _res(returncode, stdout="", stderr=""):
+    return ExecutionResult(
+        returncode=returncode, stdout=stdout, stderr=stderr,
+        success=(returncode == 0),
+    )
+
+
+@pytest.fixture
+def task():
+    return DowngradePackageTask().generate(package="vim-enhanced")
+
+
+def _dispatch(rpm_res, history_res):
+    """Return an execute_safe side effect keyed on the command."""
+    def side_effect(cmd, *args, **kwargs):
+        if cmd[0] == "rpm":
+            return rpm_res
+        if cmd[0] == "dnf" and "history" in cmd:
+            return history_res
+        return _res(0)
+    return side_effect
+
+
+class TestHappyPath:
+    def test_installed_and_downgraded_scores_full(self, task):
+        # rpm -q succeeds; dnf history list <pkg> shows a Downgrade row.
+        history = "ID | Command line | Action(s)\n229 | dg vim-enhanced | Downgrade | 4 <"
+        with patch("tasks.packages.execute_safe",
+                   side_effect=_dispatch(_res(0, "vim-enhanced-9.1.083-9.el10_2.3.x86_64"),
+                                         _res(0, history))):
+            result = task.validate()
+        assert result.passed is True
+        assert result.score == 12
+
+
+class TestTransientFailureNotMisreported:
+    def test_rpm_timeout_is_not_reported_as_not_installed(self, task):
+        # execute_safe timeout => returncode -1, success False. Must NOT claim
+        # "not installed"; must be an inconclusive "grade again" message.
+        with patch("tasks.packages.execute_safe",
+                   side_effect=_dispatch(_res(-1, stderr="Command timed out"),
+                                         _res(0, "Downgrade"))):
+            result = task.validate()
+        assert result.score == 0
+        msg = result.checks[0].message.lower()
+        assert "not installed" not in msg
+        assert "grade again" in msg or "could not verify" in msg
+
+    def test_history_timeout_does_not_null_the_downgrade_points(self, task):
+        # Package present, but dnf history query fails transiently. The downgrade
+        # check should say "could not read", not a definitive "no downgrade".
+        with patch("tasks.packages.execute_safe",
+                   side_effect=_dispatch(_res(0, "vim-enhanced-9.1.083-9.el10_2.3.x86_64"),
+                                         _res(-1, stderr="Command timed out"))):
+            result = task.validate()
+        assert result.score == 4  # pkg_installed only
+        dg = [c for c in result.checks if c.name == "downgrade_done"][0]
+        assert "could not read" in dg.message.lower()
+
+
+class TestGenuineFailures:
+    def test_genuinely_absent_package_says_not_installed(self, task):
+        # rpm exits 1 with "is not installed" — the real absent case.
+        with patch("tasks.packages.execute_safe",
+                   side_effect=_dispatch(_res(1, "package vim-enhanced is not installed"),
+                                         _res(0, ""))):
+            result = task.validate()
+        assert result.score == 0
+        assert "not installed" in result.checks[0].message.lower()
+
+    def test_no_downgrade_in_scoped_history_fails_that_check(self, task):
+        # Installed, but history for THIS package shows no downgrade.
+        history = "No transaction which manipulates package 'vim-enhanced' was found."
+        with patch("tasks.packages.execute_safe",
+                   side_effect=_dispatch(_res(0, "vim-enhanced-9.1.083-9.el10_2.3.x86_64"),
+                                         _res(0, history))):
+            result = task.validate()
+        assert result.score == 4
+        dg = [c for c in result.checks if c.name == "downgrade_done"][0]
+        assert dg.passed is False
+
+
+class TestHelpers:
+    def test_package_installed_tristate(self):
+        with patch("tasks.packages.execute_safe", return_value=_res(0, "pkg-1.0")):
+            assert DowngradePackageTask._package_installed("pkg") is True
+        with patch("tasks.packages.execute_safe",
+                   return_value=_res(1, "package pkg is not installed")):
+            assert DowngradePackageTask._package_installed("pkg") is False
+        with patch("tasks.packages.execute_safe", return_value=_res(-1, stderr="timeout")):
+            assert DowngradePackageTask._package_installed("pkg") is None
+
+    def test_downgrade_recorded_is_scoped(self):
+        # A Downgrade row for the queried package => True.
+        with patch("tasks.packages.execute_safe",
+                   return_value=_res(0, "229 | dg pkg | Downgrade | 4")):
+            assert DowngradePackageTask._downgrade_recorded("pkg") is True
+        # dnf history list returns rc=0 with no matches => False, not a false pass.
+        with patch("tasks.packages.execute_safe",
+                   return_value=_res(0, "No transaction which manipulates package 'pkg' was found.")):
+            assert DowngradePackageTask._downgrade_recorded("pkg") is False
+        # Query itself failed => inconclusive.
+        with patch("tasks.packages.execute_safe", return_value=_res(-1, stderr="timeout")):
+            assert DowngradePackageTask._downgrade_recorded("pkg") is None

--- a/tests/unit/test_downgrade_package_task.py
+++ b/tests/unit/test_downgrade_package_task.py
@@ -13,7 +13,11 @@ import pytest
 from unittest.mock import patch
 
 from validators.safe_executor import ExecutionResult
-from tasks.packages import DowngradePackageTask
+from tasks.packages import (
+    DowngradePackageTask,
+    _package_installed,
+    _downgrade_recorded,
+)
 
 
 pytestmark = pytest.mark.unit
@@ -104,22 +108,22 @@ class TestGenuineFailures:
 class TestHelpers:
     def test_package_installed_tristate(self):
         with patch("tasks.packages.execute_safe", return_value=_res(0, "pkg-1.0")):
-            assert DowngradePackageTask._package_installed("pkg") is True
+            assert _package_installed("pkg") is True
         with patch("tasks.packages.execute_safe",
                    return_value=_res(1, "package pkg is not installed")):
-            assert DowngradePackageTask._package_installed("pkg") is False
+            assert _package_installed("pkg") is False
         with patch("tasks.packages.execute_safe", return_value=_res(-1, stderr="timeout")):
-            assert DowngradePackageTask._package_installed("pkg") is None
+            assert _package_installed("pkg") is None
 
     def test_downgrade_recorded_is_scoped(self):
         # A Downgrade row for the queried package => True.
         with patch("tasks.packages.execute_safe",
                    return_value=_res(0, "229 | dg pkg | Downgrade | 4")):
-            assert DowngradePackageTask._downgrade_recorded("pkg") is True
+            assert _downgrade_recorded("pkg") is True
         # dnf history list returns rc=0 with no matches => False, not a false pass.
         with patch("tasks.packages.execute_safe",
                    return_value=_res(0, "No transaction which manipulates package 'pkg' was found.")):
-            assert DowngradePackageTask._downgrade_recorded("pkg") is False
+            assert _downgrade_recorded("pkg") is False
         # Query itself failed => inconclusive.
         with patch("tasks.packages.execute_safe", return_value=_res(-1, stderr="timeout")):
-            assert DowngradePackageTask._downgrade_recorded("pkg") is None
+            assert _downgrade_recorded("pkg") is None

--- a/tests/unit/test_package_task_transient.py
+++ b/tests/unit/test_package_task_transient.py
@@ -1,0 +1,110 @@
+"""
+Transient-failure hardening across the package validators (follow-up to #44).
+
+execute_safe returns success=False on a 5s timeout, not just on a clean
+"absent". Every package validator that keyed a verdict off that must now treat
+a failed/timed-out query as inconclusive — never a pass, never a definitive
+fail. The nastiest case was RemovePackageTask, where a timeout used to award
+full points ("removed") for work not done.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from validators.safe_executor import ExecutionResult
+from tasks.packages import (
+    InstallPackageTask,
+    RemovePackageTask,
+    InstallPackageGroupTask,
+    VerifyPackageIntegrityTask,
+    _group_installed,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _res(returncode, stdout="", stderr=""):
+    return ExecutionResult(returncode=returncode, stdout=stdout, stderr=stderr,
+                           success=(returncode == 0))
+
+
+def _rpm(res):
+    def side_effect(cmd, *a, **k):
+        return res if cmd[0] == "rpm" else _res(0)
+    return side_effect
+
+
+TIMEOUT = _res(-1, stderr="Command timed out after 5 seconds")
+
+
+class TestInstall:
+    def test_timeout_is_inconclusive_not_absent(self):
+        task = InstallPackageTask().generate(package="tree")
+        with patch("tasks.packages.execute_safe", side_effect=_rpm(TIMEOUT)):
+            r = task.validate()
+        assert r.score == 0 and r.passed is False
+        assert "not installed" not in r.checks[0].message.lower()
+        assert "grade again" in r.checks[0].message.lower()
+
+    def test_installed_passes(self):
+        task = InstallPackageTask().generate(package="tree")
+        with patch("tasks.packages.execute_safe", side_effect=_rpm(_res(0, "tree-2.1.1-1.el10.x86_64"))):
+            r = task.validate()
+        assert r.passed is True and r.score == 6
+
+    def test_absent_fails_cleanly(self):
+        task = InstallPackageTask().generate(package="tree")
+        with patch("tasks.packages.execute_safe", side_effect=_rpm(_res(1, "package tree is not installed"))):
+            r = task.validate()
+        assert r.passed is False and r.score == 0
+        assert "not installed" in r.checks[0].message.lower()
+
+
+class TestRemove:
+    def test_timeout_does_not_award_removed(self):
+        # The regression: a timeout used to score 6/6 "removed" for free.
+        task = RemovePackageTask().generate(package="tree")
+        with patch("tasks.packages.execute_safe", side_effect=_rpm(TIMEOUT)):
+            r = task.validate()
+        assert r.passed is False and r.score == 0
+        assert r.checks[0].passed is False
+
+    def test_absent_is_removed(self):
+        task = RemovePackageTask().generate(package="tree")
+        with patch("tasks.packages.execute_safe", side_effect=_rpm(_res(1, "package tree is not installed"))):
+            r = task.validate()
+        assert r.passed is True and r.score == 6
+
+    def test_still_installed_fails(self):
+        task = RemovePackageTask().generate(package="tree")
+        with patch("tasks.packages.execute_safe", side_effect=_rpm(_res(0, "tree-2.1.1-1.el10.x86_64"))):
+            r = task.validate()
+        assert r.passed is False and r.score == 0
+        assert "still installed" in r.checks[0].message.lower()
+
+
+class TestGroup:
+    def test_timeout_is_inconclusive(self):
+        task = InstallPackageGroupTask().generate(group=("Development Tools", "development"))
+        with patch("tasks.packages.execute_safe", return_value=TIMEOUT):
+            r = task.validate()
+        assert r.passed is False and r.score == 0
+        assert "grade again" in r.checks[0].message.lower()
+
+    def test_group_present_passes(self):
+        assert _group_installed("Development Tools", "development") in (True, False, None)
+        with patch("tasks.packages.execute_safe",
+                   return_value=_res(0, "Installed Groups:\n   Development Tools\n")):
+            assert _group_installed("Development Tools", "development") is True
+        with patch("tasks.packages.execute_safe", return_value=_res(0, "Installed Groups:\n   System Tools\n")):
+            assert _group_installed("Development Tools", "development") is False
+
+
+class TestVerifyIntegrity:
+    def test_rpm_timeout_is_inconclusive(self):
+        task = VerifyPackageIntegrityTask().generate(package="bash")
+        with patch("tasks.packages.execute_safe", side_effect=_rpm(TIMEOUT)):
+            r = task.validate()
+        assert r.passed is False and r.score == 0
+        assert "grade again" in r.checks[0].message.lower()


### PR DESCRIPTION
Closes #44

## The bug that started it (#44)

A candidate who genuinely downgraded `vim-enhanced` scored **0/12** ("vim-enhanced not installed"). Live evidence contradicted that: `rpm -q vim-enhanced` rc=0, `dnf history` txn 229 = `Downgrade`. Correct score 12/12.

**Root cause:** `execute_safe` returns `success=False` for a **timeout** too, and `COMMAND_TIMEOUT` is only **5s**. `rpm -q` blocks past that on an rpmdb lock held by a just-finished `dnf downgrade` / subscription-manager, so a transient timeout was scored as a definitive "not installed" — which also skipped the nested 8-pt downgrade check → 0/12. The `downgrade_done` check was also unscoped (grepped all of `dnf history`).

## Scope: this flaw was everywhere in `tasks/packages.py`

Lifted tri-state helpers to module level and routed every package-query validator through them:

| state | meaning |
|-------|---------|
| `True`  | confirmed (installed / matched) |
| `False` | query ran cleanly, no match (genuinely absent) |
| `None`  | query failed/timed out — **never** a pass or a fail |

- **`DowngradePackageTask`** — tri-state install check + `dnf history list <pkg>` scoped downgrade check.
- **`InstallPackageTask`** — timeout no longer reported as "not installed".
- **`RemovePackageTask`** — **fixes a false _positive_**: a timeout used to award full points ("package removed") for work never done.
- **`InstallPackageGroupTask`** — `dnf group list installed` timeout no longer read as "group not installed".
- **`VerifyPackageIntegrityTask`** — `rpm -q` timeout no longer read as "not installed".

Inconclusive results give the query a 30s timeout + one retry and a "wait a few seconds and grade again" message instead of a wrong verdict.

## Tests

- `tests/unit/test_downgrade_package_task.py` (7)
- `tests/unit/test_package_task_transient.py` (9) — incl. the Remove false-positive regression

```
217 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WPpnU5ycpYv4UUoxcFkEU