### PR TITLE
Name LVM task's disk, scale loops to need, queryable exam clock, tmux blacklist

### DIFF
--- a/core/exam.py
+++ b/core/exam.py
@@ -58,20 +58,21 @@ class ExamSession:
             print("Exam cancelled.")
             return None
 
-        # Build the practice device pool first (auto-creates >=3 loop devices,
-        # plus any spare non-system disk like /dev/sda) so the generator can cap
-        # whole-disk tasks to the number of devices we can actually hand out.
         from utils import helpers
         from core import task_env
         # Start from a clean box: restore anything a previous session left in
         # place (exams keep their environment for review/disputes), wipe orphan
         # loop devices, and remove leftover task artifacts.
         task_env.session_reset()
+        # Whole-disk tasks are capped by how many practice devices CAN exist,
+        # not by the 3 loops a fresh session starts with — loop devices are
+        # created on demand in _provision_devices(), so the real bound is free
+        # disk space plus any spare non-system real disk (e.g. /dev/sda).
         try:
-            pool = helpers.build_device_pool()
+            disk_budget = (helpers.loop_device_capacity()
+                           + len(helpers.get_spare_real_disks()))
         except Exception:
-            pool = []
-        disk_budget = len(pool) if pool else None
+            disk_budget = None
 
         # Generate domain-balanced tasks
         print("\nGenerating exam tasks...")
@@ -120,6 +121,12 @@ class ExamSession:
             end_time = self.start_time + timedelta(minutes=self.duration_minutes)
             print(f"\n{fmt.warning('Timer started!')} You have {self.duration_minutes} minutes.")
             print(f"Exam ends at: {end_time.strftime('%H:%M:%S')}")
+            # Uptime-anchored countdown for the candidate's other terminal —
+            # exam tasks change the system clock, so `date` can't be trusted.
+            from core import exam_clock
+            if exam_clock.start(self.duration_minutes):
+                print(fmt.dim("Check the time left any time (even after clock/"
+                              "timezone tasks): exam-time-left"))
         else:
             print(f"\n{fmt.info('Exam started!')} (No time limit)")
 
@@ -307,6 +314,8 @@ class ExamSession:
         # Stop timer
         if self.timer:
             self.timer.stop()
+        from core import exam_clock
+        exam_clock.stop()
 
         print()
         fmt.print_header("VALIDATING YOUR WORK")

--- a/core/exam_clock.py
+++ b/core/exam_clock.py
@@ -1,0 +1,104 @@
+"""
+Wall-clock-independent exam countdown, queryable from any terminal.
+
+Exam tasks legitimately change the system date, time, and timezone, so neither
+the simulator nor the candidate can trust `date` to know how much exam time is
+left. This module anchors the countdown to /proc/uptime — a system-wide clock
+that keeps counting no matter what the candidate does to the wall clock — and
+persists it in a small sourceable state file so a separate terminal can query
+it via the installed `exam-time-left` command (or `source` the state file).
+
+State file format (shell-parseable on purpose):
+    UPTIME_START=<seconds, from /proc/uptime at exam start>
+    DURATION_SECONDS=<exam length>
+    STARTED_WALL=<ISO timestamp, informational only>
+"""
+
+import os
+import logging
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+STATE_FILE = '/var/lib/rhcsa-simulator/exam_clock'
+QUERY_CMD = '/usr/local/bin/exam-time-left'
+
+_QUERY_SCRIPT = '''#!/bin/sh
+# Prints the time remaining in the running RHCSA-simulator exam.
+# Anchored to /proc/uptime, so it stays correct even when exam tasks change
+# the system date, time, or timezone. Installed by the simulator at exam start.
+STATE=/var/lib/rhcsa-simulator/exam_clock
+if [ ! -r "$STATE" ]; then
+    echo "No exam in progress."
+    exit 1
+fi
+. "$STATE"
+now=$(cut -d' ' -f1 /proc/uptime | cut -d. -f1)
+start=${UPTIME_START%.*}
+if [ -z "$now" ] || [ -z "$start" ] || [ "$now" -lt "$start" ]; then
+    echo "Cannot compute time remaining (system rebooted since exam start?)."
+    exit 1
+fi
+elapsed=$((now - start))
+remaining=$((DURATION_SECONDS - elapsed))
+if [ "$remaining" -le 0 ]; then
+    echo "TIME IS UP ($((DURATION_SECONDS / 60)) minutes elapsed)."
+    exit 0
+fi
+printf 'Time remaining: %dh %02dm %02ds   (elapsed %dm of %dm)\\n' \\
+    $((remaining / 3600)) $((remaining % 3600 / 60)) $((remaining % 60)) \\
+    $((elapsed / 60)) $((DURATION_SECONDS / 60))
+'''
+
+
+def _uptime():
+    with open('/proc/uptime') as f:
+        return float(f.read().split()[0])
+
+
+def start(duration_minutes):
+    """Record the exam start and (re)install the query command. Best-effort:
+    an exam must never fail to start over the courtesy clock."""
+    try:
+        os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
+        with open(STATE_FILE, 'w') as f:
+            f.write(
+                f"UPTIME_START={_uptime():.0f}\n"
+                f"DURATION_SECONDS={int(duration_minutes) * 60}\n"
+                f"STARTED_WALL={datetime.now().isoformat(timespec='seconds')}\n")
+        with open(QUERY_CMD, 'w') as f:
+            f.write(_QUERY_SCRIPT)
+        os.chmod(QUERY_CMD, 0o755)
+        return True
+    except Exception as e:
+        logger.debug("exam_clock.start failed: %s", e)
+        return False
+
+
+def stop():
+    """Clear the countdown (exam finished or box reset). The query command
+    stays installed and reports 'No exam in progress.'"""
+    try:
+        os.remove(STATE_FILE)
+    except OSError:
+        pass
+
+
+def remaining_seconds():
+    """Remaining seconds for the recorded exam, or None if no exam is running
+    or the anchor is unusable (e.g. the box rebooted since exam start)."""
+    try:
+        state = {}
+        with open(STATE_FILE) as f:
+            for line in f:
+                if '=' in line:
+                    k, v = line.strip().split('=', 1)
+                    state[k] = v
+        up_start = float(state['UPTIME_START'])
+        duration = int(state['DURATION_SECONDS'])
+        now = _uptime()
+        if now < up_start:
+            return None
+        return max(0, int(duration - (now - up_start)))
+    except Exception:
+        return None

--- a/core/task_env.py
+++ b/core/task_env.py
@@ -38,6 +38,12 @@ def session_reset(verbose=True):
         helpers.reset_practice_loops()
     except Exception:
         pass
+    # Clear a stale exam countdown left by an interrupted exam.
+    try:
+        from core import exam_clock
+        exam_clock.stop()
+    except Exception:
+        pass
     done = []
     try:
         from core import lab_cleanup

--- a/core/timer.py
+++ b/core/timer.py
@@ -62,9 +62,12 @@ class ExamTimer:
         self.on_expire = on_expire
         self.on_warning = on_warning
 
-        self.start_time: Optional[datetime] = None
-        self.pause_time: Optional[datetime] = None
-        self.paused_duration: timedelta = timedelta()
+        # Anchored to time.monotonic(), NOT the wall clock — exam tasks have
+        # the candidate change the system date/time/timezone, and the exam
+        # countdown must not jump when they do.
+        self.start_time: Optional[float] = None
+        self.pause_time: Optional[float] = None
+        self.paused_duration: float = 0.0
         self.is_running = False
         self.is_paused = False
         self.is_expired = False
@@ -78,7 +81,7 @@ class ExamTimer:
         if self.is_running:
             return
 
-        self.start_time = datetime.now()
+        self.start_time = time.monotonic()
         self.is_running = True
         self.is_expired = False
         self._triggered_warnings.clear()
@@ -98,27 +101,27 @@ class ExamTimer:
     def pause(self):
         """Pause the timer."""
         if self.is_running and not self.is_paused:
-            self.pause_time = datetime.now()
+            self.pause_time = time.monotonic()
             self.is_paused = True
 
     def resume(self):
         """Resume the timer."""
         if self.is_paused and self.pause_time:
-            self.paused_duration += datetime.now() - self.pause_time
+            self.paused_duration += time.monotonic() - self.pause_time
             self.pause_time = None
             self.is_paused = False
 
     def get_elapsed(self) -> timedelta:
         """Get elapsed time."""
-        if not self.start_time:
+        if self.start_time is None:
             return timedelta()
 
         if self.is_paused and self.pause_time:
-            elapsed = self.pause_time - self.start_time - self.paused_duration
+            seconds = self.pause_time - self.start_time - self.paused_duration
         else:
-            elapsed = datetime.now() - self.start_time - self.paused_duration
+            seconds = time.monotonic() - self.start_time - self.paused_duration
 
-        return elapsed
+        return timedelta(seconds=seconds)
 
     def get_remaining(self) -> timedelta:
         """Get remaining time."""
@@ -161,8 +164,9 @@ class ExamTimer:
             if not self.is_paused:
                 remaining_minutes = self.get_remaining_minutes()
 
-                # Check for expiration
-                if remaining_minutes <= 0 and not self.is_expired:
+                # Check for expiration (in seconds — get_remaining_minutes()
+                # floors, which would expire the timer a whole minute early)
+                if self.get_remaining().total_seconds() <= 0 and not self.is_expired:
                     self.is_expired = True
                     self.is_running = False
                     if self.on_expire:

--- a/tasks/lvm.py
+++ b/tasks/lvm.py
@@ -8,6 +8,7 @@ from tasks.base import BaseTask
 from tasks.registry import TaskRegistry
 from core.validator import ValidationCheck, ValidationResult
 from validators.system_validators import validate_lv_exists, get_lv_size_mb
+from validators.safe_executor import execute_safe
 from utils.helpers import get_practice_device, get_all_practice_devices, get_practice_lv, get_practice_vg
 
 
@@ -77,24 +78,32 @@ class VerifyLVExistsTask(BaseTask):
             "LV size may vary slightly due to extent alignment",
             "Path format: /dev/vg_name/lv_name or /dev/mapper/vg_name-lv_name",
         ]
+        self.device = None
         self.vg_name = None
         self.lv_name = None
         self.lv_size_mb = None
 
     def generate(self, **params):
+        # Name the target disk in the question — the candidate builds the VG
+        # from scratch here, and without a named device they'd have to guess
+        # which practice disk is safe to consume (see also exam device pool).
+        self.device = params.get('device') or get_practice_device() or '/dev/loop0'
         self.vg_name = params.get('vg_name', f'vg_exam{random.randint(1,99)}')
         self.lv_name = params.get('lv_name', f'lv_data{random.randint(1,99)}')
         self.lv_size_mb = params.get('size', random.choice([300, 350, 400]))
 
         self.description = (
             f"Create a {self.lv_size_mb}MB logical volume named '{self.lv_name}' "
-            f"in volume group '{self.vg_name}'. Create the VG first if it does not exist."
+            f"in volume group '{self.vg_name}'. Create the VG first if it does "
+            f"not exist, using the disk {self.device}."
         )
 
         self.hints = [
+            f"pvcreate {self.device}",
+            f"vgcreate {self.vg_name} {self.device}",
             "lvcreate creates a logical volume in an existing VG",
             "Use -L for size in MB and -n for the LV name",
-            "Verify with: lvs",
+            "Verify with: lvs and pvs",
         ]
 
         return self
@@ -110,12 +119,30 @@ class VerifyLVExistsTask(BaseTask):
             actual_size = get_lv_size_mb(self.vg_name, self.lv_name)
             tolerance = self.lv_size_mb * 0.05
             if actual_size and abs(actual_size - self.lv_size_mb) <= tolerance:
-                checks.append(ValidationCheck("lv_size", True, 5, f"Size correct: ~{actual_size}MB"))
-                total_points += 5
+                checks.append(ValidationCheck("lv_size", True, 3, f"Size correct: ~{actual_size}MB"))
+                total_points += 3
             else:
-                checks.append(ValidationCheck("lv_size", False, 0, f"Size incorrect: {actual_size}MB (expected {self.lv_size_mb}MB)", max_points=5))
+                checks.append(ValidationCheck("lv_size", False, 0, f"Size incorrect: {actual_size}MB (expected {self.lv_size_mb}MB)", max_points=3))
         else:
             checks.append(ValidationCheck("lv_exists", False, 0, f"Logical volume not found", max_points=5))
+
+        # VG built on the disk the question assigned (a partition on it counts)
+        result = execute_safe(['pvs', '--noheadings', '-o', 'pv_name,vg_name'])
+        on_device = False
+        if result.success:
+            for line in result.stdout.splitlines():
+                parts = line.split()
+                if (len(parts) >= 2 and parts[1] == self.vg_name
+                        and parts[0].startswith(self.device)):
+                    on_device = True
+        if on_device:
+            checks.append(ValidationCheck("vg_on_assigned_disk", True, 2,
+                          f"VG uses the assigned disk {self.device}"))
+            total_points += 2
+        else:
+            checks.append(ValidationCheck("vg_on_assigned_disk", False, 0,
+                          f"VG does not use the assigned disk {self.device}",
+                          max_points=2))
 
         passed = total_points >= (self.points * 0.7)
         return ValidationResult(self.id, passed, total_points, self.points, checks)

--- a/tasks/packages.py
+++ b/tasks/packages.py
@@ -87,7 +87,10 @@ class InstallPackageTask(BaseTask):
         self.package_name = None
 
     def generate(self, **params):
-        packages = ['tree', 'wget', 'vim-enhanced', 'tmux', 'htop', 'net-tools', 'bind-utils', 'bash-completion']
+        # No tmux/screen here (or in any install/remove pool): candidates often
+        # run the exam inside a multiplexer, and installing is harmless but the
+        # setup/teardown symmetry with remove tasks makes it a footgun.
+        packages = ['tree', 'wget', 'vim-enhanced', 'htop', 'net-tools', 'bind-utils', 'bash-completion']
         self.package_name = params.get('package', random.choice(packages))
         self.description = (
             f"Install a package using dnf:\n"
@@ -136,7 +139,9 @@ class RemovePackageTask(BaseTask):
         self.package_name = None
 
     def generate(self, **params):
-        packages = ['tree', 'wget', 'tmux', 'htop']
+        # Never draw a removal target the candidate may be actively depending
+        # on: removing tmux kills the session it's running in.
+        packages = ['tree', 'wget', 'htop']
         self.package_name = params.get('package', random.choice(packages))
         self.description = (
             f"Remove a package using dnf:\n"

--- a/tasks/registry.py
+++ b/tasks/registry.py
@@ -179,16 +179,20 @@ class TaskRegistry:
 
         disk_budget caps how many whole-disk tasks (by disk_slots) may be
         selected, so each can later be given a distinct practice device. When
-        None it is inferred from the devices currently available (without
-        creating any) with a sane floor, so callers/tests need not pass it.
+        None it is inferred from how many practice devices can exist — attached
+        loops plus free-space capacity for more plus spare real disks — with a
+        sane floor, so callers/tests need not pass it.
         """
         tasks = []
         exclude_ids = []
 
         if disk_budget is None:
+            # Loop devices are created on demand at provisioning time, so the
+            # budget is what CAN exist (free space + spare real disks), not
+            # what is attached right now.
             try:
-                from utils.helpers import get_loop_devices, get_spare_real_disks
-                disk_budget = len(get_loop_devices()) + len(get_spare_real_disks())
+                from utils.helpers import loop_device_capacity, get_spare_real_disks
+                disk_budget = loop_device_capacity() + len(get_spare_real_disks())
             except Exception:
                 disk_budget = 0
             disk_budget = max(disk_budget, 3)  # floor: exam start ensures >=3 loops

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1018,6 +1018,23 @@ def ensure_loop_devices(minimum=3):
     return get_loop_devices()
 
 
+def loop_device_capacity(size_mb=500, reserve_mb=1024):
+    """How many practice loop devices CAN exist: those already attached plus
+    as many more as free space under the loops directory allows (keeping
+    reserve_mb free). Loop images are created on demand at exam provisioning
+    (ensure_loop_devices), so selection budgets should use this rather than
+    the count currently attached."""
+    existing = len(get_loop_devices())
+    try:
+        base = '/var/lib/rhcsa-simulator'
+        os.makedirs(base, exist_ok=True)
+        st = os.statvfs(base)
+        free_mb = st.f_bavail * st.f_frsize // (1024 * 1024)
+    except Exception:
+        return max(existing, 3)
+    return existing + max(0, int((free_mb - reserve_mb) // size_mb))
+
+
 def get_spare_real_disks():
     """Non-system, unmounted real disks (e.g. /dev/sda) usable for practice."""
     spares = []


### PR DESCRIPTION
Four fixes from live exam feedback:

## LVM task names its disk (annoying-lookup fix)
`lvm_verify_001` ("Create LV ... create the VG first") never said which disk to use, forcing the candidate to scan every other storage question to find a safe device. The question now ends with "...using the disk /dev/loopN" (allocator-assigned, distinct per exam), hints lead with `pvcreate`/`vgcreate` on that device, and validation awards 2 of 10 points for the VG actually being on it (a partition on that disk counts). Audited all `disk_slots` tasks: every other one either names its device already or operates on a VG/LV/mount its setup provisions.

## Loop devices scale to need
Selection capped whole-disk tasks at the number of *currently attached* devices (3 loops + spares), even though `_provision_devices` creates loops on demand. New `helpers.loop_device_capacity()` bounds the budget by what CAN exist: attached loops + free-space capacity under `/var/lib/rhcsa-simulator` (500MB per loop, 1GB reserve) + spare real disks. Machines without a physical spare disk now simply get more loop devices.

## Queryable, clock-change-immune exam countdown
Exam tasks change the system date/time/timezone, so `date` can't tell you how much exam time is left — and the internal `ExamTimer` used `datetime.now()`, so it broke the same way. Now:
- `core/exam_clock.py` anchors the countdown to `/proc/uptime`, persists it to a sourceable state file, and installs an **`exam-time-left`** command at exam start — runnable from the candidate's other terminal at any time. Cleared at exam end and by session reset/Reset Machine.
- `ExamTimer` internals switched to `time.monotonic()`.
- Drive-by: the timer expired a full minute early (compared floored minutes to 0); expiration now compares seconds.

## tmux blacklisted from package pools
"Remove package: tmux" uninstalls the multiplexer the candidate is running the exam in. Worse, the *install* task's setup (`ensure_package_absent`) would `dnf -y remove tmux` at exam start if it was already installed. tmux is out of both pools.

## Tests
Full suite: 248 passed. Manually verified: question renders with device + matching hints; `loop_device_capacity()` computes from free space; `exam-time-left` round-trip (start → query → stop → "No exam in progress"); timer pause/resume freezes correctly and a 0-minute timer expires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPJtUZJjkRGuqZAWzRN3Wi