### PR TITLE
Include the flathub remote URL in the flatpak app-install question

### DIFF
--- a/tasks/flatpak.py
+++ b/tasks/flatpak.py
@@ -13,6 +13,11 @@ from validators.safe_executor import execute_safe
 
 logger = logging.getLogger(__name__)
 
+# The real exam always provides the remote's URL in the question — knowing
+# flathub.org by heart is not part of the objective, so every task description
+# that may require adding a remote must include it.
+FLATHUB_URL = 'https://flathub.org/repo/flathub.flatpakrepo'
+
 
 @TaskRegistry.register("flatpak")
 class InstallFlatpakRuntimeTask(BaseTask):
@@ -282,6 +287,7 @@ class InstallFlatpakAppTask(BaseTask):
         self.app_id = None
         self.app_name = None
         self.remote_name = None
+        self.remote_url = None
 
     def generate(self, **params):
         """Generate Flatpak application installation task."""
@@ -322,22 +328,24 @@ class InstallFlatpakAppTask(BaseTask):
         self.app_id = app['app_id']
         self.app_name = app['app_name']
         self.remote_name = app['remote']
+        self.remote_url = app.get('remote_url', FLATHUB_URL)
 
         self.description = (
             f"Install a Flatpak application:\n"
             f"  - Application: {self.app_name}\n"
             f"  - Application ID: {self.app_id}\n"
             f"  - Remote: {self.remote_name}\n"
-            f"  - Ensure the Flatpak remote is configured first\n"
+            f"  - Ensure the Flatpak remote is configured first; if it is\n"
+            f"    missing, add it from: {self.remote_url}\n"
             f"  - Verify the application is installed"
         )
 
         self.hints = [
+            f"Add the remote if needed: flatpak remote-add --if-not-exists {self.remote_name} {self.remote_url}",
             f"Install: flatpak install {self.remote_name} {self.app_id} -y",
             f"Verify: flatpak list | grep {self.app_id}",
             f"Info: flatpak info {self.app_id}",
             f"Search: flatpak search {self.app_name.split()[0]}",
-            "You may need to add the remote first: flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo",
         ]
 
         return self


### PR DESCRIPTION
## Problem

`InstallFlatpakAppTask` (Domain 1, e.g. "Install GNOME Clocks") told the candidate to "Ensure the Flatpak remote is configured first" but only named the remote (`flathub`) — the URL needed for `flatpak remote-add` appeared only in the hints, which cost points to reveal. The real EX200 always provides any URL required by a task in the question itself; memorizing `https://flathub.org/repo/flathub.flatpakrepo` is not an exam objective.

## Change

- The task description now includes the remote URL: *"Ensure the Flatpak remote is configured first; if it is missing, add it from: https://flathub.org/repo/flathub.flatpakrepo"*.
- Hints now lead with the `flatpak remote-add --if-not-exists <remote> <url>` command, built from the task's own remote name/URL instead of a hardcoded string.
- `remote_url` is a per-app config field (defaulting to a module-level `FLATHUB_URL`), so future non-flathub entries carry their own URL.

## Audit for similar issues

Swept all other task descriptions that reference remotes/servers/URLs:

- `AddFlathubRepoTask` — already includes the Remote URL in the question. OK.
- `tasks/repos.py` (all 6 repo tasks) — base URLs, GPG key URLs, and content-server URLs are all in the question text. OK.
- `tasks/network_storage.py` (NFS mount, fstab, autofs ×2) — server and export path given. OK.
- `tasks/time_services.py` — NTP server/pool names given. OK.
- `tasks/networking.py` — IP/gateway/DNS values given. OK.

No other task asks for an external identifier it doesn't provide.

Full suite: 248 passed. Verified the regenerated question text renders with the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPJtUZJjkRGuqZAWzRN3Wi