### PR TITLE
Quick practice: mutate the machine like exam mode

### DIFF
--- a/rhcsa_simulator.py
+++ b/rhcsa_simulator.py
@@ -66,6 +66,7 @@ def run_quick_practice(category=None):
     from tasks.registry import TaskRegistry
     from core.validator import get_validator
     from core.results_db import get_results_db
+    from core import task_env
     from utils import formatters as fmt
     from utils.helpers import confirm_action
 
@@ -98,69 +99,89 @@ def run_quick_practice(category=None):
     completed = 0
     passed = 0
 
+    # Put the box into the same real state exam/practice/adaptive modes do:
+    # fresh practice disks + no leftover artifacts up front, then inject each
+    # task's fault / negative precondition per iteration (and reverse it after).
+    # Without this, quick practice validates against default state — troubleshooting
+    # tasks have nothing to fix and positive-config tasks pass with no work done.
+    print(fmt.dim("Preparing a clean practice environment..."))
+    task_env.session_reset()
+
     for i, task in enumerate(tasks, 1):
-        fmt.clear_screen()
-        print(f"Quick Practice - Task {i}/{len(tasks)}")
-        print("=" * 60)
-        print()
-        print(fmt.bold("Task:"))
-        print(task.description)
-        print()
-
-        cat_name = fmt.format_category_name(task.category)
-        domain = getattr(task, 'exam_domain', 0)
-        domain_name = settings.EXAM_DOMAINS.get(domain, "")
-        print(fmt.bold(f"Category: {cat_name} [D{domain}]"))
-        if domain_name:
-            print(fmt.bold(f"Domain: {domain_name}"))
-        print(fmt.bold(f"Points: {task.points}"))
-        print()
-
-        if task.hints and confirm_action("Show hints?", default=False):
+        # Break something to fix / establish the precondition BEFORE the candidate
+        # works on it. Wipe screen after so setup chatter doesn't precede the task.
+        env_state = task_env.setup_task(task)
+        stop = False
+        try:
+            fmt.clear_screen()
+            print(f"Quick Practice - Task {i}/{len(tasks)}")
+            print("=" * 60)
             print()
-            for j, hint in enumerate(task.hints, 1):
-                print(f"  {j}. {hint}")
+            print(fmt.bold("Task:"))
+            print(task.description)
             print()
 
-        input("Complete the task, then press Enter to validate...")
-
-        result = validator.validate_task(task)
-        completed += 1
-
-        print()
-        if result.passed:
-            passed += 1
-            print(fmt.success(f"PASSED - {result.score}/{result.max_score} points"))
-        else:
-            print(fmt.error(f"FAILED - {result.score}/{result.max_score} points"))
-            for check in result.checks:
-                if not check.passed:
-                    print(f"    - {check.message}")
-
-        # Save to ResultsDB
-        db.save_practice_attempt(
-            task_id=task.id,
-            category=task.category,
-            difficulty=task.difficulty,
-            domain=getattr(task, 'exam_domain', 0),
-            score=result.score,
-            max_score=result.max_score,
-            passed=result.passed,
-            mode='quick'
-        )
-
-        # Show exam tips
-        exam_tips = getattr(task, 'exam_tips', [])
-        if exam_tips:
+            cat_name = fmt.format_category_name(task.category)
+            domain = getattr(task, 'exam_domain', 0)
+            domain_name = settings.EXAM_DOMAINS.get(domain, "")
+            print(fmt.bold(f"Category: {cat_name} [D{domain}]"))
+            if domain_name:
+                print(fmt.bold(f"Domain: {domain_name}"))
+            print(fmt.bold(f"Points: {task.points}"))
             print()
-            print(fmt.bold("Exam Tips:"))
-            for tip in exam_tips:
-                print(f"  * {tip}")
 
-        print()
-        if i < len(tasks):
-            if not confirm_action("Continue to next task?", default=True):
-                break
+            if task.hints and confirm_action("Show hints?", default=False):
+                print()
+                for j, hint in enumerate(task.hints, 1):
+                    print(f"  {j}. {hint}")
+                print()
+
+            input("Complete the task, then press Enter to validate...")
+
+            result = validator.validate_task(task)
+            completed += 1
+
+            print()
+            if result.passed:
+                passed += 1
+                print(fmt.success(f"PASSED - {result.score}/{result.max_score} points"))
+            else:
+                print(fmt.error(f"FAILED - {result.score}/{result.max_score} points"))
+                for check in result.checks:
+                    if not check.passed:
+                        print(f"    - {check.message}")
+
+            # Save to ResultsDB
+            db.save_practice_attempt(
+                task_id=task.id,
+                category=task.category,
+                difficulty=task.difficulty,
+                domain=getattr(task, 'exam_domain', 0),
+                score=result.score,
+                max_score=result.max_score,
+                passed=result.passed,
+                mode='quick'
+            )
+
+            # Show exam tips
+            exam_tips = getattr(task, 'exam_tips', [])
+            if exam_tips:
+                print()
+                print(fmt.bold("Exam Tips:"))
+                for tip in exam_tips:
+                    print(f"  * {tip}")
+
+            print()
+            stop = i < len(tasks) and not confirm_action("Continue to next task?", default=True)
+        finally:
+            # Always reverse this task's system changes, even on error / early
+            # exit, then wipe practice disks if the task consumed one.
+            print(fmt.dim("Restoring system..."))
+            task_env.teardown_task(task, env_state)
+            task_env.reset_after_task(task)
+
+        if stop:
+            break
 
     # Summary
     print()

--- a/tests/unit/test_quick_practice_env.py
+++ b/tests/unit/test_quick_practice_env.py
@@ -1,0 +1,112 @@
+"""
+Quick-practice must mutate the machine like exam/practice/adaptive modes do.
+
+Regression guard: run_quick_practice() once generated + validated tasks without
+injecting faults or establishing negative preconditions, so troubleshooting
+tasks had nothing to fix and positive-config tasks passed with no work done. It
+must now drive the same core.task_env lifecycle:
+
+    session_reset  ->  setup_task  ->  (validate)  ->  teardown_task  ->  reset_after_task
+"""
+
+import builtins
+import pytest
+
+import rhcsa_simulator as R
+from core import task_env
+from tasks.registry import TaskRegistry
+from core import validator as V
+from core import results_db as RDB
+from utils import formatters as fmt
+from utils import helpers as H
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeTask:
+    id = "fake_task_001"
+    category = "services"
+    difficulty = "exam"
+    points = 10
+    description = "Start and enable a service"
+    hints = ["systemctl enable --now svc"]
+    exam_domain = 3
+    exam_tips = ["a tip"]
+    has_fault_injection = False
+    has_setup = True
+    disk_slots = 0
+
+
+class _FakeResult:
+    passed = True
+    score = 10
+    max_score = 10
+    checks = []
+
+
+class _FakeValidator:
+    def __init__(self, calls):
+        self._calls = calls
+
+    def validate_task(self, task):
+        self._calls.append(("validate", task.id))
+        return _FakeResult()
+
+
+class _FakeDB:
+    def save_practice_attempt(self, **kw):
+        pass
+
+
+@pytest.fixture
+def calls(monkeypatch):
+    seq = []
+
+    monkeypatch.setattr(task_env, "session_reset", lambda *a, **k: seq.append(("session_reset",)))
+    monkeypatch.setattr(task_env, "setup_task",
+                        lambda task, *a, **k: (seq.append(("setup_task", task.id)) or {"setup": True}))
+    monkeypatch.setattr(task_env, "teardown_task",
+                        lambda task, st, *a, **k: seq.append(("teardown_task", task.id)))
+    monkeypatch.setattr(task_env, "reset_after_task",
+                        lambda task, *a, **k: seq.append(("reset_after_task", task.id)))
+
+    monkeypatch.setattr(TaskRegistry, "initialize", staticmethod(lambda *a, **k: None))
+    monkeypatch.setattr(TaskRegistry, "get_exam_tasks", staticmethod(lambda n: [_FakeTask()]))
+    monkeypatch.setattr(TaskRegistry, "get_practice_tasks",
+                        staticmethod(lambda *a, **k: [_FakeTask()]))
+    monkeypatch.setattr(V, "get_validator", lambda *a, **k: _FakeValidator(seq))
+    monkeypatch.setattr(RDB, "get_results_db", lambda *a, **k: _FakeDB())
+    monkeypatch.setattr(fmt, "clear_screen", lambda *a, **k: None)
+    monkeypatch.setattr(H, "confirm_action", lambda *a, **k: True)
+    monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
+    return seq
+
+
+def _names(seq):
+    return [c[0] for c in seq]
+
+
+def test_quick_practice_runs_full_env_lifecycle(calls):
+    R.run_quick_practice("all")
+    names = _names(calls)
+
+    assert names[0] == "session_reset", "clean env must be prepared up front"
+    assert "setup_task" in names, "the machine must be mutated per task"
+    assert names.index("setup_task") < names.index("validate"), "setup before the candidate validates"
+    assert names.index("validate") < names.index("teardown_task"), "restore after validation"
+    assert "reset_after_task" in names
+
+
+def test_teardown_runs_even_when_validation_raises(calls, monkeypatch):
+    # A failure mid-task must not leave injected faults / preconditions behind.
+    class _Boom:
+        def validate_task(self, task):
+            raise RuntimeError("boom")
+    monkeypatch.setattr(V, "get_validator", lambda *a, **k: _Boom())
+
+    with pytest.raises(RuntimeError):
+        R.run_quick_practice("all")
+
+    names = _names(calls)
+    assert "setup_task" in names and "teardown_task" in names, "teardown must run on error"


### PR DESCRIPTION
## Problem

Quick practice **did not change the machine**. `run_quick_practice()` generated tasks and validated them, but skipped the fault-injection and negative-precondition setup that exam mode performs — so on a real box:

- **Troubleshooting tasks had nothing to fix** — `inject_fault()` never ran.
- **"Start/enable service" tasks passed if the service was already running** — `setup_environment()` (which stops it first) never ran.
- **"Remove package" passed for free** when the package wasn't installed to begin with.

Candidates could "pass" quick-practice tasks without doing any work.

## Audit of all modes

| Mode | Mutated the machine? |
|------|----------------------|
| exam | ✅ yes |
| practice | ✅ yes (via `core.task_env`) |
| adaptive | ✅ yes (via `core.task_env`) |
| **quick** | ❌ **no — this PR** |
| learn | n/a — study-only, no validation |

Only quick practice was broken. `learn` correctly needs no mutation.

## Fix

Routed quick practice through the exact same `core.task_env` lifecycle the other task modes already use:

```
session_reset()            # fresh practice disks + clean leftovers, once up front
  setup_task(task)         # inject_fault() / setup_environment() BEFORE the candidate works
  ... validate ...
  teardown_task(task)      # restore_fault() / teardown_environment()   (in finally)
  reset_after_task(task)   # wipe practice disk if the task used one     (in finally)
```

Teardown/reset run in a `finally`, so injected faults are always reversed even on early exit or error.

## Tests

`tests/unit/test_quick_practice_env.py` (2): asserts the full lifecycle order (`session_reset → setup_task → validate → teardown_task → reset_after_task`) and that teardown still runs when validation raises.

```
219 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WPpnU5ycpYv4UUoxcFkEU