### PR TITLE
Weight autofs toward indirect maps; seed NFS server dirs to match

### DIFF
--- a/core/nfs_server.py
+++ b/core/nfs_server.py
@@ -33,6 +33,9 @@ _EXPORTS = [
     ('data', 'rw,sync,no_root_squash'),
     ('shared', 'rw,sync,no_root_squash'),
     ('public', 'ro,sync'),
+    # Per-user home directories for the classic indirect/wildcard autofs task
+    # (mount /home/guests/<user> from .../guests/<user> on demand).
+    ('guests', 'rw,sync,no_root_squash'),
 ]
 
 _DONE = 'RHCSA_NFS_DONE'
@@ -49,8 +52,12 @@ def _seed_block():
     return f"""
 stamp="provisioned by rhcsa-simulator on $(hostname -f 2>/dev/null || hostname) at $(date)"
 
-rm -rf {EXPORT_BASE}/data {EXPORT_BASE}/shared {EXPORT_BASE}/public
-mkdir -p {EXPORT_BASE}/data/archive {EXPORT_BASE}/shared/projects {EXPORT_BASE}/public
+rm -rf {EXPORT_BASE}/data {EXPORT_BASE}/shared {EXPORT_BASE}/public {EXPORT_BASE}/guests
+mkdir -p {EXPORT_BASE}/data/archive {EXPORT_BASE}/public
+# First-level subdirectories double as indirect-map keys (ls /shares/docs ...).
+mkdir -p {EXPORT_BASE}/shared/projects {EXPORT_BASE}/shared/docs {EXPORT_BASE}/shared/tools
+# Per-user homes for the wildcard automount task (/home/guests/<user>).
+mkdir -p {EXPORT_BASE}/guests/user1 {EXPORT_BASE}/guests/user2 {EXPORT_BASE}/guests/user3
 
 printf 'date,region,units,revenue\\n2026-01-15,EMEA,120,30450\\n2026-02-03,AMER,98,24010\\n2026-03-20,APAC,142,35980\\n' > {EXPORT_BASE}/data/sales-2026-q1.csv
 printf 'widget-a 412\\nwidget-b 87\\nwidget-c 0\\n' > {EXPORT_BASE}/data/inventory.txt
@@ -60,13 +67,21 @@ printf 'NFS export: data (read-write)\\n%s\\n' "$stamp" > {EXPORT_BASE}/data/MAN
 printf '# Team Roster\\nalice - lead\\nbob - sysadmin\\ncarol - dba\\n' > {EXPORT_BASE}/shared/team-roster.md
 printf 'Standup notes: NFS migration on track.\\n' > {EXPORT_BASE}/shared/meeting-notes.txt
 printf 'project alpha: active\\nproject beta: planning\\n' > {EXPORT_BASE}/shared/projects/status.txt
+printf 'Onboarding guide\\nRunbook index\\n' > {EXPORT_BASE}/shared/docs/index.txt
+printf 'backup.sh - nightly backup helper\\ncleanup.sh - tmp reaper\\n' > {EXPORT_BASE}/shared/tools/README.txt
 printf 'NFS export: shared (read-write)\\n%s\\n' "$stamp" > {EXPORT_BASE}/shared/MANIFEST.txt
+
+for u in user1 user2 user3; do
+  printf 'Welcome %s! This home directory lives on the NFS server.\\n' "$u" > {EXPORT_BASE}/guests/$u/README.txt
+  printf 'export PS1="[\\\\u@\\\\h \\\\W]\\\\$ "\\n' > {EXPORT_BASE}/guests/$u/.bashrc
+done
+printf 'NFS export: guests (read-write, per-user homes)\\n%s\\n' "$stamp" > {EXPORT_BASE}/guests/MANIFEST.txt
 
 printf 'Welcome to the RHCSA practice NFS server.\\nThis share is read-only.\\n' > {EXPORT_BASE}/public/announcement.txt
 printf 'rhcsa-simulator NFS v1\\n' > {EXPORT_BASE}/public/VERSION
 printf 'NFS export: public (read-only)\\n%s\\n' "$stamp" > {EXPORT_BASE}/public/MANIFEST.txt
 
-chmod -R 0777 {EXPORT_BASE}/data {EXPORT_BASE}/shared 2>/dev/null || true
+chmod -R 0777 {EXPORT_BASE}/data {EXPORT_BASE}/shared {EXPORT_BASE}/guests 2>/dev/null || true
 chmod -R 0555 {EXPORT_BASE}/public 2>/dev/null || true
 command -v restorecon >/dev/null 2>&1 && restorecon -R {EXPORT_BASE} 2>/dev/null || true
 """

--- a/tasks/network_storage.py
+++ b/tasks/network_storage.py
@@ -337,43 +337,90 @@ class ConfigureAutofsTask(BaseTask):
         self.nfs_export = None
         self.autofs_mount = None
         self.map_name = None
+        self.map_type = None
 
     def generate(self, **params):
-        """Generate autofs configuration task."""
+        """Generate autofs configuration task.
+
+        Two variants, phrased the explicit way Red Hat words them ("...so that
+        /X is an automount directory" = indirect; "...so that /X is
+        automatically mounted" = direct). Indirect is drawn 3:1 — it is by far
+        the more commonly reported exam task (wildcard/subdirectory mounts);
+        direct maps appear occasionally, so they stay in rotation.
+        """
         cfg = _nfs_config()
+        self.map_type = params.get('map_type') or random.choices(
+            ['indirect', 'direct'], weights=[3, 1])[0]
+
+        def _pick_export(suffix, fallback):
+            if cfg and cfg.get('exports'):
+                for e in cfg['exports']:
+                    if e.rstrip('/').endswith(suffix):
+                        return e
+                return cfg['exports'][0]
+            return fallback
+
         if cfg and cfg.get('exports'):
             self.nfs_server = params.get('server', cfg['host'])
-            self.nfs_export = params.get('export', cfg['exports'][0])
         else:
             self.nfs_server = params.get('server', 'nfs.example.com')
-            self.nfs_export = params.get('export', '/export/data')
-        self.autofs_mount = params.get('mount', '/data')
-        self.map_name = params.get('map', 'auto.data')
 
-        # Red Hat's wording is explicit about direct vs indirect ("...so that
-        # /X is automatically mounted" = direct; "...so that /X is an automount
-        # directory" = indirect). Mirror that: here the mount point ITSELF is
-        # the target, so this is a direct map.
-        self.description = (
-            f"Configure autofs so that {self.autofs_mount} is automatically "
-            f"mounted from an NFS export:\n"
-            f"  - NFS Server: {self.nfs_server}\n"
-            f"  - NFS Export: {self.nfs_export}\n"
-            f"  - {self.autofs_mount} itself is the mount target (a direct map, "
-            f"not a directory of automounts)\n"
-            f"  - The export must mount on access and unmount after the idle timeout\n"
-            f"  - autofs service must be running"
-        )
+        if self.map_type == 'indirect':
+            # The 'shared' export ships first-level subdirectories (docs,
+            # tools, projects) that serve as the indirect keys.
+            self.nfs_export = params.get('export',
+                                         _pick_export('/shared', '/export/shared'))
+            self.autofs_mount = params.get('mount', '/shares')
+            self.map_name = params.get('map', 'auto.shares')
 
-        self.hints = [
-            "Install autofs: dnf install autofs -y",
-            f"Direct maps are declared with /- ; add to /etc/auto.master: /- /etc/{self.map_name}",
-            f"Create /etc/{self.map_name} with: {self.autofs_mount} -rw {self.nfs_server}:{self.nfs_export}",
-            "An indirect-style master entry (mount-point + map) can never match "
-            "an absolute key like this one",
-            "Start service: systemctl enable --now autofs",
-            f"Test: ls {self.autofs_mount}"
-        ]
+            self.description = (
+                f"Configure autofs so that {self.autofs_mount} is an automount "
+                f"directory:\n"
+                f"  - NFS Server: {self.nfs_server}\n"
+                f"  - NFS Export: {self.nfs_export} (contains subdirectories "
+                f"such as docs, tools, projects)\n"
+                f"  - Accessing {self.autofs_mount}/<name> must automount "
+                f"{self.nfs_server}:{self.nfs_export}/<name>\n"
+                f"  - Use a wildcard key so any subdirectory works without "
+                f"further config changes\n"
+                f"  - Mounts appear on access and unmount after the idle timeout\n"
+                f"  - autofs service must be running"
+            )
+
+            self.hints = [
+                "Install autofs: dnf install autofs -y",
+                f"Add to /etc/auto.master: {self.autofs_mount} /etc/{self.map_name}",
+                f"Create /etc/{self.map_name} with: * -rw {self.nfs_server}:{self.nfs_export}/&",
+                "* matches the accessed name, & substitutes it into the export path",
+                "Start service: systemctl enable --now autofs",
+                f"Test: ls {self.autofs_mount}/docs"
+            ]
+        else:
+            self.nfs_export = params.get('export',
+                                         _pick_export('/data', '/export/data'))
+            self.autofs_mount = params.get('mount', '/data')
+            self.map_name = params.get('map', 'auto.data')
+
+            self.description = (
+                f"Configure autofs so that {self.autofs_mount} is automatically "
+                f"mounted from an NFS export:\n"
+                f"  - NFS Server: {self.nfs_server}\n"
+                f"  - NFS Export: {self.nfs_export}\n"
+                f"  - {self.autofs_mount} itself is the mount target (a direct "
+                f"map, not a directory of automounts)\n"
+                f"  - The export must mount on access and unmount after the idle timeout\n"
+                f"  - autofs service must be running"
+            )
+
+            self.hints = [
+                "Install autofs: dnf install autofs -y",
+                f"Direct maps are declared with /- ; add to /etc/auto.master: /- /etc/{self.map_name}",
+                f"Create /etc/{self.map_name} with: {self.autofs_mount} -rw {self.nfs_server}:{self.nfs_export}",
+                "An indirect-style master entry (mount-point + map) can never match "
+                "an absolute key like this one",
+                "Start service: systemctl enable --now autofs",
+                f"Test: ls {self.autofs_mount}"
+            ]
 
         return self
 
@@ -420,11 +467,11 @@ class ConfigureAutofsTask(BaseTask):
                 message="autofs service is not enabled"
             ))
 
-        # Check 3: direct map declared (5 points). The question asks for a
-        # direct map: a /- line in the master map plus the absolute mount
-        # point as the key in a map file. An indirect-style master entry
-        # naming the mount point reads plausibly but can never match an
-        # absolute key, so it only earns partial credit.
+        # Check 3: the right kind of map is declared (5 points). Direct maps
+        # need a /- master line plus the absolute mount point as a map key;
+        # indirect maps need the parent directory as the master entry plus a
+        # wildcard (or explicit subdirectory) key. Using the wrong style reads
+        # plausibly but can never match, so it only earns partial credit.
         import os
         import glob
 
@@ -441,33 +488,55 @@ class ConfigureAutofsTask(BaseTask):
             if os.path.isfile(extra):
                 master_lines += _noncomment_lines(extra)
 
-        has_direct_decl = any(ln.split()[0] == '/-' for ln in master_lines)
-        key_in_map = any(
-            self.autofs_mount in ln
+        map_lines = [
+            ln
             for path in glob.glob('/etc/auto.*') if os.path.isfile(path)
             and os.path.basename(path) != 'auto.master'
             for ln in _noncomment_lines(path)
-        )
-        indirect_style = any(ln.split()[0] == self.autofs_mount
-                             for ln in master_lines)
+        ]
 
-        if has_direct_decl and key_in_map:
+        has_direct_decl = any(ln.split()[0] == '/-' for ln in master_lines)
+        has_indirect_decl = any(ln.split()[0] == self.autofs_mount
+                                for ln in master_lines)
+        abs_key_in_map = any(ln.split()[0] == self.autofs_mount
+                             for ln in map_lines if ln.split())
+        wildcard_key_in_map = any(
+            ln.split()[0] == '*' and self.nfs_server in ln
+            for ln in map_lines if ln.split())
+
+        if self.map_type == 'direct':
+            ok = has_direct_decl and abs_key_in_map
+            wrong_style = has_indirect_decl
+            fix = (f"{self.autofs_mount} itself is the mount target — declare "
+                   f"a direct map (/- /etc/{self.map_name}) with "
+                   f"{self.autofs_mount} as the key")
+            ok_msg = f"Direct map declared (/-) with key {self.autofs_mount}"
+        else:
+            ok = has_indirect_decl and wildcard_key_in_map
+            wrong_style = has_direct_decl or (has_indirect_decl
+                                              and not wildcard_key_in_map)
+            fix = (f"{self.autofs_mount} is an automount directory — declare "
+                   f"'{self.autofs_mount} /etc/{self.map_name}' in the master "
+                   f"map with a wildcard key "
+                   f"(* -rw {self.nfs_server}:{self.nfs_export}/&)")
+            ok_msg = (f"Indirect map declared for {self.autofs_mount} with a "
+                      f"wildcard key")
+
+        if ok:
             checks.append(ValidationCheck(
                 name="master_entry",
                 passed=True,
                 points=5,
-                message=f"Direct map declared (/-) with key {self.autofs_mount}"
+                message=ok_msg
             ))
             total_points += 5
-        elif indirect_style:
+        elif wrong_style:
             checks.append(ValidationCheck(
                 name="master_entry",
                 passed=False,
                 points=2,
                 max_points=5,
-                message=f"Indirect-style master entry found — {self.autofs_mount} "
-                        f"itself is the mount target, so declare a direct map "
-                        f"(/- /etc/{self.map_name}) with {self.autofs_mount} as the key"
+                message=f"Map style doesn't match the question — {fix}"
             ))
             total_points += 2
         else:
@@ -542,7 +611,12 @@ class AutofsHomeDirectoriesTask(BaseTask):
         cfg = _nfs_config()
         if cfg and cfg.get('exports'):
             self.nfs_server = params.get('server', cfg['host'])
-            self.home_export = params.get('export', cfg['exports'][0])
+            # The 'guests' export ships per-user homes (user1..user3) for
+            # exactly this wildcard task; fall back to the first export.
+            guests = [e for e in cfg['exports']
+                      if e.rstrip('/').endswith('/guests')]
+            self.home_export = params.get(
+                'export', guests[0] if guests else cfg['exports'][0])
         else:
             self.nfs_server = params.get('server', 'ldap.example.com')
             self.home_export = params.get('export', '/home/guests')


### PR DESCRIPTION
Follow-up to #63, from the question "which map type am I actually likely to get?"

## What the research says

Reported EX200 autofs tasks are overwhelmingly the **indirect/wildcard** form — the canonical task is automounting LDAP/NFS user home directories under a parent like `/home/guests` or `/rhome` with `* -rw server:/export/&`. Practice-question repos and exam-dump variants all use it; direct maps are taught (van Vugt covers both) but rarely reported on the actual exam. Sources: [chlebik/rhcsa-practice-questions autofs task](https://github.com/chlebik/rhcsa-practice-questions/blob/master/questions/022_configure_autofs.md), [ExamTopics EX200 q105](https://www.examtopics.com/discussions/redhat/view/30716-exam-ex200-topic-1-question-105-discussion/), [Red Hat Learning Community on direct vs indirect](https://learn.redhat.com/t5/Platform-Linux/Difference-between-Direct-and-Indirect-Automount/td-p/20869).

## Changes

- **`autofs_basic_001` draws two variants, 3:1 indirect:direct**, each phrased Red Hat-explicitly:
  - *Indirect*: "Configure autofs so that **/shares is an automount directory**" — wildcard key over the shared export's subdirectories (docs, tools, projects), `ls /shares/docs` to test.
  - *Direct*: unchanged from #63.
  - The master-map check now validates whichever style the question asked for (indirect decl + wildcard key vs `/-` + absolute key); the wrong style earns 2/5 partial credit with a message explaining the fix.
- **NFS server seeding** grows real indirect keys: `shared/` gains `docs/` and `tools/` beside `projects/`, and a new **`guests` export** ships per-user homes (`user1..user3` with README/.bashrc) for the classic wildcard home-directory task. `autofs_home_001` targets the guests export when available.

## Tests

Full suite: 254 passed. Verified both variant questions render, the 3:1 draw holds over 400 samples (317/83), and the variant-aware check scores a correct direct map 5/5 on a live box.

Note: the live nfsserver still needs a one-time re-provision to grow the new directories (needs interactive SSH auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPJtUZJjkRGuqZAWzRN3Wi