### PR TITLE
docs: progress-code rationale + tighten README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,48 +41,84 @@ and press Enter to validate → review per-check feedback and score.
 
 | | Minimum |
 |---|---|
-| **OS** | RHEL 10, Rocky Linux 9/10, or AlmaLinux 9/10 |
+| **OS** | RHEL 10, Rocky Linux 9/10, or AlmaLinux 9/10 (EX200 v10 targets RHEL 10) |
 | **Python** | 3.6+ (ships with the OS) |
-| **Privileges** | root (validation reads users, services, mounts, SELinux, …) |
+| **Privileges** | root (validation reads users, services, mounts, SELinux, etc.) |
 | **Dependencies** | none — Python standard library only |
-| **Disk** | a few hundred MB under `/var/lib/rhcsa-simulator` for loop images |
-| **Network** | not required (only for the optional DNF-history setup) |
+| **Disk** | a few hundred MB free under `/var/lib/rhcsa-simulator` for loop-device images |
+| **Network** | not required (optional, only for the DNF-history practice setup) |
 
-**Use a throwaway VM you can snapshot/revert** — tasks change real system state
-(users, partitions, services, firewall, SELinux). 2 vCPU, 2–4 GB RAM, 20 GB OS
-disk is plenty. A spare disk is optional (loop devices cover storage practice; a
-small spare like `/dev/sda` is auto-added if present). Keep SELinux
-**Enforcing**; snapshot before each session. Cloud VMs (AWS/Azure/GCP) work well.
+### Recommended VM configuration
 
-### Packages for task scenarios
+Practice on a **throwaway VM you can snapshot/revert**, never a machine you care
+about — tasks change real system state (users, partitions, services, firewall,
+SELinux).
 
-A **minimal install doesn't ship `httpd`, `vsftpd`, `samba`, `tuned`** and a few
-others that Domain 6/7 tasks use to build a realistic scenario. If a package is
-missing, the task's fault-injection silently no-ops and the scenario looks empty
-when you go to work on it. Every launch runs a read-only `rpm -q` preflight and
-warns about what's missing — **nothing is installed automatically**.
+- **vCPUs:** 2
+- **RAM:** 2–4 GB
+- **Primary disk:** 20 GB (OS)
+- **A spare disk for storage practice:** optional. The simulator auto-creates
+  500 MB loop devices, so you don't *need* one. If you add a small spare disk
+  (e.g. a 1–2 GB `/dev/sda`), it is detected and added to the practice device
+  pool automatically — handy for realistic `fdisk`/`parted` partitioning.
+- **Install type:** minimal install is fine to launch the simulator, but see
+  [Package & service requirements for task scenarios](#package--service-requirements-for-task-scenarios)
+  below — several troubleshooting tasks expect packages a minimal install
+  doesn't ship with.
+- **Snapshot first:** take a VM snapshot before a session so you can revert.
+- **SELinux:** leave it **Enforcing** for realistic SELinux tasks.
+- **Networking:** any NAT/bridged setup; only needed if you want the optional
+  DNF transaction-history practice data.
+
+> Cloud VMs (AWS/Azure/GCP) work well — loop devices mean you don't have to
+> attach extra block storage to practice LVM/partitioning.
+
+### Package & service requirements for task scenarios
+
+The simulator itself needs nothing beyond the Python standard library. But a
+**minimal RHEL/Rocky/Alma install doesn't ship `httpd`, `vsftpd`, or several
+other services** that specific tasks (mostly Domain 7 Troubleshooting and
+Domain 6 Services) use to build a realistic scenario. If a package is
+missing, the task's fault-injection step still reports "active" — its own
+`systemctl`/`chcon`/etc. calls just no-op — so the scenario looks like
+nothing happened when you go to work on it in a second terminal.
+
+Every launch of `rhcsa-simulator` (any mode) runs a **read-only preflight
+check** (`rpm -q`) and prints a warning listing anything missing, along with
+a ready-to-run `dnf install` command. Nothing is installed automatically.
 
 | Package | Used by |
 |---|---|
-| `httpd` | Apache SELinux context/boolean, firewall, service troubleshooting |
+| `httpd` | Apache SELinux context/boolean, firewall, and service troubleshooting tasks |
 | `vsftpd` | FTP service tasks |
 | `nfs-utils` | NFS server/client and network storage tasks |
 | `samba` | Samba/SMB file sharing tasks |
 | `chrony` | time synchronization tasks |
-| `firewalld` | firewall management/troubleshooting tasks |
-| `bind-utils` | DNS lookup tooling for networking tasks |
+| `firewalld` | firewall management and troubleshooting tasks |
+| `bind-utils` | DNS lookup tooling used by networking tasks |
 | `tuned` | tuning profile (`tuned-adm`) tasks |
+
+Install everything up front so no task scenario silently fails to set up:
 
 ```bash
 dnf install -y httpd vsftpd nfs-utils samba chrony firewalld bind-utils tuned
 ```
 
-**Baseline services** tasks start/stop/enable (install the package, then leave
-the service as a fresh install sets it): `httpd`, `vsftpd`, `nfs-server`, `smb`,
-`chronyd`, `firewalld`, `sshd`, `crond`, `rsyslog`.
+**Baseline services** the simulator expects to be able to start/stop/enable —
+install the corresponding package above first, then leave the service in
+whatever state a fresh install puts it in (tasks manage state themselves):
+`httpd`, `vsftpd`, `nfs-server`, `smb`, `chronyd`, `firewalld`, `sshd`,
+`crond`, `rsyslog`.
 
-On **RHEL 10**, `firewalld` and `chrony` are enabled by default; the rest above
-are not — install them before a session that may draw a Domain 6/7 or NFS task.
+**RHEL 10.x notes:**
+- A minimal RHEL 10 install does not include `httpd`, `vsftpd`, `samba`, or
+  `tuned` — install them with the command above before an exam/practice
+  session that may draw a Domain 6/7 task.
+- `firewalld` and `chrony` are installed and enabled by default on RHEL 10, so
+  those two are usually already satisfied.
+- `nfs-utils` is not installed by default; NFS tasks that provision a
+  *remote* server (see the in-app NFS server setup) install it on the
+  remote box automatically, but local NFS client tasks still need it here.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,39 @@
 # RHCSA Mock Exam Simulator
 
-A realistic command-line **RHCSA EX200 v10** (Red Hat Enterprise Linux 10) exam
-simulator. It generates exam tasks, sets up the practice environment for you,
-validates your real system configuration with safe read-only checks, and tracks
-your progress over time.
+A command-line **RHCSA EX200 v10** (Red Hat Enterprise Linux 10) exam simulator.
+It generates tasks, sets up each task's starting state, validates your real
+system configuration with safe read-only checks, and tracks progress over time.
 
-> **EX200 v10 aligned** — tasks cover the Red Hat EX200 v10 objectives. The bank
-> currently ships **188 tasks across 25 categories in 8 domains**. Flatpak,
-> systemd timers, tuning profiles (`tuned-adm`), and secure file transfer are
-> included; legacy module streams are not.
-
-> **Active development** — functional and useful for RHCSA prep, but you may hit
-> rough edges. Bug reports and contributions welcome.
+> **188 tasks · 25 categories · 8 domains**, aligned to EX200 v10 — including
+> Flatpak, systemd timers, `tuned-adm`, and secure file transfer (no legacy
+> module streams).
+>
+> **Active development** — useful for prep, but expect rough edges. Bug reports
+> and contributions welcome.
 
 ---
 
 ## Quick Start
 
 ```bash
-# 1. On a RHEL 10 / Rocky 10 / Alma 10 VM, become root
+# On a RHEL 10 / Rocky 10 / Alma 10 VM, as root:
 sudo -i
-
-# 2. Get the code
 git clone https://github.com/justbest23/rhcsa-simulator.git
 cd rhcsa-simulator
-
-# 3. Install (interactive). For an unattended install use: ./install.sh --yes
-./install.sh
-
-# 4. Launch (must be root — validation inspects real system state)
-rhcsa-simulator
-
-# 5. At the menu, press  E  for a full Mock Exam, or  Q  for a 5-task quick round.
+./install.sh          # interactive (use --yes for unattended)
+rhcsa-simulator       # launch (must be root — validation reads real state)
 ```
 
-That's it. The simulator **auto-creates the practice disks it needs** (loop
-devices, plus any spare disk such as `/dev/sda`) and **sets up each task's
-starting state** when an exam begins — so a "kill the apache processes" task
-actually has processes running, and an "extend the logical volume" task actually
-has a volume to extend. When the exam ends, it tears all of that back down.
+At the menu, press **E** for a full Mock Exam or **Q** for a 5-task quick round.
 
-**Typical loop:** read a task → do it on the system in another terminal → come
-back and press Enter to validate → review per-check feedback and score.
+The simulator **auto-creates the practice disks it needs** (loop devices, plus
+any spare disk like `/dev/sda`) and **sets up each task's starting state** at
+exam start — so a "kill the apache processes" task actually has processes
+running, and an "extend the logical volume" task actually has a volume — then
+tears it all down when the exam ends.
+
+**Typical loop:** read a task → do it on the system in another terminal → return
+and press Enter to validate → review per-check feedback and score.
 
 ---
 
@@ -49,271 +41,167 @@ back and press Enter to validate → review per-check feedback and score.
 
 | | Minimum |
 |---|---|
-| **OS** | RHEL 10, Rocky Linux 9/10, or AlmaLinux 9/10 (EX200 v10 targets RHEL 10) |
+| **OS** | RHEL 10, Rocky Linux 9/10, or AlmaLinux 9/10 |
 | **Python** | 3.6+ (ships with the OS) |
-| **Privileges** | root (validation reads users, services, mounts, SELinux, etc.) |
+| **Privileges** | root (validation reads users, services, mounts, SELinux, …) |
 | **Dependencies** | none — Python standard library only |
-| **Disk** | a few hundred MB free under `/var/lib/rhcsa-simulator` for loop-device images |
-| **Network** | not required (optional, only for the DNF-history practice setup) |
+| **Disk** | a few hundred MB under `/var/lib/rhcsa-simulator` for loop images |
+| **Network** | not required (only for the optional DNF-history setup) |
 
-### Recommended VM configuration
+**Use a throwaway VM you can snapshot/revert** — tasks change real system state
+(users, partitions, services, firewall, SELinux). 2 vCPU, 2–4 GB RAM, 20 GB OS
+disk is plenty. A spare disk is optional (loop devices cover storage practice; a
+small spare like `/dev/sda` is auto-added if present). Keep SELinux
+**Enforcing**; snapshot before each session. Cloud VMs (AWS/Azure/GCP) work well.
 
-Practice on a **throwaway VM you can snapshot/revert**, never a machine you care
-about — tasks change real system state (users, partitions, services, firewall,
-SELinux).
+### Packages for task scenarios
 
-- **vCPUs:** 2
-- **RAM:** 2–4 GB
-- **Primary disk:** 20 GB (OS)
-- **A spare disk for storage practice:** optional. The simulator auto-creates
-  500 MB loop devices, so you don't *need* one. If you add a small spare disk
-  (e.g. a 1–2 GB `/dev/sda`), it is detected and added to the practice device
-  pool automatically — handy for realistic `fdisk`/`parted` partitioning.
-- **Install type:** minimal install is fine to launch the simulator, but see
-  [Package & service requirements for task scenarios](#package--service-requirements-for-task-scenarios)
-  below — several troubleshooting tasks expect packages a minimal install
-  doesn't ship with.
-- **Snapshot first:** take a VM snapshot before a session so you can revert.
-- **SELinux:** leave it **Enforcing** for realistic SELinux tasks.
-- **Networking:** any NAT/bridged setup; only needed if you want the optional
-  DNF transaction-history practice data.
-
-> Cloud VMs (AWS/Azure/GCP) work well — loop devices mean you don't have to
-> attach extra block storage to practice LVM/partitioning.
-
-### Package & service requirements for task scenarios
-
-The simulator itself needs nothing beyond the Python standard library. But a
-**minimal RHEL/Rocky/Alma install doesn't ship `httpd`, `vsftpd`, or several
-other services** that specific tasks (mostly Domain 7 Troubleshooting and
-Domain 6 Services) use to build a realistic scenario. If a package is
-missing, the task's fault-injection step still reports "active" — its own
-`systemctl`/`chcon`/etc. calls just no-op — so the scenario looks like
-nothing happened when you go to work on it in a second terminal.
-
-Every launch of `rhcsa-simulator` (any mode) runs a **read-only preflight
-check** (`rpm -q`) and prints a warning listing anything missing, along with
-a ready-to-run `dnf install` command. Nothing is installed automatically.
+A **minimal install doesn't ship `httpd`, `vsftpd`, `samba`, `tuned`** and a few
+others that Domain 6/7 tasks use to build a realistic scenario. If a package is
+missing, the task's fault-injection silently no-ops and the scenario looks empty
+when you go to work on it. Every launch runs a read-only `rpm -q` preflight and
+warns about what's missing — **nothing is installed automatically**.
 
 | Package | Used by |
 |---|---|
-| `httpd` | Apache SELinux context/boolean, firewall, and service troubleshooting tasks |
+| `httpd` | Apache SELinux context/boolean, firewall, service troubleshooting |
 | `vsftpd` | FTP service tasks |
 | `nfs-utils` | NFS server/client and network storage tasks |
 | `samba` | Samba/SMB file sharing tasks |
 | `chrony` | time synchronization tasks |
-| `firewalld` | firewall management and troubleshooting tasks |
-| `bind-utils` | DNS lookup tooling used by networking tasks |
+| `firewalld` | firewall management/troubleshooting tasks |
+| `bind-utils` | DNS lookup tooling for networking tasks |
 | `tuned` | tuning profile (`tuned-adm`) tasks |
-
-Install everything up front so no task scenario silently fails to set up:
 
 ```bash
 dnf install -y httpd vsftpd nfs-utils samba chrony firewalld bind-utils tuned
 ```
 
-**Baseline services** the simulator expects to be able to start/stop/enable —
-install the corresponding package above first, then leave the service in
-whatever state a fresh install puts it in (tasks manage state themselves):
-`httpd`, `vsftpd`, `nfs-server`, `smb`, `chronyd`, `firewalld`, `sshd`,
-`crond`, `rsyslog`.
+**Baseline services** tasks start/stop/enable (install the package, then leave
+the service as a fresh install sets it): `httpd`, `vsftpd`, `nfs-server`, `smb`,
+`chronyd`, `firewalld`, `sshd`, `crond`, `rsyslog`.
 
-**RHEL 10.x notes:**
-- A minimal RHEL 10 install does not include `httpd`, `vsftpd`, `samba`, or
-  `tuned` — install them with the command above before an exam/practice
-  session that may draw a Domain 6/7 task.
-- `firewalld` and `chrony` are installed and enabled by default on RHEL 10, so
-  those two are usually already satisfied.
-- `nfs-utils` is not installed by default; NFS tasks that provision a
-  *remote* server (see the in-app NFS server setup) install it on the
-  remote box automatically, but local NFS client tasks still need it here.
+On **RHEL 10**, `firewalld` and `chrony` are enabled by default; the rest above
+are not — install them before a session that may draw a Domain 6/7 or NFS task.
 
 ---
 
 ## Installation
 
-### Install script
-
 ```bash
-cd rhcsa-simulator
-./install.sh            # interactive
-./install.sh --yes      # unattended (overwrite existing install, no prompts)
+./install.sh                 # interactive
+./install.sh --yes           # unattended (overwrite, no prompts)
 ./install.sh --no-populate   # skip the optional DNF-history setup
 ```
 
-The installer:
-- checks the Python version and OS,
-- copies files to `/opt/rhcsa-simulator`,
-- creates the `rhcsa-simulator` command at `/usr/local/bin/rhcsa-simulator`,
-- sets permissions,
-- offers to build some DNF transaction history for the package-history tasks.
+The installer checks Python/OS, copies files to `/opt/rhcsa-simulator`, creates
+the `rhcsa-simulator` command in `/usr/local/bin`, and optionally builds some DNF
+transaction history for the package-history tasks. It auto-detects a
+non-interactive shell and runs unattended, so it won't stall in automation.
 
-`install.sh` auto-detects a non-interactive shell (piped/scripted) and runs
-unattended, so it won't stall in automation.
-
-### Run without installing
-
-```bash
-sudo python3 rhcsa_simulator.py
-```
+Run without installing: `sudo python3 rhcsa_simulator.py`.
 
 ---
 
 ## Usage
 
-Launch the interactive menu:
-
 ```bash
-sudo rhcsa-simulator
+sudo rhcsa-simulator    # interactive menu
 ```
-
-Main menu options:
 
 | Key | Mode | What it does |
 |---|---|---|
 | `Q` | **Quick Practice** | 5 random tasks, fast feedback |
-| `E` | **Mock Exam** | Full timed exam (20–25 tasks) with environment setup + reboot-persistence simulation |
+| `E` | **Mock Exam** | Full timed exam (20–25 tasks) with setup + reboot-persistence simulation |
 | `1` | **Learn Mode** | Study by domain — concepts, commands, tips |
 | `2` | **Practice Mode** | One category at a time, with retry & progressive hints |
-| `3` | **Adaptive Mode** | SM-2 spaced repetition — focuses your weak/overdue areas |
+| `3` | **Adaptive Mode** | SM-2 spaced repetition — focuses weak/overdue areas |
 | `4` | **Dashboard** | Stats, history, weak areas |
-| `5` | **Export Report** | Write a progress report (text) to `data/` |
-| `6` | **Result History** | Drill into past exams task by task (press `d` on a task to dispute a check) |
-| `S` | **Setup** | Practice disks, system reset, full system reset, remote NFS server, lab cleanup, DNF-history |
+| `5` | **Export Report** | Write a progress report to `data/` |
+| `6` | **Result History** | Drill into past exams (press `d` on a task to dispute a check) |
+| `S` | **Setup** | Practice disks, resets, remote NFS server, lab cleanup, DNF-history |
 | `0` | Exit | |
 
 ### Command-line shortcuts
 
 ```bash
-rhcsa-simulator --quick            # 5 random tasks
-rhcsa-simulator --quick lvm        # 5 LVM tasks
-rhcsa-simulator --exam             # jump straight into a mock exam
-rhcsa-simulator --practice lvm     # practice a specific category
-rhcsa-simulator --learn            # study mode
-rhcsa-simulator --adaptive         # SM-2 weak-area practice
-rhcsa-simulator --list-categories  # list categories/domains (no root needed)
-rhcsa-simulator --export-code      # print a progress backup code (no root needed)
-rhcsa-simulator --import-code CODE # restore progress from a code
-rhcsa-simulator --import-code -    # restore from a code piped on stdin
-rhcsa-simulator --version
+rhcsa-simulator --quick [lvm]        # 5 random (or category) tasks
+rhcsa-simulator --exam               # jump straight into a mock exam
+rhcsa-simulator --practice lvm       # practice a specific category
+rhcsa-simulator --learn              # study mode
+rhcsa-simulator --adaptive           # SM-2 weak-area practice
+rhcsa-simulator --list-categories    # categories/domains (no root needed)
+rhcsa-simulator --export-code        # print a progress backup code (no root)
+rhcsa-simulator --import-code CODE   # restore progress (use - for stdin)
 ```
 
 ---
 
 ## Progress snapshots (backup & restore, no login)
 
-Your task history and adaptive (SM-2) spaced-repetition state live in a local
-SQLite DB. To carry them across a **reinstall** or a **VM snapshot revert**,
-export a **progress code** — a self-contained, copy-pasteable string — and
-import it on the fresh box. No account, no server.
+Your task history and adaptive (SM-2) state live in a local SQLite DB. Export a
+**progress code** — a self-contained, copy-pasteable string — and import it on
+any box. No account, no server.
 
-**In the app:** main menu → **7. Progress Snapshot**:
-- **Export** a code (also saved to `data/progress_code.txt`). Keep it somewhere
-  that survives the revert — it's the only copy.
-- **Import** a code — you get a preview of what it contains, then choose
-  **Replace** (wipe local history and restore — best for a fresh box) or
-  **Merge** (keep local, add the code's entries, skip duplicates).
-- **Prune** — remove a specific exam, clear all practice attempts, reset one
-  category's adaptive state, or wipe everything (handy before exporting a clean
-  snapshot).
-
-**From the command line** (scripting a snapshot around a revert):
+**In the app:** menu → **7. Progress Snapshot** — Export (also saved to
+`data/progress_code.txt`), Import (preview, then **Replace** or **Merge**), or
+Prune.
 
 ```bash
-# Back up before reverting / reinstalling
-rhcsa-simulator --export-code > my-progress.code
-
-# Restore on the fresh box (default mode is replace)
-rhcsa-simulator --import-code "$(cat my-progress.code)"
-
-# ...or pipe it in, and merge instead of replace
+rhcsa-simulator --export-code > my-progress.code            # back up
+rhcsa-simulator --import-code "$(cat my-progress.code)"     # restore (default: replace)
 cat my-progress.code | rhcsa-simulator --import-code - --import-mode merge
 ```
 
-The code is purely uppercase-alphanumeric and carries a checksum, so a
-mistyped or truncated code is rejected rather than importing garbage. Its length
-grows with your history (a light user is a short string; a very active user can
-reach a few KB — fine to copy/paste).
+The code is uppercase-alphanumeric with a checksum, so a mistyped or truncated
+code is rejected rather than importing garbage. Its length grows with your
+history (a few KB at most).
 
-### Why this matters during active development
+**Why it matters during active development.** The code is **version-portable** —
+it survives *upgrading the simulator itself*, not just OS reinstalls. It encodes
+only your history and per-category SM-2 state (never regenerable task text), is
+format-versioned (`RH1` / `v:1`) and checksummed, and imports schema-tolerantly,
+so a code from an older build loads cleanly into a newer one. The raw SQLite DB
+under `data/` is **not** safe to copy across versions (its schema can change) —
+the code is the stable interchange format that insulates your progress. So
+before anything that wipes or migrates that DB — `git pull` to a new schema,
+`./install.sh`, a Full System Reset, a fresh VM, or deleting `data/` — export a
+code first, then import it afterward.
 
-The progress code is **version-portable** — it survives *upgrading the simulator
-itself*, not just reinstalling the OS. That is deliberate, and it is the reason
-the feature exists:
-
-- The code encodes only stable, forward-compatible data: your exam/practice
-  **history** (task id, category, score, timestamps) and per-category **SM-2
-  spaced-repetition state** (easiness factor, interval, repetitions, due date).
-  It deliberately omits task descriptions, checks, and hints — anything a new
-  release might rewrite — so it is **not tied to a particular version's task
-  set**.
-- Import is schema-tolerant: each field is read with a default and de-duplicated,
-  and the payload carries a format version (`RH1` / `v:1`) plus a checksum. A
-  code exported by an older build imports cleanly into a newer one.
-- The raw SQLite DB under `data/` is **not** safe to copy between versions — its
-  schema can change from release to release. The progress code is the stable
-  interchange format that insulates your history from those schema changes.
-
-While the simulator is under active development you routinely do things that
-wipe or migrate that local DB:
-
-- `git pull` / switching to a branch whose DB schema differs
-- re-running `./install.sh`, a **Full System Reset**, or spinning up a fresh VM
-- deleting `data/` to reproduce a bug from a clean slate
-
-**Export a code first, upgrade or reset, then import it** — your accumulated
-history and adaptive scheduling come back intact, so a version bump never costs
-you your progress:
-
-```bash
-rhcsa-simulator --export-code > my-progress.code   # before pulling / resetting
-# ... git pull / ./install.sh / rebuild the VM ...
-rhcsa-simulator --import-code "$(cat my-progress.code)"
-```
-
-> **Caveat:** SM-2 targeting is keyed by **category name**. If a new version
-> renames or removes a category, that category's *history* still imports, but its
-> spaced-repetition schedule won't re-attach to the renamed category. Task-level
-> history is unaffected.
+> **Caveat:** SM-2 targeting is keyed by **category name**. If a version renames
+> or removes a category, that category's history still imports but its
+> spaced-repetition schedule won't re-attach. Task-level history is unaffected.
 
 ---
 
-## Practice disks (LVM / partitioning / swap / filesystems)
+## Practice disks & Setup menu
 
-You normally don't have to do anything — exams provision disks automatically.
-To manage them yourself, use **Setup → Practice Disks**:
+Exams provision disks automatically. To manage them yourself, use **Setup →
+Practice Disks**: create loop devices (three 500 MB virtual disks), point at a
+real spare disk, or clean up/reset. Every whole-disk task in an exam gets a
+**distinct** device from the pool, so an LVM task and a partitioning task never
+collide. Loop images live in `/var/lib/rhcsa-simulator/loops/`.
 
-- **Create loop devices** — three 500 MB virtual disks (no spare hardware needed).
-- **Use a real disk** — point practice at a spare drive already in the VM.
-- **Clean up / reset** — remove practice LVM structures and detach loop devices.
-
-Under the hood, every whole-disk task in an exam is handed a **distinct** device
-from the pool, so an LVM task and a partitioning task never collide on the same
-disk. Loop-device images live in `/var/lib/rhcsa-simulator/loops/`.
-
-**Setup also offers:**
+**Setup** also offers:
 
 - **System Reset** — remove practice artifacts (LVM, swap files, practice repos,
   cron/at jobs, scripts) without touching SSH/network/users.
-- **Full System Reset** — strip the box back to a *basic RHEL install*: removes
-  all third-party DNF repos, all Flatpak apps/remotes, leftover lab files,
-  practice users/groups, practice disks/swap, scheduled jobs, autofs maps, tuned
-  changes, and any remote NFS exports — then unmounts every non-system mount
-  first so nothing is left over from a previous session. **Preserves** the
-  simulator itself, your GitHub/SSH connectivity (`~/.config/gh`, `~/.ssh`, git
-  config), networking, firewall, SELinux, the OS, and all real accounts. It
-  previews everything and requires typing `RESET` to proceed.
-- **Configure remote NFS server** — SSH into a RHEL box you control and have the
-  simulator provision real, seeded NFS exports so the network-storage tasks test
-  against an actual server (credentials optionally saved; exports refreshed each
-  exam and torn down after).
-- **Clean lab leftover files** — preview/remove just the task-created files.
-- **Populate Practice Environment** — build DNF transaction history.
+- **Full System Reset** — strip the box back to a basic RHEL install: all
+  third-party DNF repos, Flatpak apps/remotes, lab files, practice users/groups,
+  practice disks/swap, scheduled jobs, autofs maps, tuned changes, and remote NFS
+  exports — unmounting every non-system mount first. **Preserves** the simulator,
+  your GitHub/SSH connectivity (`~/.config/gh`, `~/.ssh`, git config),
+  networking, firewall, SELinux, the OS, and all real accounts. Previews
+  everything and requires typing `RESET`.
+- **Configure remote NFS server** — SSH into a RHEL box you control and provision
+  real, seeded NFS exports for the network-storage tasks (refreshed each exam,
+  torn down after).
+- **Clean lab leftover files** and **Populate Practice Environment** (DNF
+  history).
 
-> **Training modes reset too.** Practice and Adaptive modes now reset the box at
-> the start of a session and prepare/tear down each task's state per iteration,
-> the same way the Mock Exam does — so tasks aren't polluted by earlier work.
-> Adaptive mode also lets you choose how many tasks to run (not a fixed 5).
+> Practice and Adaptive modes reset the box at session start and set up/tear down
+> each task's state per iteration, the same way the Mock Exam does. Adaptive mode
+> also lets you choose how many tasks to run.
 
 ---
 
@@ -326,79 +214,58 @@ disk. Loop-device images live in `/var/lib/rhcsa-simulator/loops/`.
 3. **Users, Groups & Permissions** — users/groups, permissions/ACLs, essential tools
 4. **Storage & Filesystems** — partitioning, LVM, filesystems, swap, network storage
 5. **Network & DNS** — networking, SSH
-6. **Systemd, Services & Processes** — services, systemd timers, processes, time services, troubleshooting
+6. **Systemd, Services & Processes** — services, timers, processes, time services, troubleshooting
 7. **Security** — SELinux, firewall
 8. **Automation & Scripting** — scheduling (cron/at/timers), shell scripting
 
-Run `rhcsa-simulator --list-categories` for the live list and per-category task counts.
+Run `rhcsa-simulator --list-categories` for the live list and per-category counts.
 
 ---
 
 ## How it works
 
-**Read-only validation.** The simulator checks your work with whitelisted,
-timeout-protected, read-only commands (`id`, `lsblk`, `systemctl is-active`,
-`getenforce`, …). It does not modify your system *to grade* it — only the
-exam's setup/teardown phase changes state, and it reverses what it created.
-
-**Scoring.** Each task is worth points with multiple checks and partial credit.
-Default pass threshold is 70%. A full exam is 20–25 tasks over a 3-hour timer
-(configurable), followed by a reboot-persistence simulation for tasks that must
-survive a reboot.
-
-**Progress.** Results and spaced-repetition state are stored in a local SQLite
-database under `/opt/rhcsa-simulator/data/` (`ResultsDB`). Adaptive mode uses an
-SM-2 schedule (per-category easiness factor, 1→6→interval×EF progression).
+- **Read-only validation.** Work is graded with whitelisted, timeout-protected,
+  read-only commands (`id`, `lsblk`, `systemctl is-active`, `getenforce`, …).
+  Only the exam's setup/teardown phase changes state, and it reverses what it
+  created.
+- **Scoring.** Each task has multiple checks with partial credit; default pass
+  threshold is 70%. A full exam is 20–25 tasks over a 3-hour timer
+  (configurable), followed by a reboot-persistence simulation for tasks that must
+  survive a reboot.
+- **Progress.** Results and SM-2 state are stored in a local SQLite DB under
+  `/opt/rhcsa-simulator/data/` (per-category easiness factor, 1→6→interval×EF).
 
 ---
 
 ## Disputing a validator result (AI checker disputes)
 
-Think a check ("the checker") graded you wrong? You can dispute it, and an AI
-reviewer will investigate and fix the checker if you're right.
+Think a check graded you wrong? Dispute it and an AI reviewer investigates — and
+fixes the checker if you're right.
 
-**How to file one:** after an exam or from **Result History**, open a task's
-detail and press **`d`**. The simulator then:
+**File one:** in **Result History** (or after an exam), open a task's detail and
+press **`d`**. The simulator captures read-only evidence of the relevant live
+system state (category-specific diagnostics like `getfacl` / `lsblk -f`, plus any
+command you add) and your written argument, saves a Markdown report under
+`data/disputes/`, and opens a labelled GitHub issue (`checker-dispute`) with a
+**Checker source** line pointing at the exact task file, class, and `validate()`
+line. If the `gh` CLI isn't set up on the box, it prints a pre-filled GitHub "new
+issue" URL instead — no token needed locally.
 
-1. captures **read-only** evidence of the relevant live system state
-   (category-specific diagnostics — e.g. `getfacl`, `lsblk -f`, `swapon --show`
-   — plus any command you add) and your written argument,
-2. saves a full Markdown report locally under `data/disputes/`, and
-3. opens a **labelled GitHub issue** (`checker-dispute`). The issue includes a
-   **"Checker source"** line pointing at the exact task file, class, and
-   `validate()` line, so the reviewer goes straight to the code.
+**What happens next:** the `.github/workflows/checker-dispute.yml` Action fires on
+the label and runs
+[`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action).
+The reviewer opens **only** the named validator, decides strictly from your
+evidence whether the checker is genuinely wrong (bad path/grep, inverted
+condition, off-by-one, a bad RHEL 10 assumption) or the task simply wasn't done,
+posts a **verdict comment**, and — **only if the checker is wrong** — makes the
+minimal fix, runs `pytest`, and opens a **fix PR** that closes the issue.
 
-If the `gh` CLI isn't installed/authenticated on your exam box, it prints a
-**pre-filled GitHub "new issue" URL** instead — open it in any browser where
-you're logged into GitHub and click *Submit*. No `gh` or token needed on the box.
-
-**What happens next (the automation):** a GitHub Action
-(`.github/workflows/checker-dispute.yml`) fires on the `checker-dispute` label
-and runs [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action).
-The AI reviewer reads the issue, opens **only** the named validator file, and
-decides — strictly from your evidence — whether the checker logic is genuinely
-wrong (bad device-naming, wrong path/grep, inverted condition, off-by-one, a bad
-RHEL 10 assumption) or you simply hadn't completed the task. It then:
-
-- posts a **verdict comment** on the issue, and
-- **only if the checker is actually wrong**, creates a branch, makes the minimal
-  fix, runs `pytest`, and opens a **fix PR** that closes the issue.
-
-### Enabling the automation on your own fork
-
-The workflow is included but needs one secret and is already scoped correctly:
-
-1. Generate a token with `claude setup-token` (uses your Claude subscription — no
-   per-call API billing), **or** use a pay-as-you-go Anthropic API key.
-2. In your fork: **Settings → Secrets and variables → Actions → New repository
-   secret**, add **`CLAUDE_CODE_OAUTH_TOKEN`** (or **`ANTHROPIC_API_KEY`**).
-3. That's it. The workflow already grants `id-token: write` (required for the
-   OAuth token exchange) and reads either secret automatically.
-
-> The review is scoped to one file and capped at a bounded number of turns to
-> keep credit usage low. To re-run a dispute, remove and re-add the
-> `checker-dispute` label on the issue (issue-triggered workflows always run
-> from the default branch).
+**Enable it on your fork:** under Settings → Secrets and variables → Actions, add
+**`CLAUDE_CODE_OAUTH_TOKEN`** (from `claude setup-token`, uses your Claude
+subscription) or **`ANTHROPIC_API_KEY`**. The workflow is already scoped
+(`id-token: write`) and reads either. Re-run a dispute by removing and re-adding
+the `checker-dispute` label (issue-triggered workflows run from the default
+branch).
 
 ---
 
@@ -408,9 +275,8 @@ The workflow is included but needs one secret and is already scoped correctly:
 rhcsa-simulator/
 ├── rhcsa_simulator.py   # entry point / CLI
 ├── config/              # settings, exam objectives
-├── core/                # exam, practice, learn, adaptive, menu, results_db, reboot engine
-│                        #   dispute (checker disputes), full_reset, nfs_server,
-│                        #   lab_cleanup, task_env (per-task setup/teardown)
+├── core/                # exam, practice, learn, adaptive, menu, results_db, reboot
+│                        #   dispute, full_reset, nfs_server, lab_cleanup, task_env
 ├── tasks/               # task definitions by category (+ fault injection/teardown)
 ├── validators/          # safe read-only validation framework
 ├── device/              # loop-device / practice-disk management
@@ -425,10 +291,9 @@ rhcsa-simulator/
 2. Subclass `BaseTask`, decorate with `@TaskRegistry.register("category")`.
 3. Implement `generate()` (build the prompt) and `validate()` (return a
    `ValidationResult`).
-4. If the task needs a whole disk, set `disk_slots = 1` so the allocator gives
-   it a dedicated device. If it needs a starting state (a process to kill, an LV
-   to extend), add `has_fault_injection = True` with `inject_fault()` /
-   `restore_fault()`.
+4. If the task needs a whole disk, set `disk_slots = 1`. If it needs a starting
+   state (a process to kill, an LV to extend), add `has_fault_injection = True`
+   with `inject_fault()` / `restore_fault()`.
 
 ## AI-powered feedback (optional)
 
@@ -437,14 +302,13 @@ Set `ANTHROPIC_API_KEY` to enable line-by-line command analysis. See
 
 ## Troubleshooting
 
-- **"must be run as root"** — launch with `sudo`; validation needs root.
+- **"must be run as root"** — launch with `sudo`.
 - **Storage tasks fail in a container** — loop devices/SELinux/systemd may be
   limited; use a real RHEL/Rocky/Alma VM.
-- **Left in a messy state after a crash** — run **Setup → System Reset**; it also
-  restores any practice "faults" that were still active.
-- **Want a truly clean box (stale mounts, extra repos/flatpaks, leftover users)**
-  — run **Setup → Full System Reset**. It unmounts every non-system mount first,
-  so leftovers from a previous exam/NFS session are cleared too.
+- **Messy state after a crash** — run **Setup → System Reset** (also restores any
+  practice "faults" still active).
+- **Want a truly clean box** — run **Setup → Full System Reset** (unmounts every
+  non-system mount first, clearing stale mounts/repos/flatpaks/users).
 - **Reinstall from scratch** — re-run `./install.sh --yes`.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -235,6 +235,47 @@ mistyped or truncated code is rejected rather than importing garbage. Its length
 grows with your history (a light user is a short string; a very active user can
 reach a few KB — fine to copy/paste).
 
+### Why this matters during active development
+
+The progress code is **version-portable** — it survives *upgrading the simulator
+itself*, not just reinstalling the OS. That is deliberate, and it is the reason
+the feature exists:
+
+- The code encodes only stable, forward-compatible data: your exam/practice
+  **history** (task id, category, score, timestamps) and per-category **SM-2
+  spaced-repetition state** (easiness factor, interval, repetitions, due date).
+  It deliberately omits task descriptions, checks, and hints — anything a new
+  release might rewrite — so it is **not tied to a particular version's task
+  set**.
+- Import is schema-tolerant: each field is read with a default and de-duplicated,
+  and the payload carries a format version (`RH1` / `v:1`) plus a checksum. A
+  code exported by an older build imports cleanly into a newer one.
+- The raw SQLite DB under `data/` is **not** safe to copy between versions — its
+  schema can change from release to release. The progress code is the stable
+  interchange format that insulates your history from those schema changes.
+
+While the simulator is under active development you routinely do things that
+wipe or migrate that local DB:
+
+- `git pull` / switching to a branch whose DB schema differs
+- re-running `./install.sh`, a **Full System Reset**, or spinning up a fresh VM
+- deleting `data/` to reproduce a bug from a clean slate
+
+**Export a code first, upgrade or reset, then import it** — your accumulated
+history and adaptive scheduling come back intact, so a version bump never costs
+you your progress:
+
+```bash
+rhcsa-simulator --export-code > my-progress.code   # before pulling / resetting
+# ... git pull / ./install.sh / rebuild the VM ...
+rhcsa-simulator --import-code "$(cat my-progress.code)"
+```
+
+> **Caveat:** SM-2 targeting is keyed by **category name**. If a new version
+> renames or removes a category, that category's *history* still imports, but its
+> spaced-repetition schedule won't re-attach to the renamed category. Task-level
+> history is unaffected.
+
 ---
 
 ## Practice disks (LVM / partitioning / swap / filesystems)


### PR DESCRIPTION
Two related README changes.

### 1. New: "Why progress codes matter during active development"
Adds to the *Progress snapshots* section the rationale that was missing — that progress is **version-portable**: the code encodes only history + per-category SM-2 state (not regenerable task text), is format-versioned (`RH1`/`v:1`) and checksummed, and imports schema-tolerantly, so a code from an older build loads into a newer one. The raw `data/` SQLite DB is *not* safe to copy across versions; the code is the stable interchange format. Lists the dev workflows that wipe/migrate the DB (`git pull`, `./install.sh`, Full System Reset, fresh VM, deleting `data/`) and the export → upgrade → import recipe. Caveat noted: SM-2 targeting is keyed by category name.

### 2. Tighten the whole README (452 → 316 lines)
Condense prose without dropping facts — fold the VM-config bullets into a paragraph, compress the package/service and Setup/Full-Reset sections, trim the dispute-workflow walkthrough. All commands, tables, the package matrix, the domain list, and the reset guarantees are retained. Drops the one fragile internal anchor link.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WPpnU5ycpYv4UUoxcFkEU