### PR TITLE
Restore the machine to a clean state on every session exit

### DIFF
--- a/core/adaptive.py
+++ b/core/adaptive.py
@@ -81,6 +81,10 @@ class AdaptiveMode:
                 results.append((task, result))
         except StopIteration:
             print(fmt.info("\nSession ended early."))
+        finally:
+            # However the session ends (finished, quit, or Ctrl-C), leave a
+            # clean box — reverse any still-active setup and remove artifacts.
+            task_env.session_teardown(tasks)
 
         # Show session summary
         if results:

--- a/core/exam.py
+++ b/core/exam.py
@@ -47,6 +47,7 @@ class ExamSession:
         self.timer = None
         self._injected_tasks = []
         self._setup_tasks = []
+        self._torn_down = False
 
     def start(self):
         """Start the exam session."""
@@ -257,6 +258,28 @@ class ExamSession:
             except Exception:
                 pass
 
+    def teardown(self):
+        """Return the box to a clean state — safe to call on ANY exit path
+        (graded normally, quit early, or Ctrl-C) and idempotent.
+
+        Reverses the exam's injected faults / preconditions and tears down the
+        remote NFS exports, then removes the candidate's own lab artifacts and
+        resets practice disks so returning to the menu leaves a vanilla box. The
+        _torn_down guard makes a second call (e.g. from an outer finally after a
+        normal finish) a no-op."""
+        if self._torn_down:
+            return
+        self._torn_down = True
+        try:
+            self._restore_exam_faults()
+        except Exception:
+            pass
+        try:
+            from core import task_env
+            task_env.session_reset(verbose=False)
+        except Exception:
+            pass
+
     def _count_domains(self):
         """Count unique domains in generated tasks."""
         domains = set()
@@ -376,8 +399,8 @@ class ExamSession:
             duration, validation_results, reboot_result
         )
 
-        # Restore any fault-injected environments now that scoring is done
-        self._restore_exam_faults()
+        # Scoring is done — return the box to a clean, vanilla state.
+        self.teardown()
 
         # Save to ResultsDB
         db = get_results_db()
@@ -538,12 +561,17 @@ def run_exam_mode():
     task_count = _select_exam_task_count()
     reboot_sim = _select_reboot_simulation()
     session = ExamSession(task_count=task_count, reboot_simulation=reboot_sim)
-    session.start()
+    try:
+        session.start()
 
-    if not session.tasks:
-        return None
+        if not session.tasks:
+            return None
 
-    input("\nPress Enter when you're ready to validate your work...")
+        input("\nPress Enter when you're ready to validate your work...")
 
-    result = session.validate_all()
-    return result
+        return session.validate_all()
+    finally:
+        # However this exits — graded, quit early, or Ctrl-C at the prompt —
+        # reverse the injected faults/preconditions and clean up. Idempotent, so
+        # a normal finish (which already tore down in validate_all) is unaffected.
+        session.teardown()

--- a/core/practice.py
+++ b/core/practice.py
@@ -104,6 +104,10 @@ class PracticeSession:
             print(fmt.success("\nPractice session complete!"))
         except StopIteration:
             print(fmt.info("\nPractice session ended early."))
+        finally:
+            # However the session ends (finished, quit, or Ctrl-C), leave a
+            # clean box — reverse any still-active setup and remove artifacts.
+            task_env.session_teardown(tasks)
 
     def _select_category(self):
         """Select practice category."""

--- a/core/task_env.py
+++ b/core/task_env.py
@@ -107,3 +107,32 @@ def reset_after_task(task):
         helpers.reset_practice_loops()
     except Exception:
         pass
+
+
+def session_teardown(tasks, verbose=True):
+    """End-of-session cleanup — call this on EVERY exit path (finished, quit, or
+    Ctrl-C) so returning to the menu leaves a clean box.
+
+    It (1) reverses every task's injected fault / negative precondition, then
+    (2) removes leftover lab artifacts and resets practice disks (same as the
+    start-of-session reset). Both steps are idempotent and swallow errors: the
+    per-task restore records are cleared as they replay, so calling this twice —
+    e.g. once at normal end and again from an outer finally — is a harmless
+    no-op. Safe to call even if setup never ran (empty/None tasks is fine).
+    """
+    if verbose:
+        print(fmt.dim("Restoring the machine to a clean state..."))
+    for task in tasks or []:
+        if getattr(task, 'has_fault_injection', False):
+            try:
+                task.restore_fault()
+            except Exception:
+                pass
+        if getattr(task, 'has_setup', False):
+            try:
+                task.teardown_environment()
+            except Exception:
+                pass
+    # Remove candidate-created artifacts (files, mounts, swap, units, …) and
+    # reset practice disks so the box is back to a clean, vanilla state.
+    session_reset(verbose=False)

--- a/tests/unit/test_session_teardown.py
+++ b/tests/unit/test_session_teardown.py
@@ -1,0 +1,107 @@
+"""
+Session teardown on every exit path.
+
+The machine must be returned to a clean state whenever a session ends — finished,
+quit, or Ctrl-C — not just on a fully-graded exam. Covers core.task_env
+.session_teardown (training modes) and ExamSession.teardown (exam mode).
+"""
+
+import pytest
+
+from core import task_env
+from core import exam as exam_mod
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Task:
+    def __init__(self, tid, fault=False, setup=False, sink=None):
+        self.id = tid
+        self.has_fault_injection = fault
+        self.has_setup = setup
+        self._sink = sink
+
+    def restore_fault(self):
+        self._sink.append(("restore_fault", self.id))
+        return True, "restored"
+
+    def teardown_environment(self):
+        self._sink.append(("teardown_env", self.id))
+        return True, "torn down"
+
+
+class TestSessionTeardown:
+    def test_reverses_setup_then_cleans_box(self, monkeypatch):
+        sink = []
+        monkeypatch.setattr(task_env, "session_reset",
+                            lambda *a, **k: sink.append(("session_reset",)))
+        tasks = [
+            _Task("fault_1", fault=True, sink=sink),
+            _Task("setup_1", setup=True, sink=sink),
+            _Task("plain_1", sink=sink),  # nothing to reverse
+        ]
+        task_env.session_teardown(tasks, verbose=False)
+
+        assert ("restore_fault", "fault_1") in sink
+        assert ("teardown_env", "setup_1") in sink
+        # Artifact cleanup / disk reset happens after per-task reversal.
+        assert sink[-1] == ("session_reset",)
+        # A plain task triggers neither restore nor teardown.
+        assert not any(t[0] in ("restore_fault", "teardown_env") and t[1] == "plain_1"
+                       for t in sink)
+
+    def test_empty_and_none_are_safe(self, monkeypatch):
+        sink = []
+        monkeypatch.setattr(task_env, "session_reset",
+                            lambda *a, **k: sink.append(("session_reset",)))
+        task_env.session_teardown([], verbose=False)
+        task_env.session_teardown(None, verbose=False)
+        # Still cleans the box even with no tasks.
+        assert sink == [("session_reset",), ("session_reset",)]
+
+    def test_task_restore_errors_do_not_stop_cleanup(self, monkeypatch):
+        sink = []
+        monkeypatch.setattr(task_env, "session_reset",
+                            lambda *a, **k: sink.append(("session_reset",)))
+
+        class _Boom(_Task):
+            def restore_fault(self):
+                raise RuntimeError("restore blew up")
+
+        task_env.session_teardown([_Boom("boom", fault=True, sink=sink)], verbose=False)
+        # The box is still cleaned despite the per-task error.
+        assert ("session_reset",) in sink
+
+
+class TestExamTeardown:
+    def test_idempotent(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(exam_mod.ExamSession, "_restore_exam_faults",
+                            lambda self: calls.append("restore"))
+        monkeypatch.setattr(task_env, "session_reset",
+                            lambda *a, **k: calls.append("reset"))
+
+        s = exam_mod.ExamSession(task_count=1)
+        s.teardown()
+        s.teardown()  # second call must be a no-op
+        assert calls == ["restore", "reset"]
+
+    def test_run_exam_mode_tears_down_on_early_quit(self, monkeypatch):
+        # If the candidate Ctrl-C's the "Press Enter" prompt before validating,
+        # the outer finally must still restore + clean.
+        torn = []
+        monkeypatch.setattr(exam_mod, "_select_exam_task_count", lambda: 1)
+        monkeypatch.setattr(exam_mod, "_select_reboot_simulation", lambda: False)
+        monkeypatch.setattr(exam_mod.ExamSession, "start",
+                            lambda self: setattr(self, "tasks", [object()]))
+        monkeypatch.setattr(exam_mod.ExamSession, "teardown",
+                            lambda self: torn.append(True))
+
+        def _interrupt(*a, **k):
+            raise KeyboardInterrupt()
+        monkeypatch.setattr("builtins.input", _interrupt)
+
+        with pytest.raises(KeyboardInterrupt):
+            exam_mod.run_exam_mode()
+        assert torn == [True], "teardown must run even when the exam is aborted"


### PR DESCRIPTION
Returns the machine to a clean, vanilla state whenever a session ends — **finished, quit, or Ctrl-C** — not just after a fully-graded exam.

## The gap
- **Exam:** injected faults/preconditions were only reversed at the *tail* of `validate_all()`. Quitting before validating (Ctrl-C at the "Press Enter to validate" prompt, or any exception) left the box in the broken/precondition state — never returned to vanilla.
- **All modes:** the candidate's own artifacts (files, mounts, swap, LVM, units) were only cleaned at the *next* session start, not on exit.

## Fix
- **`core/task_env.session_teardown(tasks)`** — reverse every task's fault/precondition, then remove lab artifacts + reset practice disks. Idempotent and error-swallowing; safe on any exit path and with empty/`None` tasks.
- **Exam** — new idempotent `ExamSession.teardown()` (restore faults + NFS + clean box), guarded by a `_torn_down` flag. `validate_all()` calls it after scoring; **`run_exam_mode()` wraps the whole flow in `try/finally`** so a Ctrl-C / early quit still tears down exactly once.
- **Practice / Adaptive** — call `session_teardown(tasks)` in a `finally` around the task loop.

## Tests
`tests/unit/test_session_teardown.py` (5): per-task reversal happens before box cleanup; empty/`None` safety; a per-task restore error doesn't block cleanup; exam teardown is idempotent; teardown runs on an **aborted** exam.

> Quick practice's session teardown rides on its env-lifecycle PR (#50), which is what routes quick through `task_env`. This PR covers exam/practice/adaptive; once #50 merges, quick is covered by the same helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WPpnU5ycpYv4UUoxcFkEU