### PR TITLE
Add post-setup sanity check (tasks must actually change the machine)

### DIFF
--- a/core/exam.py
+++ b/core/exam.py
@@ -100,6 +100,10 @@ class ExamSession:
         # can't pass on pre-existing/default state.
         self._setup_task_environments()
 
+        # Sanity-check that setup actually put the box into each task's scenario
+        # (no task should already be passing before the candidate starts).
+        self._sanity_check_tasks()
+
         # Refresh the remote NFS server's exports so this exam starts clean.
         self._reprovision_nfs()
 
@@ -176,6 +180,21 @@ class ExamSession:
                 # is still valid, so stay quiet to avoid alarming the candidate.
             except Exception as e:
                 print(fmt.warning(f"  ✗ {task.id}: setup error ({e})"))
+
+    def _sanity_check_tasks(self):
+        """After setup, verify no task is already passing before the candidate
+        starts. A pass at t=0 means its fault/precondition no-op'd (or it passes
+        on default state) — a free pass. Print only a non-spoiling count here (so
+        we don't reveal WHICH tasks need no work); full details go to the log."""
+        try:
+            from core import task_sanity
+            warnings = task_sanity.check_tasks(self.tasks, verbose_console=False)
+        except Exception:
+            return
+        if warnings:
+            print(fmt.warning(
+                f"  ⚠ {len(warnings)} task(s) may not have initialized correctly "
+                f"(see the log). They'll still be scored normally."))
 
     def _clean_lab_leftovers(self):
         """Remove leftover task artifacts (files/dirs/mounts the tasks ask the

--- a/core/task_env.py
+++ b/core/task_env.py
@@ -73,6 +73,19 @@ def setup_task(task, verbose=True):
             if verbose:
                 print(fmt.warning(f"  Setup error: {e}"))
 
+    # Sanity check: with setup done and nothing done by the candidate yet, the
+    # task must NOT already be passing. If it is, the fault/precondition no-op'd
+    # (or it passes on default state) and the candidate would get a free pass.
+    try:
+        from core import task_sanity
+        warning = task_sanity.check_task(task)
+        if warning:
+            logger.warning("SANITY: %s", warning)
+            if verbose:
+                print(fmt.warning(f"  ⚠ {warning}"))
+    except Exception as e:
+        logger.debug("sanity check skipped for %s: %s", getattr(task, 'id', '?'), e)
+
     return state
 
 

--- a/core/task_sanity.py
+++ b/core/task_sanity.py
@@ -1,0 +1,99 @@
+"""
+Post-setup sanity check — "is this task actually a task?"
+
+After a task's environment is prepared (fault injected, negative precondition
+established, lab leftovers cleaned) but BEFORE the candidate has done anything,
+the task must **not** already be passing. If `validate()` passes at t=0 then one
+of these is true and the candidate would get a free pass:
+
+  * the setup silently no-op'd — e.g. an httpd SELinux fault where httpd isn't
+    installed, so `chcon`/`systemctl` did nothing and there's no symptom to fix;
+  * a positive-config task is satisfied by default/pre-existing state and has no
+    setup to make it real work;
+  * a leftover artifact from a previous session wasn't cleaned.
+
+This check is deliberately generic — it drives each task's OWN read-only
+`validate()` (via the exception-safe ValidationEngine) and just asserts the task
+is not already green. That makes it work for every task type without knowing
+anything task-specific, and it runs in EVERY mode: exam calls check_tasks() after
+its setup phase, and quick/practice/adaptive get it for free because they all
+prepare tasks through core.task_env.setup_task(), which calls check_task() here.
+
+It is advisory: it logs (and optionally prints) a warning so a broken scenario is
+visible, but never aborts the session — a task whose fault didn't take is still
+presented, just descriptively.
+"""
+
+import logging
+
+from utils import formatters as fmt
+
+logger = logging.getLogger(__name__)
+
+
+def _already_satisfied(task, validator):
+    """True if the task validates as passed right now, False if not, None if the
+    check couldn't run (validate errored / returned nothing)."""
+    try:
+        result = validator.validate_task(task)
+    except Exception as e:  # validate_task is exception-safe, but be defensive
+        logger.debug("sanity: validate raised for %s: %s", getattr(task, 'id', '?'), e)
+        return None
+    if result is None or getattr(result, 'error_message', None):
+        # A validation error means we can't trust the verdict — don't flag.
+        return None
+    return bool(getattr(result, 'passed', False))
+
+
+def check_task(task, validator=None):
+    """Return a warning string if `task` is already satisfied before any work is
+    done (suspicious), else None.
+
+    Pass a validator to reuse one across many tasks; otherwise the shared engine
+    is used.
+    """
+    if validator is None:
+        from core.validator import get_validator
+        validator = get_validator()
+
+    satisfied = _already_satisfied(task, validator)
+    if not satisfied:
+        return None
+
+    tid = getattr(task, 'id', '?')
+    category = getattr(task, 'category', '?')
+    has_prep = getattr(task, 'has_fault_injection', False) or getattr(task, 'has_setup', False)
+    if has_prep:
+        reason = ("its fault/precondition setup did not change the machine "
+                  "(silent no-op — is the required package/service present?)")
+    else:
+        reason = ("it passes on default/pre-existing state and has no setup to "
+                  "require real work")
+    return f"{tid} ({category}): already satisfied before you start — {reason}"
+
+
+def check_tasks(tasks, verbose_console=True):
+    """Run the post-setup sanity check over `tasks`. Logs every suspicious task
+    and returns the list of warning strings.
+
+    verbose_console=True prints each warning (training modes, where revealing a
+    gimme task is harmless). Exam mode passes verbose_console=False so it can show
+    only a non-spoiling aggregate instead of naming which tasks need no work.
+    """
+    from core.validator import get_validator
+    validator = get_validator()
+
+    warnings = []
+    for task in tasks:
+        try:
+            w = check_task(task, validator)
+        except Exception as e:
+            logger.debug("sanity: check_task failed for %s: %s",
+                         getattr(task, 'id', '?'), e)
+            continue
+        if w:
+            warnings.append(w)
+            logger.warning("SANITY: %s", w)
+            if verbose_console:
+                print(fmt.warning(f"  ⚠ {w}"))
+    return warnings

--- a/tests/unit/test_task_sanity.py
+++ b/tests/unit/test_task_sanity.py
@@ -1,0 +1,95 @@
+"""
+Post-setup sanity check (core.task_sanity).
+
+A task must not already be passing right after setup and before the candidate
+does anything — a pass at t=0 means the fault/precondition no-op'd (or it passes
+on default state). These tests drive the check with a fake validator so no real
+system state is touched.
+"""
+
+import pytest
+
+from core import task_sanity
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Result:
+    def __init__(self, passed, error_message=None):
+        self.passed = passed
+        self.error_message = error_message
+
+
+class _Validator:
+    """Stand-in for the ValidationEngine keyed on task id."""
+    def __init__(self, verdicts):
+        self._verdicts = verdicts  # task_id -> _Result | Exception
+
+    def validate_task(self, task):
+        v = self._verdicts[task.id]
+        if isinstance(v, Exception):
+            raise v
+        return v
+
+
+class _Task:
+    def __init__(self, tid, category="services", has_setup=False, has_fault_injection=False):
+        self.id = tid
+        self.category = category
+        self.has_setup = has_setup
+        self.has_fault_injection = has_fault_injection
+
+
+class TestCheckTask:
+    def test_not_passing_at_start_is_fine(self):
+        # The normal, healthy case: setup broke something, task fails until fixed.
+        t = _Task("ok_001", has_fault_injection=True)
+        v = _Validator({"ok_001": _Result(passed=False)})
+        assert task_sanity.check_task(t, v) is None
+
+    def test_already_passing_with_setup_is_flagged_as_noop(self):
+        t = _Task("httpd_fault_001", has_fault_injection=True)
+        v = _Validator({"httpd_fault_001": _Result(passed=True)})
+        w = task_sanity.check_task(t, v)
+        assert w is not None
+        assert "httpd_fault_001" in w
+        assert "no-op" in w.lower()
+
+    def test_already_passing_without_setup_is_flagged_as_default_state(self):
+        t = _Task("selinux_enforcing_001", has_setup=False, has_fault_injection=False)
+        v = _Validator({"selinux_enforcing_001": _Result(passed=True)})
+        w = task_sanity.check_task(t, v)
+        assert w is not None
+        assert "default" in w.lower()
+
+    def test_validation_error_is_not_flagged(self):
+        # If validate() couldn't produce a trustworthy verdict, don't cry wolf.
+        t = _Task("weird_001", has_setup=True)
+        v = _Validator({"weird_001": _Result(passed=True, error_message="Validation error: boom")})
+        assert task_sanity.check_task(t, v) is None
+
+    def test_validator_exception_is_swallowed(self):
+        t = _Task("boom_001")
+        v = _Validator({"boom_001": RuntimeError("kaboom")})
+        assert task_sanity.check_task(t, v) is None
+
+
+class TestCheckTasks:
+    def test_returns_and_counts_only_suspicious(self, monkeypatch):
+        tasks = [
+            _Task("free_pass_001", has_fault_injection=True),
+            _Task("healthy_001", has_fault_injection=True),
+        ]
+        v = _Validator({
+            "free_pass_001": _Result(passed=True),
+            "healthy_001": _Result(passed=False),
+        })
+        monkeypatch.setattr(task_sanity, "get_validator", lambda: v, raising=False)
+        # get_validator is imported inside check_tasks from core.validator; patch there
+        import core.validator as CV
+        monkeypatch.setattr(CV, "get_validator", lambda: v)
+
+        warnings = task_sanity.check_tasks(tasks, verbose_console=False)
+        assert len(warnings) == 1
+        assert "free_pass_001" in warnings[0]


### PR DESCRIPTION
Adds a mode-agnostic sanity check that catches the exact failure we keep hitting: a task whose setup silently no-op'd, so the candidate gets a **free pass**.

## The invariant
Right after setup — fault injected / negative precondition established / lab cleaned — but **before the candidate does anything**, a task must **not** already be passing. A pass at t=0 means one of:
- the fault/precondition no-op'd (e.g. an httpd SELinux fault where httpd isn't installed → `chcon`/`systemctl` did nothing),
- a positive-config task is satisfied by default state with no setup to require work,
- a leftover from a prior session wasn't cleaned.

## How it works (generic, no per-task knowledge)
`core/task_sanity.py` drives each task's **own read-only `validate()`** via the exception-safe `ValidationEngine` and just asserts it isn't already green. So it works for every task type, in every mode:

- **exam** — `check_tasks()` runs after the setup phase and prints only a **non-spoiling count** (`⚠ N task(s) may not have initialized correctly (see the log)`); per-task details go to the log so it never reveals which tasks need no work.
- **quick / practice / adaptive** — get it for free: they all prepare tasks through `core.task_env.setup_task()`, which now calls `check_task()` after setup.

Advisory only — it logs/warns, never aborts (a task whose fault didn't take is still presented, just descriptively).

## Tests
`tests/unit/test_task_sanity.py` (6): healthy task not flagged; already-passing flagged as no-op (with setup) vs default-state (without); validation errors and validator exceptions don't cry wolf; batch counts only the suspicious ones.

> Note: quick practice routes through `setup_task()` only once #50 merges; until then it covers exam/practice/adaptive. The check lives in `setup_task()`, so any mode using it is covered automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WPpnU5ycpYv4UUoxcFkEU