### PR TITLE
Session lifecycle overhaul: consent-gated installs, no answer leaks, exam env persists, one Reset button

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ cd rhcsa-simulator
 rhcsa-simulator       # launch (must be root — validation reads real state)
 ```
 
-At the menu, press **E** for a full Mock Exam or **Q** for a 5-task quick round.
+At the menu, press **E** for a full Mock Exam or **Q** for a quick practice round.
 
 The simulator **auto-creates the practice disks it needs** (loop devices, plus
 any spare disk like `/dev/sda`) and **sets up each task's starting state** at
 exam start — so a "kill the apache processes" task actually has processes
-running, and an "extend the logical volume" task actually has a volume — then
-tears it all down when the exam ends.
+running, and an "extend the logical volume" task actually has a volume. After
+the exam the environment is kept for review/disputes; **Setup → Reset Machine**
+(or the next session start) cleans everything up.
 
 **Typical loop:** read a task → do it on the system in another terminal → return
 and press Enter to validate → review per-check feedback and score.
@@ -78,14 +79,15 @@ SELinux).
 The simulator itself needs nothing beyond the Python standard library. But a
 **minimal RHEL/Rocky/Alma install doesn't ship `httpd`, `vsftpd`, or several
 other services** that specific tasks (mostly Domain 7 Troubleshooting and
-Domain 6 Services) use to build a realistic scenario. If a package is
-missing, the task's fault-injection step still reports "active" — its own
-`systemctl`/`chcon`/etc. calls just no-op — so the scenario looks like
-nothing happened when you go to work on it in a second terminal.
+Domain 6 Services) use to build a realistic scenario.
 
-Every launch of `rhcsa-simulator` (any mode) runs a **read-only preflight
-check** (`rpm -q`) and prints a warning listing anything missing, along with
-a ready-to-run `dnf install` command. Nothing is installed automatically.
+Every launch runs a **read-only preflight check** (`rpm -q`) and warns about
+anything missing. When a session's drawn tasks need a missing package, the
+simulator **asks (Y/n) whether to install it** at session start — nothing is
+ever installed without your consent. If you decline, the affected scenarios
+degrade gracefully: SELinux troubleshooting tasks plant the same audit-log
+evidence a real denial would have produced (so `ausearch | audit2why` still
+leads you to the root cause), and service-based scenarios are skipped.
 
 | Package | Used by |
 |---|---|
@@ -147,7 +149,7 @@ sudo rhcsa-simulator    # interactive menu
 
 | Key | Mode | What it does |
 |---|---|---|
-| `Q` | **Quick Practice** | 5 random tasks, fast feedback |
+| `Q` | **Quick Practice** | Short session (you pick 4-20 tasks), fast feedback |
 | `E` | **Mock Exam** | Full timed exam (20–25 tasks) with setup + reboot-persistence simulation |
 | `1` | **Learn Mode** | Study by domain — concepts, commands, tips |
 | `2` | **Practice Mode** | One category at a time, with retry & progressive hints |
@@ -155,13 +157,13 @@ sudo rhcsa-simulator    # interactive menu
 | `4` | **Dashboard** | Stats, history, weak areas |
 | `5` | **Export Report** | Write a progress report to `data/` |
 | `6` | **Result History** | Drill into past exams (press `d` on a task to dispute a check) |
-| `S` | **Setup** | Practice disks, resets, remote NFS server, lab cleanup, DNF-history |
+| `S` | **Setup** | Practice disks, Reset Machine, remote NFS server, DNF-history |
 | `0` | Exit | |
 
 ### Command-line shortcuts
 
 ```bash
-rhcsa-simulator --quick [lvm]        # 5 random (or category) tasks
+rhcsa-simulator --quick [lvm]        # short practice round (pick 4-20 tasks)
 rhcsa-simulator --exam               # jump straight into a mock exam
 rhcsa-simulator --practice lvm       # practice a specific category
 rhcsa-simulator --learn              # study mode
@@ -201,7 +203,7 @@ so a code from an older build loads cleanly into a newer one. The raw SQLite DB
 under `data/` is **not** safe to copy across versions (its schema can change) —
 the code is the stable interchange format that insulates your progress. So
 before anything that wipes or migrates that DB — `git pull` to a new schema,
-`./install.sh`, a Full System Reset, a fresh VM, or deleting `data/` — export a
+`./install.sh`, a Reset Machine, a fresh VM, or deleting `data/` — export a
 code first, then import it afterward.
 
 > **Caveat:** SM-2 targeting is keyed by **category name**. If a version renames
@@ -220,24 +222,30 @@ collide. Loop images live in `/var/lib/rhcsa-simulator/loops/`.
 
 **Setup** also offers:
 
-- **System Reset** — remove practice artifacts (LVM, swap files, practice repos,
-  cron/at jobs, scripts) without touching SSH/network/users.
-- **Full System Reset** — strip the box back to a basic RHEL install: all
-  third-party DNF repos, Flatpak apps/remotes, lab files, practice users/groups,
-  practice disks/swap, scheduled jobs, autofs maps, tuned changes, and remote NFS
-  exports — unmounting every non-system mount first. **Preserves** the simulator,
-  your GitHub/SSH connectivity (`~/.config/gh`, `~/.ssh`, git config),
-  networking, firewall, SELinux, the OS, and all real accounts. Previews
-  everything and requires typing `RESET`.
+- **Reset Machine** — *the* single cleanup button. Restores any injected faults
+  and task starting-states to their originals, then strips every practice
+  artifact: lab files, practice disks & swap, third-party DNF repos, Flatpak
+  apps/remotes, scheduled jobs, autofs maps, tuned changes, practice
+  users/groups, and remote NFS exports — unmounting every non-system mount
+  first. **Preserves** the simulator, your GitHub/SSH connectivity
+  (`~/.config/gh`, `~/.ssh`, git config), networking, firewall, SELinux, the
+  OS, and all real accounts. Previews everything and requires typing `RESET`.
 - **Configure remote NFS server** — SSH into a RHEL box you control and provision
-  real, seeded NFS exports for the network-storage tasks (refreshed each exam,
-  torn down after).
-- **Clean lab leftover files** and **Populate Practice Environment** (DNF
-  history).
+  real, seeded NFS exports for the network-storage tasks (refreshed each exam).
+- **Populate Practice Environment** (DNF history).
 
-> Practice and Adaptive modes reset the box at session start and set up/tear down
-> each task's state per iteration, the same way the Mock Exam does. Adaptive mode
-> also lets you choose how many tasks to run.
+### When does the machine get cleaned?
+
+- **After a Mock Exam: never automatically.** The environment is deliberately
+  left exactly as you finished it, so you can compare your work against the
+  scores and file checker disputes with live evidence. Clean up explicitly with
+  **Setup → Reset Machine** — or just start the next session, which resets
+  everything first.
+- **Training sessions** (Quick/Practice/Adaptive) revert all system changes
+  **once, at the end of the session** (finish, quit, or Ctrl-C) — not between
+  tasks. Practice disks are the one exception: they're wiped between disk tasks
+  so the next one gets a clean device.
+- **Every session start** restores anything a previous session left behind.
 
 ---
 
@@ -262,8 +270,10 @@ Run `rhcsa-simulator --list-categories` for the live list and per-category count
 
 - **Read-only validation.** Work is graded with whitelisted, timeout-protected,
   read-only commands (`id`, `lsblk`, `systemctl is-active`, `getenforce`, …).
-  Only the exam's setup/teardown phase changes state, and it reverses what it
-  created.
+  Only session setup changes state (injecting faults, preparing starting
+  states); everything is reversed at training-session end, at next session
+  start, or via **Setup → Reset Machine** (see *When does the machine get
+  cleaned?* above).
 - **Scoring.** Each task has multiple checks with partial credit; default pass
   threshold is 70%. A full exam is 20–25 tasks over a 3-hour timer
   (configurable), followed by a reboot-persistence simulation for tasks that must
@@ -341,10 +351,9 @@ Set `ANTHROPIC_API_KEY` to enable line-by-line command analysis. See
 - **"must be run as root"** — launch with `sudo`.
 - **Storage tasks fail in a container** — loop devices/SELinux/systemd may be
   limited; use a real RHEL/Rocky/Alma VM.
-- **Messy state after a crash** — run **Setup → System Reset** (also restores any
-  practice "faults" still active).
-- **Want a truly clean box** — run **Setup → Full System Reset** (unmounts every
-  non-system mount first, clearing stale mounts/repos/flatpaks/users).
+- **Messy state after a crash / want a clean box** — run **Setup → Reset
+  Machine**. It restores active faults, unmounts every non-system mount, and
+  clears stale mounts/repos/flatpaks/practice users in one pass.
 - **Reinstall from scratch** — re-run `./install.sh --yes`.
 
 ## License

--- a/core/adaptive.py
+++ b/core/adaptive.py
@@ -69,9 +69,10 @@ class AdaptiveMode:
             return
 
         # Reset the box to a clean, practice-ready state (fresh loop disks +
-        # remove leftover artifacts) just like exam mode does at start.
+        # remove leftover artifacts) just like exam mode does at start, and
+        # offer to install any packages the drawn tasks rely on.
         print(fmt.dim("Preparing a clean practice environment..."))
-        task_env.session_reset()
+        task_env.prepare_session(tasks)
 
         # Run session
         results = []
@@ -91,24 +92,12 @@ class AdaptiveMode:
             self._show_summary(results, source)
 
     def _select_task_count(self):
-        """Ask how many tasks this session should include (default 5, no cap)."""
-        print(fmt.bold("How many tasks this session?"))
-        print(fmt.dim("  Enter a number (e.g. 5, 10, 15). Default 5."))
-        while True:
-            raw = input("\nNumber of tasks [5]: ").strip() or '5'
-            try:
-                n = int(raw)
-            except ValueError:
-                print(fmt.error("Please enter a whole number."))
-                continue
-            if n < 1:
-                print(fmt.error("Enter at least 1."))
-                continue
-            if n > 40:
-                print(fmt.warning("Capping at 40 tasks for one session."))
-                n = 40
-            print()
-            return n
+        """Ask how many tasks this session should include (4-20, default 5) —
+        same chooser as quick practice and practice mode."""
+        from utils.helpers import select_task_count
+        n = select_task_count(default=5)
+        print()
+        return n
 
     def _select_categories(self):
         """Select categories based on SM-2 data. Returns (categories, source_label)."""
@@ -210,7 +199,7 @@ class AdaptiveMode:
         # precondition) so it requires real work — same setup exam mode runs.
         fmt.clear_screen()
         print(fmt.bold("Preparing task environment..."))
-        env_state = task_env.setup_task(task)
+        task_env.setup_task(task)
         time.sleep(1)
 
         fmt.clear_screen()
@@ -290,11 +279,12 @@ class AdaptiveMode:
             print(fmt.success("\nGreat job!"))
         print()
 
-        # Reverse this task's system changes, then wipe practice disks if it
-        # consumed one so the next task starts clean.
-        print(fmt.dim("Restoring system..."))
-        task_env.teardown_task(task, env_state)
-        task_env.reset_after_task(task)
+        # System changes are reverted once, at the end of the session (see
+        # start()'s finally). Only wipe practice disks between disk tasks so the
+        # next one gets a clean, signature-free device.
+        if getattr(task, 'disk_slots', 0) > 0 and current < total:
+            print(fmt.dim("Re-provisioning practice disks for the next task..."))
+            task_env.reset_after_task(task)
 
         if current < total:
             if not confirm_action("Continue to next task?", default=True):

--- a/core/exam.py
+++ b/core/exam.py
@@ -47,7 +47,6 @@ class ExamSession:
         self.timer = None
         self._injected_tasks = []
         self._setup_tasks = []
-        self._torn_down = False
 
     def start(self):
         """Start the exam session."""
@@ -63,18 +62,11 @@ class ExamSession:
         # plus any spare non-system disk like /dev/sda) so the generator can cap
         # whole-disk tasks to the number of devices we can actually hand out.
         from utils import helpers
-        # Start from a clean loop-device pool. Interrupted prior sessions can
-        # leave orphan loops (attached to deleted images, stale PV/fs
-        # signatures, dangling LVM-devices-file entries) that would otherwise be
-        # handed to disk tasks and break pvcreate/mkfs. Reset wipes those and
-        # recreates fresh, signature-free practice disks.
-        try:
-            helpers.reset_practice_loops()
-        except Exception:
-            pass
-        # Remove leftover task artifacts from previous sessions (stray
-        # /tmp/*.txt, old mount points, swap files, etc.) so this exam is clean.
-        self._clean_lab_leftovers()
+        from core import task_env
+        # Start from a clean box: restore anything a previous session left in
+        # place (exams keep their environment for review/disputes), wipe orphan
+        # loop devices, and remove leftover task artifacts.
+        task_env.session_reset()
         try:
             pool = helpers.build_device_pool()
         except Exception:
@@ -93,6 +85,15 @@ class ExamSession:
 
         # Give each whole-disk task a distinct device (no two share one disk)
         self._provision_devices()
+
+        # Offer to install any packages the drawn scenarios rely on. Nothing is
+        # installed without the user's consent; tasks whose packages remain
+        # missing degrade gracefully (reduced scenario / fabricated evidence).
+        from core import preflight
+        try:
+            preflight.offer_task_packages(self.tasks)
+        except Exception:
+            pass
 
         # Inject faults / set up environments for tasks that require it
         self._inject_exam_faults()
@@ -145,42 +146,56 @@ class ExamSession:
             helpers.end_device_allocation()
 
     def _inject_exam_faults(self):
-        """Inject faults / create practice environments for all tasks that need it."""
-        import time
+        """Inject faults / create practice environments for all tasks that need
+        it. Output is deliberately generic — printing the task id or the
+        injection message would hand the candidate the answer (e.g. "Set wrong
+        SELinux context (etc_t) on /var/www/html"). Details go to the log."""
         fault_tasks = [t for t in self.tasks if getattr(t, 'has_fault_injection', False)]
         if not fault_tasks:
             return
         print(fmt.bold("\nPreparing exam environment..."))
+        armed = skipped = 0
         for task in fault_tasks:
             try:
                 ok, msg = task.inject_fault()
                 if ok:
-                    print(fmt.success(f"  ✓ {task.id}: {msg}"))
                     self._injected_tasks.append(task)
+                    armed += 1
+                    logger.info("fault armed: %s: %s", task.id, msg)
                 else:
-                    print(fmt.warning(f"  ✗ {task.id}: {msg} (task will be descriptive only)"))
+                    skipped += 1
+                    logger.warning("fault skipped (descriptive only): %s: %s", task.id, msg)
             except Exception as e:
-                print(fmt.warning(f"  ✗ {task.id}: setup error ({e})"))
-        time.sleep(1)
+                skipped += 1
+                logger.warning("fault setup error: %s: %s", task.id, e)
+        line = f"  {armed} scenario(s) prepared"
+        if skipped:
+            line += f", {skipped} skipped (details in the log)"
+        print(fmt.dim(line))
         print()
 
     def _setup_task_environments(self):
         """Run setup_environment() for positive-config tasks so they establish a
         negative precondition (stop a default-on service, move an artifact aside)
-        and therefore require real work to pass."""
+        and therefore require real work to pass. Output stays generic — the
+        setup message describes exactly what was changed (i.e. the answer)."""
         setup_tasks = [t for t in self.tasks if getattr(t, 'has_setup', False)]
         if not setup_tasks:
             return
+        prepared = 0
         for task in setup_tasks:
             try:
                 ok, msg = task.setup_environment()
                 if ok:
-                    print(fmt.success(f"  ✓ {task.id}: {msg}"))
                     self._setup_tasks.append(task)
+                    prepared += 1
+                    logger.info("precondition set: %s: %s", task.id, msg)
                 # A False result just means no precondition was needed; the task
                 # is still valid, so stay quiet to avoid alarming the candidate.
             except Exception as e:
-                print(fmt.warning(f"  ✗ {task.id}: setup error ({e})"))
+                logger.warning("precondition error: %s: %s", task.id, e)
+        if prepared:
+            print(fmt.dim(f"  {prepared} starting state(s) prepared"))
 
     def _sanity_check_tasks(self):
         """After setup, verify no task is already passing before the candidate
@@ -196,17 +211,6 @@ class ExamSession:
             print(fmt.warning(
                 f"  ⚠ {len(warnings)} task(s) may not have initialized correctly "
                 f"(see the log). They'll still be scored normally."))
-
-    def _clean_lab_leftovers(self):
-        """Remove leftover task artifacts (files/dirs/mounts the tasks ask the
-        candidate to create) so each exam starts from a clean slate."""
-        try:
-            from core import lab_cleanup
-            done = lab_cleanup.clean(dry_run=False)
-        except Exception:
-            return
-        if done:
-            print(fmt.dim(f"Removed {len(done)} leftover lab artifact(s) from a previous session."))
 
     def _has_nfs_tasks(self):
         return any(getattr(t, 'category', '') == 'network_storage' for t in self.tasks)
@@ -237,67 +241,12 @@ class ExamSession:
                 print(fmt.dim(f"      {line}"))
             print(fmt.dim("      Fix via Setup → Configure remote NFS server → Test connection."))
 
-    def _teardown_nfs(self):
-        """Tear our exports off the remote NFS server after the exam."""
-        if not self._has_nfs_tasks():
-            return
-        try:
-            from core import nfs_server
-        except Exception:
-            return
-        if not nfs_server.load_config():
-            return
-        try:
-            # Unmount our client-side NFS mounts FIRST, while the server is
-            # still exporting, so they can't become stale when exports go away.
-            n = nfs_server.unmount_client_mounts()
-            if n:
-                print(fmt.dim(f"  Unmounted {n} client NFS mount(s)."))
-            ok, _ = nfs_server.remove_exports()
-            if ok:
-                print(fmt.dim("  NFS exports removed from server."))
-        except Exception:
-            pass
-
-    def _restore_exam_faults(self):
-        """Restore any environments that were set up for the exam."""
-        # NFS teardown runs independently of local fault/setup state.
-        self._teardown_nfs()
-        if not self._injected_tasks and not self._setup_tasks:
-            return
-        print(fmt.dim("\nCleaning up exam environment..."))
-        for task in self._injected_tasks:
-            try:
-                task.restore_fault()
-            except Exception:
-                pass
-        for task in self._setup_tasks:
-            try:
-                task.teardown_environment()
-            except Exception:
-                pass
-
-    def teardown(self):
-        """Return the box to a clean state — safe to call on ANY exit path
-        (graded normally, quit early, or Ctrl-C) and idempotent.
-
-        Reverses the exam's injected faults / preconditions and tears down the
-        remote NFS exports, then removes the candidate's own lab artifacts and
-        resets practice disks so returning to the menu leaves a vanilla box. The
-        _torn_down guard makes a second call (e.g. from an outer finally after a
-        normal finish) a no-op."""
-        if self._torn_down:
-            return
-        self._torn_down = True
-        try:
-            self._restore_exam_faults()
-        except Exception:
-            pass
-        try:
-            from core import task_env
-            task_env.session_reset(verbose=False)
-        except Exception:
-            pass
+    # NOTE: there is deliberately NO automatic teardown at exam end. The
+    # environment (injected faults, the candidate's work, NFS mounts) is left
+    # in place so scores can be reviewed against live state and checker
+    # disputes can capture real evidence. Cleanup happens explicitly via the
+    # menu's single "Reset Machine" action, or automatically at the start of
+    # the next session.
 
     def _count_domains(self):
         """Count unique domains in generated tasks."""
@@ -418,8 +367,13 @@ class ExamSession:
             duration, validation_results, reboot_result
         )
 
-        # Scoring is done — return the box to a clean, vanilla state.
-        self.teardown()
+        # Deliberately NO cleanup here — the environment stays exactly as the
+        # candidate left it so they can re-inspect their work against the
+        # scores and file checker disputes with live evidence.
+        print()
+        print(fmt.info("The exam environment has been left in place so you can "
+                       "review your work and dispute any check (Result History → task → 'd')."))
+        print(fmt.info("When you're done, run  Setup → Reset Machine  to clean up."))
 
         # Save to ResultsDB
         db = get_results_db()
@@ -580,17 +534,13 @@ def run_exam_mode():
     task_count = _select_exam_task_count()
     reboot_sim = _select_reboot_simulation()
     session = ExamSession(task_count=task_count, reboot_simulation=reboot_sim)
-    try:
-        session.start()
+    session.start()
 
-        if not session.tasks:
-            return None
+    if not session.tasks:
+        return None
 
-        input("\nPress Enter when you're ready to validate your work...")
+    input("\nPress Enter when you're ready to validate your work...")
 
-        return session.validate_all()
-    finally:
-        # However this exits — graded, quit early, or Ctrl-C at the prompt —
-        # reverse the injected faults/preconditions and clean up. Idempotent, so
-        # a normal finish (which already tore down in validate_all) is unaffected.
-        session.teardown()
+    # No teardown on any exit path — the environment persists for review and
+    # disputes. The next session start (or Setup → Reset Machine) cleans up.
+    return session.validate_all()

--- a/core/menu.py
+++ b/core/menu.py
@@ -27,7 +27,7 @@ class MenuSystem:
 
             # Quick Start section
             print(fmt.bold("QUICK START"))
-            fmt.print_menu_option('Q', "Quick Practice", "5 random tasks")
+            fmt.print_menu_option('Q', "Quick Practice", "Short session, 4-20 random tasks")
             fmt.print_menu_option('E', "Mock Exam", f"20–25 tasks, {settings.DEFAULT_EXAM_DURATION} min, reboot sim")
             print()
 
@@ -168,7 +168,7 @@ class MenuSystem:
 {settings.APP_NAME} v{settings.VERSION} - Quick Guide
 
 QUICK START
-  Q - Quick Practice: 5 random tasks with validation.
+  Q - Quick Practice: a short session (4-20 random tasks) with validation.
       Perfect for daily practice sessions.
 
   E - Mock Exam: {settings.DEFAULT_EXAM_TASKS}-task exam with {settings.DEFAULT_EXAM_DURATION}-min timer.
@@ -220,11 +220,9 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
         print("  1. Setup Practice Disks (loop devices for LVM)")
         print("  2. View Task Statistics")
         print("  3. Network Backup/Restore")
-        print("  4. System Reset (remove practice artifacts)")
+        print("  4. Reset Machine (undo ALL practice changes, back to a clean box)")
         print("  5. Populate Practice Environment (DNF history)")
         print(f"  6. Configure remote NFS server for NFS tasks ({nfs_status})")
-        print("  7. Clean lab leftover files (remove task artifacts)")
-        print("  8. Full System Reset (strip box back to a basic RHEL install)")
         print("  0. Return to Menu")
         print()
 
@@ -237,62 +235,30 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
         elif choice == '3':
             self.network_management()
         elif choice == '4':
-            self.system_reset()
+            self.reset_machine()
         elif choice == '5':
             self.populate_practice_environment()
         elif choice == '6':
             self.configure_nfs_server()
-        elif choice == '7':
-            self.clean_lab_leftovers()
-        elif choice == '8':
-            self.full_system_reset()
 
-    def clean_lab_leftovers(self):
-        """Preview and remove leftover task artifacts (files/dirs/mounts the
-        tasks ask the candidate to create)."""
-        from core import lab_cleanup
-        from utils.helpers import confirm_action
+    def reset_machine(self):
+        """THE single reset. Restores any active faults/preconditions, removes
+        every practice artifact (lab files, disks, swap, repos, flatpaks,
+        scheduled jobs, autofs, tuned, NFS exports, practice users) and returns
+        the box to a clean basic-RHEL state. Preserves the simulator,
+        GitHub/SSH connectivity, networking, SELinux and the OS.
 
-        fmt.clear_screen()
-        fmt.print_header("CLEAN LAB LEFTOVER FILES")
-
-        planned = lab_cleanup.clean(dry_run=True)
-        if not planned:
-            print(fmt.success("Nothing to clean — no known task artifacts present."))
-            input("\nPress Enter to return...")
-            return
-
-        print("These task-created artifacts would be removed "
-              "(/etc and your dotfiles are never touched):")
-        print()
-        for line in planned:
-            print(f"  {line}")
-        print()
-        if not confirm_action(f"Remove these {len(planned)} item(s)?", default=False):
-            print(fmt.dim("Cancelled — nothing removed."))
-            input("\nPress Enter to return...")
-            return
-
-        done = lab_cleanup.clean(dry_run=False)
-        print()
-        print(fmt.success(f"Removed {len(done)} item(s)."))
-        for line in done:
-            if line.startswith('FAILED'):
-                print(fmt.warning(f"  {line}"))
-        input("\nPress Enter to return...")
-
-    def full_system_reset(self):
-        """Strip the box back to a basic RHEL install: remove third-party repos,
-        Flatpak apps/remotes, lab files, practice users, scheduled jobs, autofs
-        maps, tuned changes, practice disks/swap and NFS exports. Preserves the
-        simulator, GitHub/SSH connectivity, networking, SELinux and the OS."""
+        Replaces the old System Reset / Clean lab leftovers / Full System Reset
+        trio — one button, one behavior."""
         from core import full_reset
         from utils.helpers import confirm_action
 
         fmt.clear_screen()
-        fmt.print_header("FULL SYSTEM RESET")
+        fmt.print_header("RESET MACHINE")
 
-        print(fmt.warning("This returns the machine to a BASIC RHEL install. It removes:"))
+        print(fmt.warning("This undoes ALL practice changes and returns the machine to a"))
+        print(fmt.warning("clean basic-RHEL state. It removes:"))
+        print("  - injected faults & task starting-states (restored to original)")
         print("  - all third-party DNF repos (RHEL system repos are kept)")
         print("  - all Flatpak apps and remotes")
         print("  - leftover lab files, practice users/groups, practice disks & swap")
@@ -330,7 +296,7 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             return
 
         print()
-        print(fmt.bold("Running full system reset..."))
+        print(fmt.bold("Resetting machine..."))
 
         def progress(msg):
             print(msg)
@@ -339,8 +305,8 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
 
         print()
         print("=" * 50)
-        print(fmt.success("Full system reset complete."))
-        print(fmt.info("The box is back to a basic RHEL state; simulator and GitHub"))
+        print(fmt.success("Reset complete."))
+        print(fmt.info("The box is back to a clean state; simulator and GitHub"))
         print(fmt.info("connectivity were left intact."))
         print()
         input("Press Enter to return...")
@@ -1411,486 +1377,3 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
         print()
         input("Press Enter to return...")
 
-    def system_reset(self):
-        """Reset system to barebones practice-ready state without touching SSH or network."""
-        import subprocess
-        import os
-        import re
-        from utils.helpers import (
-            cleanup_practice_devices, get_loop_devices, confirm_action
-        )
-
-        fmt.clear_screen()
-        fmt.print_header("SYSTEM RESET")
-
-        print(fmt.warning("This removes practice artifacts: LVM, swap files, practice repos,"))
-        print(fmt.warning("cron/at jobs, tuned profile, and scripts in /usr/local/bin/."))
-        print(fmt.info("SSH, network, firewall, SELinux, and users will NOT be touched."))
-        print()
-
-        if not confirm_action("Continue with system reset?", default=False):
-            print(fmt.dim("Reset cancelled."))
-            print()
-            input("Press Enter to return...")
-            return
-
-        # ── Step 1: Loop devices / LVM ───────────────────────────────────────
-        print()
-        print(fmt.bold("Step 1: Practice Disks (loop devices / LVM)"))
-        loop_devices = get_loop_devices()
-        if loop_devices:
-            # Unmount any loop partitions (e.g. loop1p1 mounted at /mnt/...)
-            # Use -rno (raw) to avoid tree-drawing characters that break split()
-            lsblk = subprocess.run(
-                ['lsblk', '-rno', 'NAME,MOUNTPOINT'],
-                capture_output=True, text=True
-            )
-            for line in lsblk.stdout.splitlines():
-                parts = line.split()
-                if len(parts) == 2:
-                    name, mnt = parts
-                    if 'loop' in name and 'p' in name and mnt.startswith('/'):
-                        subprocess.run(['umount', '-f', f'/dev/{name}'], capture_output=True)
-            print(f"  Found: {', '.join(loop_devices)}")
-            if confirm_action("  Remove all LVM structures and practice disks?", default=True):
-                if cleanup_practice_devices():
-                    print(fmt.success("  Practice disks cleaned up"))
-                else:
-                    print(fmt.error("  Cleanup had errors — check manually"))
-        else:
-            print(fmt.dim("  No loop practice disks found"))
-
-        # ── Step 1b: Real practice disks (wipe partitions) ───────────────────
-        from utils.helpers import list_all_block_devices, wipe_disk
-        real_practice = [
-            d for d in list_all_block_devices()
-            if not d['is_system'] and d['has_partitions'] and not d['mounted']
-        ]
-        if real_practice:
-            print()
-            print(fmt.bold("Step 1b: Real Disk Partitions"))
-            for d in real_practice:
-                swap_note = " (has swap)" if d.get('has_swap') else ""
-                print(f"  {d['device']}  {d['size']}{swap_note} — has partitions")
-            print(fmt.warning("  Wiping will destroy ALL partitions and data on these disks."))
-            if confirm_action("  Wipe all partitions and LVM from these disks?", default=True):
-                for d in real_practice:
-                    print(f"  Wiping {d['device']}...")
-                    ok, msgs = wipe_disk(d['device'])
-                    for msg in msgs:
-                        print(f"    {msg}")
-
-        # ── Step 2: Active swap (files + loop-device partitions) ─────────────
-        print()
-        print(fmt.bold("Step 2: Practice Swap"))
-        swap_entries = []   # (device, type)
-        try:
-            with open('/proc/swaps', 'r') as f:
-                for line in f.readlines()[1:]:   # skip header
-                    parts = line.split()
-                    if len(parts) < 2:
-                        continue
-                    device, stype = parts[0], parts[1]
-                    # Skip the real system swap (nvme/rhel-swap)
-                    is_system = '/dev/nvme' in device or 'rhel' in device or 'dm-' in device
-                    if is_system:
-                        continue
-                    if stype == 'file':
-                        swap_entries.append((device, 'file'))
-                    elif stype == 'partition':
-                        swap_entries.append((device, 'partition'))
-        except Exception:
-            pass
-
-        if swap_entries:
-            for device, stype in swap_entries:
-                label = 'swap file' if stype == 'file' else 'swap partition'
-                print(f"  Active {label}: {device}")
-            if confirm_action("  Deactivate and remove these swap entries?", default=True):
-                for device, stype in swap_entries:
-                    subprocess.run(['swapoff', device], capture_output=True)
-                    if stype == 'file' and os.path.exists(device):
-                        try:
-                            os.remove(device)
-                            print(fmt.success(f"  Removed {device}"))
-                        except OSError as e:
-                            print(fmt.error(f"  Could not remove {device}: {e}"))
-                    else:
-                        print(fmt.success(f"  Deactivated {device}"))
-        else:
-            print(fmt.dim("  No practice swap found"))
-
-        # ── Step 3: /etc/fstab cleanup ───────────────────────────────────────
-        print()
-        print(fmt.bold("Step 3: /etc/fstab Cleanup"))
-        # Build device-specific patterns from the practice device config so we
-        # never accidentally nuke fstab entries for legitimate non-practice disks.
-        from utils.helpers import get_practice_device_config
-        _practice_cfg = get_practice_device_config()
-        _practice_devs = []
-        if _practice_cfg and _practice_cfg.get('mode') == 'real':
-            _practice_devs = _practice_cfg.get('devices', [])
-
-        _fstab_patterns = [
-            re.compile(r'/var/lib/rhcsa-simulator/loops/'),
-            re.compile(r'/dev/loop\d+'),
-            re.compile(r'\s/tmp/swap\S*'),
-            re.compile(r'\s/root/swapfile'),
-            re.compile(r'\s/swapfile\b'),
-            re.compile(r'\s/var/swap\b'),
-            re.compile(r'\s/opt/swap\S*'),
-            re.compile(r'RHCSA-FAULT'),   # injected by fault tasks
-        ] + [re.compile(re.escape(dev)) for dev in _practice_devs]
-
-        # Also flag any UUID entries that resolve to non-system block devices
-        def _is_practice_uuid(token):
-            if not token.startswith('UUID='):
-                return False
-            uuid = token[5:]
-            r = subprocess.run(['blkid', '-U', uuid], capture_output=True, text=True)
-            if r.returncode != 0:
-                return False  # unresolvable UUID — leave it alone
-            dev = r.stdout.strip()
-            # If it resolves to nvme or known LVM, it's system
-            return not any(x in dev for x in ['nvme', 'rhel', 'dm-'])
-
-        try:
-            with open('/etc/fstab', 'r') as f:
-                fstab_lines = f.readlines()
-
-            practice_lines, clean_lines = [], []
-            for line in fstab_lines:
-                stripped = line.strip()
-                if not stripped or stripped.startswith('#'):
-                    clean_lines.append(line)
-                    continue
-                fields = stripped.split()
-                is_practice = any(p.search(line) for p in _fstab_patterns)
-                # Also catch UUID-based practice swap/mount entries
-                if not is_practice and fields:
-                    is_practice = _is_practice_uuid(fields[0])
-                if is_practice:
-                    practice_lines.append(line.rstrip())
-                else:
-                    clean_lines.append(line)
-
-            if practice_lines:
-                print("  Practice entries to remove:")
-                for pl in practice_lines:
-                    print(f"    {pl}")
-                if confirm_action("  Remove these entries from /etc/fstab?", default=True):
-                    with open('/etc/fstab', 'w') as f:
-                        f.writelines(clean_lines)
-                    print(fmt.success("  /etc/fstab cleaned"))
-            else:
-                print(fmt.dim("  No practice entries in /etc/fstab"))
-        except Exception as e:
-            print(fmt.error(f"  Error reading /etc/fstab: {e}"))
-
-        # ── Step 4: Non-default repos ────────────────────────────────────────
-        print()
-        print(fmt.bold("Step 4: Non-Default Repos (/etc/yum.repos.d/)"))
-        # Keep only files managed by subscription-manager or clearly RHEL system repos
-        _keep_repo_patterns = [
-            'redhat.repo',          # subscription-manager managed
-        ]
-        def _is_system_repo(fname):
-            if fname in _keep_repo_patterns:
-                return True
-            # rhel-* repos managed by sub-manager
-            if fname.startswith('rhel-') or fname.startswith('redhat-'):
-                return True
-            return False
-
-        repo_dir = '/etc/yum.repos.d'
-        repo_files_to_remove = []
-        try:
-            for fname in sorted(os.listdir(repo_dir)):
-                if fname.endswith('.repo') and not _is_system_repo(fname):
-                    repo_files_to_remove.append(os.path.join(repo_dir, fname))
-        except Exception:
-            pass
-
-        if repo_files_to_remove:
-            print("  Non-default repo files found:")
-            for rf in repo_files_to_remove:
-                print(f"    {rf}")
-            if confirm_action("  Remove these repo files?", default=True):
-                for rf in repo_files_to_remove:
-                    try:
-                        os.remove(rf)
-                    except OSError as e:
-                        print(fmt.error(f"  Could not remove {rf}: {e}"))
-                print(fmt.success("  Non-default repos removed"))
-        else:
-            print(fmt.dim("  No non-default repos found"))
-
-        # ── Step 5: Root crontab ─────────────────────────────────────────────
-        print()
-        print(fmt.bold("Step 5: Root Crontab"))
-        try:
-            result = subprocess.run(
-                ['crontab', '-l', '-u', 'root'],
-                capture_output=True, text=True
-            )
-            crontab_content = result.stdout.strip()
-            if result.returncode == 0 and crontab_content:
-                print("  Current root crontab:")
-                for line in crontab_content.splitlines():
-                    print(f"    {line}")
-                if confirm_action("  Clear root crontab?", default=True):
-                    subprocess.run(['crontab', '-r', '-u', 'root'], capture_output=True)
-                    print(fmt.success("  Root crontab cleared"))
-            else:
-                print(fmt.dim("  Root crontab is empty"))
-        except Exception as e:
-            print(fmt.error(f"  Error accessing crontab: {e}"))
-
-        # ── Step 6: At jobs ──────────────────────────────────────────────────
-        print()
-        print(fmt.bold("Step 6: Scheduled 'at' Jobs"))
-        try:
-            result = subprocess.run(['atq'], capture_output=True, text=True)
-            if result.stdout.strip():
-                print("  Pending at jobs:")
-                for line in result.stdout.strip().splitlines():
-                    print(f"    {line}")
-                if confirm_action("  Remove all pending at jobs?", default=True):
-                    job_ids = [
-                        line.split()[0]
-                        for line in result.stdout.strip().splitlines()
-                        if line.strip()
-                    ]
-                    for jid in job_ids:
-                        subprocess.run(['atrm', jid], capture_output=True)
-                    print(fmt.success("  At jobs removed"))
-            else:
-                print(fmt.dim("  No pending at jobs"))
-        except FileNotFoundError:
-            print(fmt.dim("  'at' not installed — skipping"))
-        except Exception as e:
-            print(fmt.error(f"  Error: {e}"))
-
-        # ── Step 7: Tuned profile ────────────────────────────────────────────
-        print()
-        print(fmt.bold("Step 7: Tuned Profile"))
-        try:
-            active_result = subprocess.run(
-                ['tuned-adm', 'active'], capture_output=True, text=True
-            )
-            current = active_result.stdout.strip() if active_result.returncode == 0 else "unknown"
-            print(f"  Current: {current}")
-
-            rec_result = subprocess.run(
-                ['tuned-adm', 'recommend'], capture_output=True, text=True
-            )
-            recommended = rec_result.stdout.strip() if rec_result.returncode == 0 else 'balanced'
-            print(f"  Recommended for this system: {recommended}")
-
-            if confirm_action(f"  Reset tuned to '{recommended}'?", default=True):
-                subprocess.run(['tuned-adm', 'profile', recommended], capture_output=True)
-                print(fmt.success(f"  Tuned profile set to '{recommended}'"))
-        except FileNotFoundError:
-            print(fmt.dim("  tuned-adm not installed — skipping"))
-        except Exception as e:
-            print(fmt.error(f"  Error: {e}"))
-
-        # ── Step 8: Practice scripts in /usr/local/bin ───────────────────────
-        print()
-        print(fmt.bold("Step 8: Practice Scripts (/usr/local/bin/*.sh)"))
-        try:
-            scripts = [
-                os.path.join('/usr/local/bin', f)
-                for f in os.listdir('/usr/local/bin')
-                if f.endswith('.sh') and os.path.isfile(os.path.join('/usr/local/bin', f))
-            ]
-            if scripts:
-                print("  Shell scripts found:")
-                for s in scripts:
-                    print(f"    {s}")
-                if confirm_action("  Remove these scripts?", default=True):
-                    for s in scripts:
-                        try:
-                            os.remove(s)
-                        except OSError as e:
-                            print(fmt.error(f"  Could not remove {s}: {e}"))
-                    print(fmt.success("  Scripts removed"))
-            else:
-                print(fmt.dim("  No .sh scripts in /usr/local/bin"))
-        except Exception as e:
-            print(fmt.error(f"  Error: {e}"))
-
-        # ── Step 9: Autofs cleanup ───────────────────────────────────────────
-        print()
-        print(fmt.bold("Step 9: Autofs Cleanup"))
-        autofs_dirty = False
-
-        # Stop autofs first so active mounts are cleanly torn down before
-        # we modify or remove any map files — otherwise removal fails (EBUSY)
-        autofs_active = subprocess.run(
-            ['systemctl', 'is-active', '--quiet', 'autofs'],
-            capture_output=True
-        ).returncode == 0
-        if autofs_active:
-            print("  Stopping autofs service to unmount active maps...")
-            subprocess.run(['systemctl', 'stop', 'autofs'], capture_output=True)
-
-        # auto.master — remove any uncommented non-system lines
-        auto_master = '/etc/auto.master'
-        _auto_master_defaults = {'+dir:/etc/auto.master.d', '+auto.master'}
-        try:
-            with open(auto_master) as f:
-                master_lines = f.readlines()
-            practice_master, clean_master = [], []
-            for line in master_lines:
-                s = line.strip()
-                if not s or s.startswith('#') or s in _auto_master_defaults:
-                    clean_master.append(line)
-                else:
-                    practice_master.append(line.rstrip())
-            if practice_master:
-                autofs_dirty = True
-                print("  Non-default entries in /etc/auto.master:")
-                for pl in practice_master:
-                    print(f"    {pl}")
-                if confirm_action("  Remove these entries?", default=True):
-                    with open(auto_master, 'w') as f:
-                        f.writelines(clean_master)
-                    print(fmt.success("  /etc/auto.master cleaned"))
-        except FileNotFoundError:
-            pass
-        except Exception as e:
-            print(fmt.error(f"  Could not read {auto_master}: {e}"))
-
-        # /etc/auto.master.d/ — remove any .autofs drop-in files
-        master_d = '/etc/auto.master.d'
-        try:
-            drop_ins = [
-                os.path.join(master_d, f)
-                for f in os.listdir(master_d)
-                if f.endswith('.autofs')
-            ]
-            if drop_ins:
-                autofs_dirty = True
-                print("  Drop-in autofs files found:")
-                for di in drop_ins:
-                    print(f"    {di}")
-                if confirm_action("  Remove these files?", default=True):
-                    for di in drop_ins:
-                        try:
-                            os.remove(di)
-                        except OSError as e:
-                            print(fmt.error(f"  Could not remove {di}: {e}"))
-                    print(fmt.success("  Drop-in files removed"))
-        except FileNotFoundError:
-            pass
-
-        # /etc/auto.* map files (other than auto.master and auto.misc)
-        try:
-            extra_maps = [
-                f'/etc/{f}'
-                for f in os.listdir('/etc')
-                if f.startswith('auto.')
-                and f not in ('auto.master', 'auto.misc', 'auto.master.d')
-                and os.path.isfile(f'/etc/{f}')
-            ]
-            if extra_maps:
-                autofs_dirty = True
-                print("  Extra autofs map files found:")
-                for em in extra_maps:
-                    print(f"    {em}")
-                if confirm_action("  Remove these map files?", default=True):
-                    for em in extra_maps:
-                        try:
-                            os.remove(em)
-                        except OSError as e:
-                            print(fmt.error(f"  Could not remove {em}: {e}"))
-                    print(fmt.success("  Extra map files removed"))
-        except Exception as e:
-            print(fmt.error(f"  Error scanning /etc/auto.*: {e}"))
-
-        if not autofs_dirty:
-            print(fmt.dim("  Autofs config is clean"))
-
-        # ── Step 10: Practice users and groups ───────────────────────────────
-        print()
-        print(fmt.bold("Step 10: Practice Users & Groups"))
-
-        # Regex patterns derived from every username/groupname generator in tasks/.
-        # Only matches: known prefix + exactly 2 digit suffix (the randint range),
-        # or a fixed practice name. Does NOT match plain words without digits.
-        import re as _re
-        # Name-based pattern: prefix + 1-2 digit suffix (randint range is 10-99 or 1-99)
-        _USER_PAT_NUMBERED = _re.compile(
-            r'^('
-            r'alice|bob|carol|dave|eve|frank|grace|hank|'
-            r'anna|ben|clara|dan|ella|finn|gina|hugo|iris|jake|'
-            r'staffuser|ageuser|operator|locktest|removeuser|shelluser|troubleuser|'
-            r'(?:nginx|redis|tomcat|grafana|prometheus|elasticsearch|kafka|rabbitmq|consul|vault)svc|'
-            r'appsvc|mailsvc|websvc|dbsvc|ftpsvc|logsvc|'
-            r'loginuser|sudouser|'
-            r'user'
-            r')\d{1,2}$'
-        )
-        # Fixed names with no numeric suffix
-        _USER_PAT_FIXED = _re.compile(r'^sudopractice$')
-
-        def _is_practice_user(name):
-            return bool(_USER_PAT_NUMBERED.match(name) or _USER_PAT_FIXED.match(name))
-        _GROUP_PAT = _re.compile(
-            r'^(devteam|qagroup|opsgroup|infrateam|secteam|datateam|cloudops)\d{2}$'
-        )
-
-        practice_users, practice_groups = [], []
-        try:
-            import pwd, grp as _grp
-            for pw in pwd.getpwall():
-                if pw.pw_uid >= 1000 and _is_practice_user(pw.pw_name):
-                    practice_users.append(pw.pw_name)
-            for gr in _grp.getgrall():
-                if gr.gr_gid >= 1000 and _GROUP_PAT.match(gr.gr_name):
-                    practice_groups.append(gr.gr_name)
-        except Exception as e:
-            print(fmt.error(f"  Error scanning users/groups: {e}"))
-
-        if practice_users:
-            print("  Practice users found:")
-            for u in practice_users:
-                print(f"    {u}")
-            if confirm_action("  Delete these users (and their home dirs)?", default=True):
-                for u in practice_users:
-                    subprocess.run(['userdel', '-r', u], capture_output=True)
-                print(fmt.success(f"  Removed {len(practice_users)} practice user(s)"))
-        else:
-            print(fmt.dim("  No practice users found"))
-
-        if practice_groups:
-            print("  Practice groups found:")
-            for g in practice_groups:
-                print(f"    {g}")
-            if confirm_action("  Delete these groups?", default=True):
-                for g in practice_groups:
-                    subprocess.run(['groupdel', g], capture_output=True)
-                print(fmt.success(f"  Removed {len(practice_groups)} practice group(s)"))
-
-        # ── Step 11: Restore any active troubleshooting fault ────────────────
-        try:
-            from tasks.troubleshooting import restore_any_active_fault
-            had_fault, msg = restore_any_active_fault()
-            if had_fault:
-                print()
-                print(fmt.bold("Step 11: Active Fault Restore"))
-                print(fmt.success(f"  Restored: {msg}"))
-        except Exception as e:
-            print()
-            print(fmt.error(f"Step 10: Fault restore failed — {e}"))
-            print(fmt.warning("  Check /var/lib/rhcsa-simulator/active_fault.json manually"))
-
-        # ── Done ─────────────────────────────────────────────────────────────
-        print()
-        print("=" * 50)
-        print(fmt.success("System reset complete!"))
-        print(fmt.info("SSH and network were not modified."))
-        print(fmt.info("Firewall, SELinux, and users were not modified."))
-        print()
-        input("Press Enter to return...")

--- a/core/practice.py
+++ b/core/practice.py
@@ -47,6 +47,10 @@ class PracticeSession:
             self.difficulty = self._select_difficulty()
         self.skip_reboot = self._select_reboot_filter()
 
+        from utils.helpers import select_task_count
+        print()
+        self.task_count = select_task_count(default=self.task_count)
+
         tasks = TaskRegistry.get_practice_tasks(
             self.category,
             self.difficulty,
@@ -92,10 +96,10 @@ class PracticeSession:
         print(fmt.info(f"\nStarting session…"))
 
         # Reset the box to a clean, practice-ready state (fresh loop disks +
-        # remove leftover artifacts) exactly like exam mode does at start, so
-        # tasks aren't polluted by a previous session.
+        # remove leftover artifacts) exactly like exam mode does at start, and
+        # offer to install any packages the drawn tasks rely on.
         print(fmt.dim("Preparing a clean practice environment..."))
-        task_env.session_reset()
+        task_env.prepare_session(tasks)
 
         # Practice each task
         try:
@@ -191,7 +195,7 @@ class PracticeSession:
         # tasks require real work instead of passing on default state.
         fmt.clear_screen()
         print(fmt.bold("Preparing task environment..."))
-        env_state = task_env.setup_task(task)
+        task_env.setup_task(task)
         print()
         time.sleep(1)
 
@@ -307,13 +311,15 @@ class PracticeSession:
                 input("Press Enter to continue...")
                 break
 
-        # Reverse the per-task system changes regardless of outcome, then wipe
-        # practice disks if this task consumed one so the next task starts clean.
-        print()
-        print(fmt.dim("Restoring system..."))
-        task_env.teardown_task(task, env_state)
-        task_env.reset_after_task(task)
-        time.sleep(1)
+        # Per-task system changes are NOT reverted here — everything is undone
+        # once, at the end of the session (session_teardown in start()'s
+        # finally). Only disk tasks get their practice disk wiped now, because
+        # the next disk task needs a clean, signature-free device to work on.
+        if getattr(task, 'disk_slots', 0) > 0 and current < total:
+            print()
+            print(fmt.dim("Re-provisioning practice disks for the next task..."))
+            task_env.reset_after_task(task)
+            time.sleep(1)
 
         if stop_requested:
             raise StopIteration

--- a/core/preflight.py
+++ b/core/preflight.py
@@ -55,6 +55,60 @@ def missing_packages(statuses=None):
     return sorted(pkg for pkg, installed in statuses.items() if installed is False)
 
 
+def filter_missing(packages):
+    """Subset of `packages` confirmed NOT installed (rpm answered). Unknown
+    statuses (no rpm binary, timeout) are excluded — never offer to install
+    something we can't verify is absent."""
+    return sorted(pkg for pkg in set(packages) if _rpm_installed(pkg) is False)
+
+
+def install_packages(packages):
+    """dnf-install the given packages. Returns (ok, output). Only ever called
+    after the user has explicitly consented — never call this unprompted."""
+    if not packages:
+        return True, ""
+    try:
+        r = subprocess.run(['dnf', 'install', '-y', *sorted(set(packages))],
+                           capture_output=True, text=True, timeout=600)
+        return r.returncode == 0, (r.stdout or '') + (r.stderr or '')
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+        return False, str(e)
+
+
+def offer_task_packages(tasks):
+    """Session-prep package prompt.
+
+    Gathers required_packages from the generated tasks; for any that are
+    missing, asks the user (Y/n) whether to install them. NOTHING is installed
+    without consent. Returns the list of packages still missing afterwards so
+    fault injectors can fall back (reduced scenario / fabricated evidence).
+    """
+    needed = set()
+    for t in tasks or []:
+        needed.update(getattr(t, 'required_packages', []) or [])
+    if not needed:
+        return []
+    missing = filter_missing(needed)
+    if not missing:
+        return []
+
+    from utils.helpers import confirm_action
+    print(fmt.warning(
+        f"\nSome tasks in this session use package(s) not installed on this "
+        f"system: {', '.join(missing)}"))
+    print(fmt.dim("  Without them those scenarios run in a reduced mode "
+                  "(or are skipped). Installed packages stay installed."))
+    if confirm_action(f"Install {', '.join(missing)} now?", default=True):
+        print(fmt.dim("  Installing (this can take a minute)..."))
+        ok, out = install_packages(missing)
+        if ok:
+            print(fmt.success(f"  Installed: {', '.join(missing)}"))
+        else:
+            tail = (out or '').strip().splitlines()[-1] if (out or '').strip() else 'no output'
+            print(fmt.warning(f"  Install failed — continuing without. ({tail})"))
+    return filter_missing(needed)
+
+
 def warn_missing(missing=None):
     """Print a one-time warning listing missing packages and how to install
     them. No-op if nothing is missing (or rpm status is unknown)."""

--- a/core/task_env.py
+++ b/core/task_env.py
@@ -26,6 +26,14 @@ def session_reset(verbose=True):
     leftovers — both operations no-op cleanly.
     """
     from utils import helpers
+    # First restore any faults/preconditions still active from a previous
+    # session — exams deliberately leave the environment in place for review
+    # and disputes, so the NEXT session is where it gets undone.
+    try:
+        from tasks.troubleshooting import restore_any_active_fault
+        restore_any_active_fault()
+    except Exception:
+        pass
     try:
         helpers.reset_practice_loops()
     except Exception:
@@ -41,6 +49,18 @@ def session_reset(verbose=True):
     return done
 
 
+def prepare_session(tasks, verbose=True):
+    """Start-of-session prep shared by the training modes: reset the box to a
+    clean state, then offer to install any packages the drawn tasks rely on
+    (consent-gated — nothing installs silently)."""
+    session_reset(verbose=verbose)
+    try:
+        from core import preflight
+        preflight.offer_task_packages(tasks)
+    except Exception:
+        pass
+
+
 def setup_task(task, verbose=True):
     """Change the system for one task before the candidate works on it.
 
@@ -48,6 +68,9 @@ def setup_task(task, verbose=True):
     setup_environment() (establish a negative precondition so a positive-config
     task can't pass on default state) — the same calls exam.py makes. Returns a
     small state dict for teardown_task() to reverse.
+
+    Console output stays GENERIC: the injection/setup message spells out
+    exactly what was broken (i.e. the answer), so it goes to the log only.
     """
     state = {'fault': False, 'setup': False}
 
@@ -55,23 +78,27 @@ def setup_task(task, verbose=True):
         try:
             ok, msg = task.inject_fault()
             state['fault'] = ok
+            logger.info("fault %s: %s: %s", "armed" if ok else "skipped", task.id, msg)
             if verbose:
-                print(fmt.success(f"  Fault active: {msg}") if ok
-                      else fmt.warning(f"  Fault injection failed: {msg} (descriptive mode only)"))
+                print(fmt.dim("  Scenario prepared — the described symptom is live.") if ok
+                      else fmt.warning("  Scenario could not be set up (details in the log) — task is descriptive only."))
         except Exception as e:
+            logger.warning("fault error: %s: %s", getattr(task, 'id', '?'), e)
             if verbose:
-                print(fmt.warning(f"  Fault injection error: {e}"))
+                print(fmt.warning("  Scenario setup error (details in the log)."))
 
     if getattr(task, 'has_setup', False):
         try:
             ok, msg = task.setup_environment()
             state['setup'] = ok
             # A False result just means no precondition was needed; stay quiet.
+            logger.info("precondition %s: %s: %s", "set" if ok else "not needed", task.id, msg)
             if verbose and ok:
-                print(fmt.dim(f"  Precondition set: {msg}"))
+                print(fmt.dim("  Starting state prepared."))
         except Exception as e:
+            logger.warning("setup error: %s: %s", getattr(task, 'id', '?'), e)
             if verbose:
-                print(fmt.warning(f"  Setup error: {e}"))
+                print(fmt.warning("  Starting-state setup error (details in the log)."))
 
     # Sanity check: with setup done and nothing done by the candidate yet, the
     # task must NOT already be passing. If it is, the fault/precondition no-op'd

--- a/rhcsa_simulator.py
+++ b/rhcsa_simulator.py
@@ -62,13 +62,13 @@ Quick Start Examples:
 
 
 def run_quick_practice(category=None):
-    """Run quick practice - 5 tasks with ResultsDB tracking."""
+    """Run quick practice - a short session (4-20 tasks) with ResultsDB tracking."""
     from tasks.registry import TaskRegistry
     from core.validator import get_validator
     from core.results_db import get_results_db
     from core import task_env
     from utils import formatters as fmt
-    from utils.helpers import confirm_action
+    from utils.helpers import confirm_action, select_task_count
 
     TaskRegistry.initialize()
     db = get_results_db()
@@ -77,9 +77,12 @@ def run_quick_practice(category=None):
     fmt.print_header("QUICK PRACTICE")
 
     if category and category != 'all':
-        print(f"5 {fmt.format_category_name(category)} tasks.")
+        print(f"{fmt.format_category_name(category)} tasks.")
     else:
-        print("5 random tasks across all categories.")
+        print("Random tasks across all categories.")
+    print()
+
+    count = select_task_count(default=5)
     print()
 
     if not confirm_action("Ready to start?", default=True):
@@ -87,9 +90,9 @@ def run_quick_practice(category=None):
 
     # Get tasks
     if category and category != 'all':
-        tasks = TaskRegistry.get_practice_tasks(category, 'exam', 5)
+        tasks = TaskRegistry.get_practice_tasks(category, 'exam', count)
     else:
-        tasks = TaskRegistry.get_exam_tasks(5)
+        tasks = TaskRegistry.get_exam_tasks(count)
 
     if not tasks:
         print(fmt.error("Could not generate tasks"))
@@ -100,19 +103,17 @@ def run_quick_practice(category=None):
     passed = 0
 
     # Put the box into the same real state exam/practice/adaptive modes do:
-    # fresh practice disks + no leftover artifacts up front, then inject each
-    # task's fault / negative precondition per iteration (and reverse it after).
-    # Without this, quick practice validates against default state — troubleshooting
-    # tasks have nothing to fix and positive-config tasks pass with no work done.
+    # clean slate + package offer up front, then inject each task's fault /
+    # negative precondition right before the candidate works on it. All system
+    # changes are reverted ONCE, at the end of the session (finally below).
     print(fmt.dim("Preparing a clean practice environment..."))
-    task_env.session_reset()
+    task_env.prepare_session(tasks)
 
-    for i, task in enumerate(tasks, 1):
-        # Break something to fix / establish the precondition BEFORE the candidate
-        # works on it. Wipe screen after so setup chatter doesn't precede the task.
-        env_state = task_env.setup_task(task)
-        stop = False
-        try:
+    try:
+        for i, task in enumerate(tasks, 1):
+            # Break something to fix / establish the precondition BEFORE the
+            # candidate works on it (setup output is generic — no spoilers).
+            task_env.setup_task(task)
             fmt.clear_screen()
             print(f"Quick Practice - Task {i}/{len(tasks)}")
             print("=" * 60)
@@ -171,17 +172,19 @@ def run_quick_practice(category=None):
                 for tip in exam_tips:
                     print(f"  * {tip}")
 
-            print()
-            stop = i < len(tasks) and not confirm_action("Continue to next task?", default=True)
-        finally:
-            # Always reverse this task's system changes, even on error / early
-            # exit, then wipe practice disks if the task consumed one.
-            print(fmt.dim("Restoring system..."))
-            task_env.teardown_task(task, env_state)
-            task_env.reset_after_task(task)
+            # Wipe practice disks between disk tasks so the next one gets a
+            # clean, signature-free device (other changes revert at session end).
+            if getattr(task, 'disk_slots', 0) > 0 and i < len(tasks):
+                print(fmt.dim("Re-provisioning practice disks for the next task..."))
+                task_env.reset_after_task(task)
 
-        if stop:
-            break
+            print()
+            if i < len(tasks) and not confirm_action("Continue to next task?", default=True):
+                break
+    finally:
+        # However the session ends (finished, quit, or Ctrl-C), leave a clean
+        # box — reverse all faults/preconditions and remove artifacts.
+        task_env.session_teardown(tasks)
 
     # Summary
     print()
@@ -328,17 +331,18 @@ def main():
         run_adaptive_mode()
         return 0
 
-    # Warn if a troubleshooting fault was left active (e.g. simulator crashed)
+    # Note if a previous session's environment is still in place (expected —
+    # exams deliberately leave the box as-is for review/disputes).
     try:
         from tasks.troubleshooting import load_fault_state
         stale = load_fault_state()
         if stale:
             from utils import formatters as fmt
             print(fmt.warning(
-                f"\n! Active fault detected from a previous session: {stale.get('task_id')}"
-            ))
-            print(fmt.warning("  Run System Reset to restore the system, or it will be"))
-            print(fmt.warning("  restored automatically when the next troubleshooting task ends.\n"))
+                "\n! A previous session's environment is still active (kept for "
+                "review/disputes)."))
+            print(fmt.warning("  Run  Setup → Reset Machine  to clean it up; starting a new"))
+            print(fmt.warning("  session also resets it automatically.\n"))
     except Exception:
         pass
 

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -33,6 +33,13 @@ class BaseTask(ABC):
     # positive-config tasks can pass on pre-existing/default state.
     has_setup = False
 
+    # Packages this task's fault injection / scenario needs to be fully real
+    # (e.g. httpd for an Apache troubleshooting fault). Session prep collects
+    # these and OFFERS to install what's missing (never installs silently). If
+    # the user declines, the task must degrade gracefully — reduced scenario,
+    # fabricated log evidence, or descriptive-only.
+    required_packages = []
+
     def __init__(self, id, category, difficulty, points):
         self.id = id
         self.category = category

--- a/tasks/troubleshooting.py
+++ b/tasks/troubleshooting.py
@@ -381,14 +381,14 @@ def _restore_env_setup(info, msgs):
             msgs.append(f"Reinstalled flatpak {app}")
 
 
-# ── httpd preflight (RHEL/Rocky minimal installs don't ship httpd) ───────────
+# ── httpd availability (RHEL/Rocky minimal installs don't ship httpd) ────────
 #
-# Several fault-injection tasks describe an "httpd is running but ..." symptom
-# and manipulate SELinux/firewall/service state around it. On a minimal
-# install httpd is absent, so those manipulations silently no-op and the
-# candidate never sees the intended symptom (issue #37). These helpers install
-# and start httpd on demand, tracked separately from the task's own fault
-# record, so restore_fault() can put the host back exactly as it found it.
+# Several fault-injection tasks describe an "httpd is running but ..." symptom.
+# Session prep OFFERS to install missing packages (tasks declare them via
+# required_packages) — nothing is ever installed silently here. If httpd is
+# still absent when a fault is injected, the task degrades: SELinux faults
+# fabricate the log evidence a real denial would have left (see
+# _seed_avc_denial), service/firewall faults fall back to descriptive-only.
 
 def _httpd_pkg_key(task_id):
     return f'{task_id}__httpd_pkg'
@@ -398,10 +398,8 @@ def _httpd_svc_key(task_id):
     return f'{task_id}__httpd_svc'
 
 
-def _ensure_httpd_installed(task_id):
-    """Install httpd if missing. Returns True once httpd is present."""
-    from tasks.env_setup import ensure_package_installed
-    ensure_package_installed(_httpd_pkg_key(task_id), 'httpd')
+def _httpd_present():
+    """True if the httpd package is installed. Never installs anything."""
     return _run(['rpm', '-q', 'httpd']).returncode == 0
 
 
@@ -412,13 +410,50 @@ def _ensure_httpd_running(task_id):
 
 
 def _restore_httpd_setup(task_id, msgs):
-    """Undo whatever _ensure_httpd_installed()/_ensure_httpd_running() did for
-    this task — service state first, then the package."""
+    """Undo whatever _ensure_httpd_running() did for this task (and replay any
+    package record left by an older version) — service state first."""
     for key in (_httpd_svc_key(task_id), _httpd_pkg_key(task_id)):
         state = load_fault_state(key)
         if state:
             _restore_env_setup(state['restore_info'], msgs)
             clear_fault_state(key)
+
+
+# ── Synthetic AVC evidence ────────────────────────────────────────────────────
+#
+# When a real denial can't be triggered (httpd not installed, so nothing ever
+# hits the mislabelled file / blocked port), the candidate would find empty
+# audit logs and the troubleshooting trail would go cold. In that case we write
+# the same records a real denial would have produced — an AVC line into
+# /var/log/audit/audit.log (so `ausearch -m AVC | audit2why` works) and a
+# setroubleshoot-style journal entry — so the documented diagnosis path still
+# leads to the root cause.
+
+_AUDIT_LOG = '/var/log/audit/audit.log'
+
+
+def _seed_avc_denial(avc_body, journal_msg):
+    """Append one AVC record to the audit log and mirror it to the journal.
+    Best-effort: failures are silent (the fault itself is still in place)."""
+    import time as _time
+    import random as _random
+    ts = f"{_time.time():.3f}"
+    serial = _random.randint(9000, 99999)
+    line = f"type=AVC msg=audit({ts}:{serial}): avc:  denied  {avc_body}\n"
+    try:
+        existed = os.path.exists(_AUDIT_LOG)
+        os.makedirs(os.path.dirname(_AUDIT_LOG), exist_ok=True)
+        with open(_AUDIT_LOG, 'a') as f:
+            f.write(line)
+        if not existed:
+            os.chmod(_AUDIT_LOG, 0o600)
+    except OSError:
+        pass
+    try:
+        _run(['logger', '-p', 'daemon.err', '-t', 'setroubleshoot', journal_msg],
+             timeout=10)
+    except Exception:
+        pass
 
 
 # ── Base class ────────────────────────────────────────────────────────────────
@@ -446,6 +481,8 @@ class TroubleshootingTask(BaseTask):
 
 @TaskRegistry.register("troubleshooting")
 class SELinuxHttpdContextFaultTask(TroubleshootingTask):
+
+    required_packages = ['httpd']
 
     def __init__(self):
         super().__init__(
@@ -484,9 +521,6 @@ class SELinuxHttpdContextFaultTask(TroubleshootingTask):
         return self
 
     def inject_fault(self):
-        if not _ensure_httpd_installed(self.id):
-            return False, "httpd package is not installed and could not be installed (check repo access)"
-
         # Create a test file so there's actually content to serve
         os.makedirs(self.web_root, exist_ok=True)
         test_file = f'{self.web_root}/index.html'
@@ -499,10 +533,27 @@ class SELinuxHttpdContextFaultTask(TroubleshootingTask):
         if r.returncode != 0:
             return False, f"chcon failed: {r.stderr.strip()}"
 
-        # Also ensure httpd is running so the symptom is visible
-        _ensure_httpd_running(self.id)
-
         save_fault_state(self.id, {'path': self.web_root})
+
+        if _httpd_present():
+            # Real symptom: run httpd and hit it so a genuine AVC denial lands
+            # in the audit log for the candidate to find.
+            _ensure_httpd_running(self.id)
+            _run(['curl', '-s', '-o', '/dev/null', '--max-time', '3',
+                  'http://localhost'], timeout=8)
+        else:
+            # httpd isn't installed (user declined the install offer) — leave
+            # the evidence a real denial would have produced so the documented
+            # diagnosis path (ausearch/audit2why, journal) still works.
+            _seed_avc_denial(
+                '{ read } for  pid=2841 comm="httpd" name="index.html" '
+                f'dev="dm-0" ino=17825828 '
+                'scontext=system_u:system_r:httpd_t:s0 '
+                'tcontext=unconfined_u:object_r:etc_t:s0 tclass=file permissive=0',
+                'SELinux is preventing /usr/sbin/httpd from read access on the '
+                f'file {self.web_root}/index.html. For complete SELinux messages '
+                'run: ausearch -m AVC | audit2why')
+
         return True, f"Set wrong SELinux context (etc_t) on {self.web_root}"
 
     def restore_fault(self):
@@ -560,6 +611,8 @@ class SELinuxHttpdContextFaultTask(TroubleshootingTask):
 @TaskRegistry.register("troubleshooting")
 class SELinuxHttpdBooleanFaultTask(TroubleshootingTask):
 
+    required_packages = ['httpd']
+
     def __init__(self):
         super().__init__(
             id="fault_selinux_boolean_httpd_001",
@@ -597,10 +650,6 @@ class SELinuxHttpdBooleanFaultTask(TroubleshootingTask):
         return self
 
     def inject_fault(self):
-        if not _ensure_httpd_installed(self.id):
-            return False, "httpd package is not installed and could not be installed (check repo access)"
-        _ensure_httpd_running(self.id)
-
         # Save current value first
         r = _run(['getsebool', self.boolean_name])
         if r.returncode == 0 and '->' in r.stdout:
@@ -611,13 +660,28 @@ class SELinuxHttpdBooleanFaultTask(TroubleshootingTask):
         if r.returncode != 0:
             return False, f"setsebool failed: {r.stderr.strip()}"
 
-        # Trigger an actual denial so audit logs have something real
-        _run(['curl', '-s', '--max-time', '2', 'http://localhost:8080'], timeout=5)
-
         save_fault_state(self.id, {
             'boolean': self.boolean_name,
             'original_value': self._original_value,
         })
+
+        if _httpd_present():
+            _ensure_httpd_running(self.id)
+            # Trigger an actual denial so audit logs have something real
+            _run(['curl', '-s', '--max-time', '2', 'http://localhost:8080'], timeout=5)
+        else:
+            # No httpd to generate the denial (user declined the install offer)
+            # — leave the records a real one would have produced so
+            # ausearch/audit2why still point at the boolean.
+            _seed_avc_denial(
+                '{ name_connect } for  pid=2841 comm="httpd" dest=8080 '
+                'scontext=system_u:system_r:httpd_t:s0 '
+                'tcontext=system_u:object_r:http_cache_port_t:s0 '
+                'tclass=tcp_socket permissive=0',
+                'SELinux is preventing /usr/sbin/httpd from name_connect access '
+                'on the tcp_socket port 8080. For complete SELinux messages '
+                'run: ausearch -m AVC | audit2why')
+
         return True, f"Set {self.boolean_name}=off (was {self._original_value})"
 
     def restore_fault(self):
@@ -666,6 +730,8 @@ class SELinuxHttpdBooleanFaultTask(TroubleshootingTask):
 @TaskRegistry.register("troubleshooting")
 class FirewallHttpBlockedFaultTask(TroubleshootingTask):
 
+    required_packages = ['httpd']
+
     def __init__(self):
         super().__init__(
             id="fault_firewall_http_001",
@@ -703,8 +769,8 @@ class FirewallHttpBlockedFaultTask(TroubleshootingTask):
         return self
 
     def inject_fault(self):
-        if not _ensure_httpd_installed(self.id):
-            return False, "httpd package is not installed and could not be installed (check repo access)"
+        if not _httpd_present():
+            return False, "httpd is not installed (declined at the install offer) — skipping this scenario"
 
         # Content + a running httpd so "curl localhost works" is actually true
         os.makedirs('/var/www/html', exist_ok=True)
@@ -862,6 +928,8 @@ class SshdBadConfigFaultTask(TroubleshootingTask):
 @TaskRegistry.register("troubleshooting")
 class HttpdDisabledFaultTask(TroubleshootingTask):
 
+    required_packages = ['httpd']
+
     def __init__(self):
         super().__init__(
             id="fault_service_httpd_001",
@@ -898,8 +966,8 @@ class HttpdDisabledFaultTask(TroubleshootingTask):
         return self
 
     def inject_fault(self):
-        if not _ensure_httpd_installed(self.id):
-            return False, "httpd package is not installed and could not be installed (check repo access)"
+        if not _httpd_present():
+            return False, "httpd is not installed (declined at the install offer) — skipping this scenario"
 
         r = _run(['systemctl', 'is-active', self.service])
         self._was_active = r.returncode == 0

--- a/tests/e2e/test_practice_mode.py
+++ b/tests/e2e/test_practice_mode.py
@@ -24,6 +24,8 @@ class TestCategorySelection:
     def test_select_category_menu(self, initialized_registry):
         session = PracticeSession()
         with patch("builtins.input", side_effect=["q"]), \
+             patch("utils.helpers.select_task_count", return_value=1), \
+             patch("core.practice.task_env"), \
              patch("core.practice.fmt"):
             session.start()
 
@@ -49,6 +51,8 @@ class TestPracticeTask:
              patch("core.practice.get_validator") as mock_val, \
              patch("core.practice.get_results_db", return_value=tmp_db), \
              patch("core.practice.confirm_action", side_effect=[True]), \
+             patch("utils.helpers.select_task_count", return_value=1), \
+             patch("core.practice.task_env"), \
              patch("core.practice.fmt"):
             mock_engine = MagicMock()
             mock_engine.validate_task.return_value = mock_result
@@ -78,6 +82,8 @@ class TestPracticeTask:
              patch("core.practice.get_validator") as mock_val, \
              patch("core.practice.get_results_db", return_value=tmp_db), \
              patch("core.practice.confirm_action", side_effect=[True]), \
+             patch("utils.helpers.select_task_count", return_value=1), \
+             patch("core.practice.task_env"), \
              patch("core.practice.fmt"):
             mock_engine = MagicMock()
             mock_engine.validate_task.side_effect = [fail_result, pass_result]
@@ -101,6 +107,8 @@ class TestPracticeTask:
              patch("core.practice.get_validator") as mock_val, \
              patch("core.practice.get_results_db") as mock_db, \
              patch("core.practice.confirm_action", side_effect=[False, True]), \
+             patch("utils.helpers.select_task_count", return_value=1), \
+             patch("core.practice.task_env"), \
              patch("core.practice.fmt") as mock_fmt:
             mock_fmt.bold.side_effect = lambda x: x
             mock_fmt.success.side_effect = lambda x: x

--- a/tests/unit/test_preflight_offer.py
+++ b/tests/unit/test_preflight_offer.py
@@ -1,0 +1,65 @@
+"""
+preflight.offer_task_packages: the ONLY path that may install packages, and it
+is strictly consent-gated (Y/n prompt). Declining installs nothing.
+"""
+
+import pytest
+
+from core import preflight
+
+
+pytestmark = pytest.mark.unit
+
+
+class _T:
+    def __init__(self, pkgs):
+        self.required_packages = pkgs
+
+
+@pytest.fixture
+def gather(monkeypatch):
+    state = {"installed": [], "missing": {"httpd"}, "asked": [], "answer": False}
+
+    monkeypatch.setattr(preflight, "filter_missing",
+                        lambda pkgs: sorted(set(pkgs) & state["missing"]))
+
+    def fake_install(pkgs):
+        state["installed"].extend(pkgs)
+        state["missing"] -= set(pkgs)
+        return True, ""
+    monkeypatch.setattr(preflight, "install_packages", fake_install)
+
+    from utils import helpers
+    def fake_confirm(prompt, default=False):
+        state["asked"].append(prompt)
+        return state["answer"]
+    monkeypatch.setattr(helpers, "confirm_action", fake_confirm)
+    return state
+
+
+def test_no_required_packages_no_prompt(gather):
+    still = preflight.offer_task_packages([_T([]), _T([])])
+    assert still == []
+    assert gather["asked"] == [], "must not prompt when nothing is needed"
+
+
+def test_all_present_no_prompt(gather):
+    gather["missing"] = set()
+    still = preflight.offer_task_packages([_T(["httpd"])])
+    assert still == []
+    assert gather["asked"] == []
+
+
+def test_decline_installs_nothing(gather):
+    gather["answer"] = False
+    still = preflight.offer_task_packages([_T(["httpd"])])
+    assert gather["asked"], "must ask before installing"
+    assert gather["installed"] == [], "declining must install NOTHING"
+    assert still == ["httpd"], "caller learns what is still missing"
+
+
+def test_consent_installs(gather):
+    gather["answer"] = True
+    still = preflight.offer_task_packages([_T(["httpd"]), _T(["httpd"])])
+    assert gather["installed"] == ["httpd"]
+    assert still == []

--- a/tests/unit/test_quick_practice_env.py
+++ b/tests/unit/test_quick_practice_env.py
@@ -1,12 +1,11 @@
 """
-Quick-practice must mutate the machine like exam/practice/adaptive modes do.
+Quick-practice environment lifecycle.
 
-Regression guard: run_quick_practice() once generated + validated tasks without
-injecting faults or establishing negative preconditions, so troubleshooting
-tasks had nothing to fix and positive-config tasks passed with no work done. It
-must now drive the same core.task_env lifecycle:
+Quick practice must mutate the machine like exam/practice/adaptive modes do,
+with the session-level teardown model: system changes are reverted ONCE at the
+end of the session (finish, quit, or error) — never between tasks:
 
-    session_reset  ->  setup_task  ->  (validate)  ->  teardown_task  ->  reset_after_task
+    prepare_session  ->  setup_task  ->  (validate)  ->  ...  ->  session_teardown
 """
 
 import builtins
@@ -63,11 +62,12 @@ class _FakeDB:
 def calls(monkeypatch):
     seq = []
 
-    monkeypatch.setattr(task_env, "session_reset", lambda *a, **k: seq.append(("session_reset",)))
+    monkeypatch.setattr(task_env, "prepare_session",
+                        lambda tasks, *a, **k: seq.append(("prepare_session",)))
     monkeypatch.setattr(task_env, "setup_task",
                         lambda task, *a, **k: (seq.append(("setup_task", task.id)) or {"setup": True}))
-    monkeypatch.setattr(task_env, "teardown_task",
-                        lambda task, st, *a, **k: seq.append(("teardown_task", task.id)))
+    monkeypatch.setattr(task_env, "session_teardown",
+                        lambda tasks, *a, **k: seq.append(("session_teardown",)))
     monkeypatch.setattr(task_env, "reset_after_task",
                         lambda task, *a, **k: seq.append(("reset_after_task", task.id)))
 
@@ -79,6 +79,7 @@ def calls(monkeypatch):
     monkeypatch.setattr(RDB, "get_results_db", lambda *a, **k: _FakeDB())
     monkeypatch.setattr(fmt, "clear_screen", lambda *a, **k: None)
     monkeypatch.setattr(H, "confirm_action", lambda *a, **k: True)
+    monkeypatch.setattr(H, "select_task_count", lambda *a, **k: 4)
     monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
     return seq
 
@@ -87,19 +88,42 @@ def _names(seq):
     return [c[0] for c in seq]
 
 
-def test_quick_practice_runs_full_env_lifecycle(calls):
+def test_quick_practice_runs_session_lifecycle(calls):
     R.run_quick_practice("all")
     names = _names(calls)
 
-    assert names[0] == "session_reset", "clean env must be prepared up front"
+    assert names[0] == "prepare_session", "clean env + package offer up front"
     assert "setup_task" in names, "the machine must be mutated per task"
     assert names.index("setup_task") < names.index("validate"), "setup before the candidate validates"
-    assert names.index("validate") < names.index("teardown_task"), "restore after validation"
+    assert names[-1] == "session_teardown", "revert happens once, at session end"
+
+
+def test_no_per_task_teardown(calls):
+    # System changes must persist across the session; only the end-of-session
+    # teardown reverts them (per-task revert was removed by design).
+    R.run_quick_practice("all")
+    assert _names(calls).count("session_teardown") == 1
+    assert "teardown_task" not in _names(calls)
+    # Non-disk task: no disk re-provisioning either.
+    assert "reset_after_task" not in _names(calls)
+
+
+def test_disk_tasks_reprovision_between_tasks(calls, monkeypatch):
+    class _DiskTask(_FakeTask):
+        id = "disk_task_001"
+        disk_slots = 1
+
+    monkeypatch.setattr(TaskRegistry, "get_exam_tasks",
+                        staticmethod(lambda n: [_DiskTask(), _FakeTask()]))
+    R.run_quick_practice("all")
+    names = _names(calls)
+    # Disk wiped after the disk task (another task follows), before session end.
     assert "reset_after_task" in names
+    assert names.index("reset_after_task") < names.index("session_teardown")
 
 
-def test_teardown_runs_even_when_validation_raises(calls, monkeypatch):
-    # A failure mid-task must not leave injected faults / preconditions behind.
+def test_session_teardown_runs_even_when_validation_raises(calls, monkeypatch):
+    # A failure mid-session must not leave injected faults / preconditions behind.
     class _Boom:
         def validate_task(self, task):
             raise RuntimeError("boom")
@@ -109,4 +133,4 @@ def test_teardown_runs_even_when_validation_raises(calls, monkeypatch):
         R.run_quick_practice("all")
 
     names = _names(calls)
-    assert "setup_task" in names and "teardown_task" in names, "teardown must run on error"
+    assert "setup_task" in names and "session_teardown" in names, "teardown must run on error"

--- a/tests/unit/test_session_teardown.py
+++ b/tests/unit/test_session_teardown.py
@@ -1,9 +1,13 @@
 """
-Session teardown on every exit path.
+Session teardown / environment-persistence contract.
 
-The machine must be returned to a clean state whenever a session ends — finished,
-quit, or Ctrl-C — not just on a fully-graded exam. Covers core.task_env
-.session_teardown (training modes) and ExamSession.teardown (exam mode).
+- Training sessions (quick/practice/adaptive) revert everything ONCE at session
+  end via core.task_env.session_teardown.
+- Exam mode deliberately performs NO automatic teardown — the environment stays
+  in place after grading (and on early quit) so the candidate can review scores
+  and file disputes against live state.
+- The next session start (task_env.session_reset) restores anything a previous
+  session left behind.
 """
 
 import pytest
@@ -74,29 +78,44 @@ class TestSessionTeardown:
         assert ("session_reset",) in sink
 
 
-class TestExamTeardown:
-    def test_idempotent(self, monkeypatch):
+class TestSessionResetRestoresPreviousSession:
+    def test_session_reset_replays_leftover_fault_records(self, monkeypatch):
+        # Exams leave their environment in place; the NEXT session start must
+        # restore those faults before cleaning.
         calls = []
-        monkeypatch.setattr(exam_mod.ExamSession, "_restore_exam_faults",
-                            lambda self: calls.append("restore"))
-        monkeypatch.setattr(task_env, "session_reset",
-                            lambda *a, **k: calls.append("reset"))
+        import tasks.troubleshooting as ts
+        monkeypatch.setattr(ts, "restore_any_active_fault",
+                            lambda: (calls.append("restore_faults") or (True, "ok")))
+        from utils import helpers
+        monkeypatch.setattr(helpers, "reset_practice_loops",
+                            lambda *a, **k: calls.append("loops"))
+        from core import lab_cleanup
+        monkeypatch.setattr(lab_cleanup, "clean", lambda **k: calls.append("lab") or [])
 
-        s = exam_mod.ExamSession(task_count=1)
-        s.teardown()
-        s.teardown()  # second call must be a no-op
-        assert calls == ["restore", "reset"]
+        task_env.session_reset(verbose=False)
+        assert calls[0] == "restore_faults", "restore previous session's faults FIRST"
+        assert "loops" in calls and "lab" in calls
 
-    def test_run_exam_mode_tears_down_on_early_quit(self, monkeypatch):
-        # If the candidate Ctrl-C's the "Press Enter" prompt before validating,
-        # the outer finally must still restore + clean.
-        torn = []
+
+class TestExamKeepsEnvironment:
+    def test_exam_has_no_auto_teardown(self):
+        # The old auto-teardown API must be gone — cleanup is only via
+        # session_reset (next session) or the menu's Reset Machine.
+        assert not hasattr(exam_mod.ExamSession, "teardown")
+        assert not hasattr(exam_mod.ExamSession, "_restore_exam_faults")
+
+    def test_run_exam_mode_does_not_clean_on_early_quit(self, monkeypatch):
+        # Ctrl-C at the "Press Enter" prompt must leave the environment as-is
+        # (kept for review/disputes) — nothing may revert or reset here.
+        touched = []
         monkeypatch.setattr(exam_mod, "_select_exam_task_count", lambda: 1)
         monkeypatch.setattr(exam_mod, "_select_reboot_simulation", lambda: False)
         monkeypatch.setattr(exam_mod.ExamSession, "start",
                             lambda self: setattr(self, "tasks", [object()]))
-        monkeypatch.setattr(exam_mod.ExamSession, "teardown",
-                            lambda self: torn.append(True))
+        monkeypatch.setattr(task_env, "session_reset",
+                            lambda *a, **k: touched.append("session_reset"))
+        monkeypatch.setattr(task_env, "session_teardown",
+                            lambda *a, **k: touched.append("session_teardown"))
 
         def _interrupt(*a, **k):
             raise KeyboardInterrupt()
@@ -104,4 +123,4 @@ class TestExamTeardown:
 
         with pytest.raises(KeyboardInterrupt):
             exam_mod.run_exam_mode()
-        assert torn == [True], "teardown must run even when the exam is aborted"
+        assert touched == [], "exam exit must not clean the environment"

--- a/tests/unit/test_troubleshooting_httpd_preflight.py
+++ b/tests/unit/test_troubleshooting_httpd_preflight.py
@@ -1,14 +1,15 @@
 """
-Tests for the httpd preflight added to the httpd-related troubleshooting fault
-tasks (issue #37): on a minimal RHEL/Rocky install httpd isn't present, so
-injecting the fault (wrong SELinux context, blocked firewall port, disabled
-service, ...) silently did nothing observable — the candidate never saw the
-symptom. tasks.troubleshooting._ensure_httpd_installed/_ensure_httpd_running
-now install/start httpd on demand before the fault is applied, and
-_restore_httpd_setup reverts exactly what was changed.
+httpd-dependent troubleshooting faults must NEVER install packages themselves.
+
+Packages are offered (Y/n) at session prep via preflight.offer_task_packages;
+tasks only declare required_packages. When httpd is absent at inject time:
+
+  * SELinux faults still inject (the misconfiguration is real) and plant the
+    audit-log evidence a real denial would have produced (_seed_avc_denial),
+    so `ausearch -m AVC | audit2why` still leads to the root cause.
+  * Service/firewall faults (which need a real httpd to run) skip cleanly.
 """
 
-import subprocess
 from types import SimpleNamespace
 
 import pytest
@@ -19,200 +20,115 @@ pytestmark = pytest.mark.unit
 
 
 class FakeSystem:
-    """Minimal stand-in for rpm/dnf/systemctl state, driven by subprocess.run."""
+    """Stand-in for rpm/systemctl/chcon/setsebool state, driven by ts._run."""
 
-    def __init__(self, httpd_installed=False, httpd_active=False,
-                 httpd_enabled=False, install_should_fail=False):
+    def __init__(self, httpd_installed=False):
         self.httpd_installed = httpd_installed
-        self.httpd_active = httpd_active
-        self.httpd_enabled = httpd_enabled
-        self.install_should_fail = install_should_fail
         self.calls = []
 
     def run(self, cmd, **kwargs):
         self.calls.append(list(cmd))
         prog = cmd[0]
-
         if prog == 'rpm' and cmd[1:3] == ['-q', 'httpd']:
             return SimpleNamespace(returncode=0 if self.httpd_installed else 1,
-                                    stdout='', stderr='')
-
-        if prog == 'dnf' and 'install' in cmd:
-            if self.install_should_fail:
-                return SimpleNamespace(returncode=1, stdout='', stderr='no repo access')
-            self.httpd_installed = True
-            return SimpleNamespace(returncode=0, stdout='', stderr='')
-
-        if prog == 'dnf' and 'remove' in cmd:
-            self.httpd_installed = False
-            self.httpd_active = False
-            self.httpd_enabled = False
-            return SimpleNamespace(returncode=0, stdout='', stderr='')
-
-        if prog == 'systemctl':
-            sub = cmd[1]
-            if sub == 'cat':
-                return SimpleNamespace(returncode=0 if self.httpd_installed else 1,
-                                        stdout='', stderr='')
-            if sub == 'is-active':
-                return SimpleNamespace(
-                    returncode=0 if self.httpd_active else 3,
-                    stdout='active' if self.httpd_active else 'inactive', stderr='')
-            if sub == 'is-enabled':
-                return SimpleNamespace(
-                    returncode=0 if self.httpd_enabled else 1,
-                    stdout='enabled' if self.httpd_enabled else 'disabled', stderr='')
-            if sub == 'enable':
-                self.httpd_enabled = True
-                return SimpleNamespace(returncode=0, stdout='', stderr='')
-            if sub == 'disable':
-                self.httpd_enabled = False
-                return SimpleNamespace(returncode=0, stdout='', stderr='')
-            if sub == 'start':
-                self.httpd_active = True
-                return SimpleNamespace(returncode=0, stdout='', stderr='')
-            if sub == 'stop':
-                self.httpd_active = False
-                return SimpleNamespace(returncode=0, stdout='', stderr='')
-
+                                   stdout='', stderr='')
+        if prog == 'getsebool':
+            return SimpleNamespace(returncode=0,
+                                   stdout='httpd_can_network_connect --> on',
+                                   stderr='')
+        # chcon, setsebool, systemctl, curl, logger, firewall-cmd ... succeed
         return SimpleNamespace(returncode=0, stdout='', stderr='')
 
 
 @pytest.fixture
-def fake_state_file(tmp_path, monkeypatch):
-    monkeypatch.setattr(ts, 'FAULT_STATE_FILE', str(tmp_path / 'active_fault.json'))
+def no_httpd(monkeypatch, tmp_path):
+    fake = FakeSystem(httpd_installed=False)
+    monkeypatch.setattr(ts, '_run', lambda cmd, **kw: fake.run(cmd, **kw))
+    # State + audit files sandboxed
+    monkeypatch.setattr(ts, 'FAULT_STATE_FILE', str(tmp_path / 'fault.json'))
+    monkeypatch.setattr(ts, '_AUDIT_LOG', str(tmp_path / 'audit.log'))
+    return fake, tmp_path
 
 
-@pytest.fixture
-def fake_system(monkeypatch, fake_state_file):
-    system = FakeSystem()
-    monkeypatch.setattr(subprocess, 'run', system.run)
-    return system
+def _no_dnf(fake):
+    return not any(c and c[0] == 'dnf' for c in fake.calls)
 
 
-def dnf_calls(system, verb):
-    return [c for c in system.calls if c[:2] == ['dnf', '-y'] and verb in c]
+class TestNoSilentInstalls:
+    def test_httpd_present_is_read_only(self, no_httpd):
+        fake, _ = no_httpd
+        assert ts._httpd_present() is False
+        fake.httpd_installed = True
+        assert ts._httpd_present() is True
+        assert _no_dnf(fake), "presence check must never run dnf"
+
+    def test_tasks_declare_required_packages(self):
+        for cls in (ts.SELinuxHttpdContextFaultTask, ts.SELinuxHttpdBooleanFaultTask,
+                    ts.FirewallHttpBlockedFaultTask, ts.HttpdDisabledFaultTask):
+            assert 'httpd' in cls.required_packages
 
 
-class TestEnsureHttpdInstalled:
-    def test_installs_when_missing(self, fake_system):
-        fake_system.httpd_installed = False
-        assert ts._ensure_httpd_installed('task1') is True
-        assert fake_system.httpd_installed is True
-        assert dnf_calls(fake_system, 'install')
-
-    def test_records_restore_state_when_installed(self, fake_system):
-        ts._ensure_httpd_installed('task1')
-        state = ts.load_fault_state(ts._httpd_pkg_key('task1'))
-        assert state is not None
-        assert state['restore_info']['restore_type'] == 'pkg_remove'
-        assert state['restore_info']['pkg'] == 'httpd'
-
-    def test_noop_when_already_installed(self, fake_system):
-        fake_system.httpd_installed = True
-        assert ts._ensure_httpd_installed('task1') is True
-        assert not dnf_calls(fake_system, 'install')
-        assert ts.load_fault_state(ts._httpd_pkg_key('task1')) is None
-
-    def test_returns_false_when_install_fails(self, fake_system):
-        fake_system.httpd_installed = False
-        fake_system.install_should_fail = True
-        assert ts._ensure_httpd_installed('task1') is False
-
-
-class TestEnsureHttpdRunning:
-    def test_starts_and_enables_when_stopped(self, fake_system):
-        fake_system.httpd_installed = True
-        fake_system.httpd_active = False
-        fake_system.httpd_enabled = False
-        ts._ensure_httpd_running('task1')
-        assert fake_system.httpd_active is True
-        assert fake_system.httpd_enabled is True
-
-    def test_noop_when_already_running(self, fake_system):
-        fake_system.httpd_installed = True
-        fake_system.httpd_active = True
-        fake_system.httpd_enabled = True
-        ts._ensure_httpd_running('task1')
-        assert ts.load_fault_state(ts._httpd_svc_key('task1')) is None
-
-
-class TestRestoreHttpdSetup:
-    def test_uninstalls_and_stops_what_it_started(self, fake_system):
-        fake_system.httpd_installed = False
-        ts._ensure_httpd_installed('task1')
-        ts._ensure_httpd_running('task1')
-        assert fake_system.httpd_installed is True
-        assert fake_system.httpd_active is True
-
-        msgs = []
-        ts._restore_httpd_setup('task1', msgs)
-
-        assert fake_system.httpd_installed is False
-        assert msgs
-        assert ts.load_fault_state(ts._httpd_pkg_key('task1')) is None
-        assert ts.load_fault_state(ts._httpd_svc_key('task1')) is None
-
-    def test_noop_when_nothing_was_changed(self, fake_system):
-        fake_system.httpd_installed = True
-        fake_system.httpd_active = True
-        fake_system.httpd_enabled = True
-        ts._ensure_httpd_installed('task1')
-        ts._ensure_httpd_running('task1')
-
-        msgs = []
-        ts._restore_httpd_setup('task1', msgs)
-        assert msgs == []
-        assert fake_system.httpd_installed is True
-
-
-class TestHttpdDisabledFaultTaskWithMissingPackage:
-    """fault_service_httpd_001 previously assumed httpd was already installed;
-    on a minimal install its systemctl stop/disable calls were silent no-ops."""
-
-    def test_inject_installs_httpd_then_disables_it(self, fake_system):
-        fake_system.httpd_installed = False
-        task = ts.HttpdDisabledFaultTask()
-
+class TestSELinuxFaultsWithoutHttpd:
+    def test_context_fault_injects_and_seeds_avc(self, no_httpd):
+        fake, sandbox = no_httpd
+        task = ts.SELinuxHttpdContextFaultTask()
+        task.web_root = str(sandbox / 'www')
         ok, msg = task.inject_fault()
+        assert ok, msg
+        assert _no_dnf(fake), "inject_fault must never dnf install"
+        # Synthetic AVC evidence written for the candidate to find
+        log = sandbox / 'audit.log'
+        assert log.exists()
+        content = log.read_text()
+        assert 'type=AVC' in content and 'etc_t' in content and 'httpd' in content
 
-        assert ok is True
-        assert fake_system.httpd_installed is True
-        assert fake_system.httpd_active is False
-        assert fake_system.httpd_enabled is False
-
-    def test_restore_leaves_host_as_it_found_it(self, fake_system):
-        fake_system.httpd_installed = False
-        task = ts.HttpdDisabledFaultTask()
-        task.inject_fault()
-
-        ok, msg = task.restore_fault()
-
-        assert ok is True
-        assert fake_system.httpd_installed is False
-
-    def test_inject_fails_cleanly_when_httpd_cannot_be_installed(self, fake_system):
-        fake_system.httpd_installed = False
-        fake_system.install_should_fail = True
-        task = ts.HttpdDisabledFaultTask()
-
+    def test_boolean_fault_injects_and_seeds_avc(self, no_httpd):
+        fake, sandbox = no_httpd
+        task = ts.SELinuxHttpdBooleanFaultTask()
         ok, msg = task.inject_fault()
+        assert ok, msg
+        assert _no_dnf(fake)
+        content = (sandbox / 'audit.log').read_text()
+        assert 'name_connect' in content and 'httpd_t' in content
 
+    def test_real_httpd_means_no_synthetic_avc(self, no_httpd):
+        fake, sandbox = no_httpd
+        fake.httpd_installed = True
+        task = ts.SELinuxHttpdContextFaultTask()
+        task.web_root = str(sandbox / 'www')
+        ok, _ = task.inject_fault()
+        assert ok
+        # With a real httpd triggering a real denial, nothing is fabricated.
+        assert not (sandbox / 'audit.log').exists()
+        assert _no_dnf(fake)
+
+
+class TestServiceFaultsWithoutHttpd:
+    def test_firewall_fault_skips_cleanly(self, no_httpd):
+        fake, _ = no_httpd
+        ok, msg = ts.FirewallHttpBlockedFaultTask().inject_fault()
         assert ok is False
-        assert 'httpd' in msg.lower()
-        # No fault state should be recorded for a failed injection.
-        assert ts.load_fault_state(task.id) is None
+        assert 'not installed' in msg
+        assert _no_dnf(fake)
 
-    def test_inject_skips_install_when_httpd_already_present(self, fake_system):
-        fake_system.httpd_installed = True
-        fake_system.httpd_active = True
-        fake_system.httpd_enabled = True
+    def test_service_fault_skips_cleanly(self, no_httpd):
+        fake, _ = no_httpd
         task = ts.HttpdDisabledFaultTask()
-
+        task.generate()
         ok, msg = task.inject_fault()
+        assert ok is False
+        assert 'not installed' in msg
+        assert _no_dnf(fake)
 
-        assert ok is True
-        assert not dnf_calls(fake_system, 'install')
-        # Original was active+enabled, so restore should bring it back.
-        assert task._was_active is True
-        assert task._was_enabled is True
+
+class TestSeedAvcHelper:
+    def test_seed_appends_parseable_record(self, no_httpd):
+        fake, sandbox = no_httpd
+        ts._seed_avc_denial('{ read } for pid=1 comm="httpd" tclass=file',
+                            'SELinux is preventing httpd ...')
+        line = (sandbox / 'audit.log').read_text().strip()
+        assert line.startswith('type=AVC msg=audit(')
+        # timestamp:serial framing intact
+        assert '): avc:  denied  ' in line
+        # journal mirror attempted via logger
+        assert any(c and c[0] == 'logger' for c in fake.calls)

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -140,6 +140,28 @@ def confirm_action(prompt, default=False):
         print("Please answer 'y' or 'n'")
 
 
+def select_task_count(default=5, minimum=4, maximum=20):
+    """Ask how many tasks this session should include (clamped to a sane
+    range). Shared by quick practice, practice, and adaptive modes."""
+    prompt = f"How many tasks this session? ({minimum}-{maximum}) [{default}]: "
+    while True:
+        raw = input(prompt).strip()
+        if not raw:
+            return default
+        try:
+            n = int(raw)
+        except ValueError:
+            print("Please enter a whole number.")
+            continue
+        if n < minimum:
+            print(f"Minimum is {minimum}.")
+            continue
+        if n > maximum:
+            print(f"Maximum is {maximum}.")
+            continue
+        return n
+
+
 def get_terminal_width():
     """
     Get the current terminal width.


### PR DESCRIPTION
Implements the batch of behavior decisions from today's review.

## 1. Package installs are consent-gated (kills #41's silent `dnf install`)
- New `preflight.offer_task_packages()`: at session prep (all modes) it collects the drawn tasks' `required_packages`, and **asks Y/n** before installing anything. Declining installs nothing; installed packages stay installed (no more install/remove churn).
- httpd fault tasks now declare `required_packages=['httpd']` and never touch dnf themselves.

## 2. No more answer leaks + SELinux faults are discoverable in the logs
- Exam/training prep output no longer prints `✓ fault_selinux_context_httpd_001: Set wrong SELinux context (etc_t) on /var/www/html` — screens show generic counts; details go to the log only.
- SELinux context/boolean faults now inject **with or without httpd**. With httpd they trigger a *real* AVC denial (curl). Without it they plant the same evidence a real denial leaves: a parseable `type=AVC` record in `/var/log/audit/audit.log` + a setroubleshoot-style journal line — so `ausearch -m AVC | audit2why` still leads to the answer, per the task's own hints.
- Firewall/service httpd faults skip cleanly when httpd is absent.

## 3. Exam environment persists for review & disputes
- **No automatic teardown at exam end** (or early quit): the box stays exactly as the candidate left it so they can compare their work to the scores and file disputes with live evidence. A notice explains this after grading.
- `session_reset()` now replays leftover fault/precondition records first, so **any next session start restores the box automatically**; exam start uses the same shared reset.

## 4. Training sessions revert once, at session end
- Per-task teardown removed from quick/practice/adaptive — changes persist through the session and revert in a `finally` at the end (finish, quit, or Ctrl-C). Practice disks are still wiped **between disk tasks** so the next disk task gets a clean device.

## 5. One Reset button
- Setup menu's *System Reset / Clean lab leftovers / Full System Reset* trio consolidated into a single **Reset Machine** (restores faults + full artifact sweep, preview + typed `RESET`). ~480 lines of duplicate reset code removed.

## 6. Task-count chooser
- All training modes ask how many tasks (4–20, default 5) via a shared `select_task_count()`.

README updated throughout. Tests: 22 new/rewritten across preflight consent, no-httpd fault behavior + AVC seeding, teardown/persistence contract, quick-practice lifecycle. **248 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WPpnU5ycpYv4UUoxcFkEU