### PR TITLE
Exam-style question terseness, /mnt + .repo cleanup, prune recent attempts

### DIFF
--- a/core/full_reset.py
+++ b/core/full_reset.py
@@ -84,14 +84,23 @@ def _noop(_msg):
 
 def list_nondefault_repos():
     """Third-party .repo files under /etc/yum.repos.d (RHEL system repos kept)."""
+    # Task-created repo files are removable even when their name collides with
+    # a protected system prefix (older task builds generated rhel-baseos/
+    # rhel-appstream; real RHEL repos only ever live in redhat.repo).
+    try:
+        from core.lab_cleanup import _PRACTICE_REPO_SET
+    except Exception:
+        _PRACTICE_REPO_SET = set()
     out, d = [], '/etc/yum.repos.d'
     try:
         for f in sorted(os.listdir(d)):
             if not f.endswith('.repo'):
                 continue
-            if f in _KEEP_REPO_FILES or f.startswith(_KEEP_REPO_PREFIXES):
+            full = os.path.join(d, f)
+            if full not in _PRACTICE_REPO_SET and (
+                    f in _KEEP_REPO_FILES or f.startswith(_KEEP_REPO_PREFIXES)):
                 continue
-            out.append(os.path.join(d, f))
+            out.append(full)
     except Exception:
         pass
     return out

--- a/core/lab_cleanup.py
+++ b/core/lab_cleanup.py
@@ -10,7 +10,8 @@ can interfere with the next run.
 Rather than snapshot the whole filesystem and diff it (which risks deleting
 unrelated user data), this module removes ONLY the specific paths the
 simulator's own tasks define — a curated manifest derived from the task set.
-It never touches /etc (fstab is handled separately by the fstab guard) and never
+The only /etc paths it touches are the exact task-created repo files in
+PRACTICE_REPO_FILES (fstab is handled separately by the fstab guard); it never
 touches shell dotfiles, SSH keys, or anything outside the manifest.
 """
 
@@ -23,16 +24,42 @@ SWAP_FILES = ['/swapfile', '/var/swap', '/swap.img']
 
 # Mount points / directories tasks create. Unmounted first if mounted, then the
 # directory tree is removed (these are simulator-owned scratch locations).
+# Globs, not exact names: the generators randomise a numeric suffix
+# (/mnt/data90, /mnt/vfat97, /mnt/practice_extend7503, ...), and without the
+# glob every one of them lingered forever.
 DIR_ARTIFACTS = [
-    '/mnt/data', '/mnt/nfsdata', '/mnt/shared', '/mnt/persistent',
-    '/mnt/practice_extend', '/mnt/vfat', '/mnt/external', '/mnt/faulttest',
-    '/mnt/recovery', '/mnt/rescue', '/mnt/sysimage', '/mnt/nonexistent',
+    '/mnt/data*', '/mnt/nfsdata*', '/mnt/shared*', '/mnt/persistent*',
+    '/mnt/practice_extend*', '/mnt/vfat*', '/mnt/external*', '/mnt/faulttest*',
+    '/mnt/recovery*', '/mnt/rescue*', '/mnt/sysimage', '/mnt/nonexistent',
     '/mnt/lvm*',
     '/opt/appdata', '/opt/webdata',
     '/srv/nfs', '/srv/samba', '/srv/website', '/srv/web', '/srv/webapp',
     '/srv/shares', '/srv/ftp', '/srv/acltest*',
     '/home/guests',
 ]
+
+# Task-created DNF repo files (tasks/repos.py generates exactly these repo
+# IDs; the file is always /etc/yum.repos.d/<id>.repo). EXACT names only —
+# never a glob, and never subscription-manager's redhat.repo. Note that
+# 'rhel-baseos'/'rhel-appstream' really are task names: genuine RHEL system
+# repos live in redhat.repo, never in files named like these.
+PRACTICE_REPO_FILES = [
+    f'/etc/yum.repos.d/{rid}.repo' for rid in (
+        'rocky10-baseos', 'rocky10-appstream', 'rocky10-crb',
+        'rocky10-extras', 'rocky10-devel',
+        'alma10-baseos', 'alma10-appstream', 'alma10-crb', 'alma10-extras',
+        'epel', 'epel9', 'grafana', 'nodesource-nodejs', 'vscode',
+        'kubernetes', 'hashicorp', 'docker-ce', 'elrepo', 'rpmfusion-free',
+        'pgdg17', 'mariadb', 'nginx', 'tailscale', 'google-cloud-cli',
+        'packages-microsoft-com-prod',
+        'broken-baseos', 'broken-appstream', 'broken-crb', 'broken-extras',
+        'broken-epel',
+        'baseos', 'appstream', 'BaseOS', 'AppStream',
+        'local-baseos', 'local-appstream', 'lab-baseos', 'lab-appstream',
+        'rhel-baseos', 'rhel-appstream',
+    )
+]
+_PRACTICE_REPO_SET = set(PRACTICE_REPO_FILES)
 
 # Individual files/dirs under /tmp and a couple of /root, /home markers. Globs
 # cover the randomised name families (journal_*, scp_*, top_*, etc.).
@@ -102,6 +129,9 @@ def _is_safe(path):
         return False
     if path in SWAP_FILES:
         return True
+    # The only /etc paths ever touched: the exact task-created repo files.
+    if path in _PRACTICE_REPO_SET:
+        return True
     return path.startswith(_ALLOWED_PREFIXES)
 
 
@@ -158,7 +188,8 @@ def _find_units():
 def find_leftovers():
     """Existing artifact paths cleanup would act on (timeout-guarded)."""
     found = set()
-    for pattern in SWAP_FILES + DIR_ARTIFACTS + FILE_ARTIFACTS:
+    for pattern in (SWAP_FILES + DIR_ARTIFACTS + FILE_ARTIFACTS
+                    + PRACTICE_REPO_FILES):
         for match in _expand(pattern):
             if _is_safe(match) and _exists(match):
                 found.add(os.path.normpath(match))
@@ -215,7 +246,16 @@ def clean(dry_run=False):
             elif _sh(['rm', '-rf', '--', path], 15) == 0:
                 actions.append(f"removed file {path}")
 
-    # 4. Candidate-created systemd units + their helper scripts.
+    # 4. Task-created DNF repo files (exact names from the manifest only).
+    for path in PRACTICE_REPO_FILES:
+        if not _is_safe(path) or not _exists(path):
+            continue
+        if dry_run:
+            actions.append(f"would remove repo {path}")
+        elif _sh(['rm', '-f', '--', path], 15) == 0:
+            actions.append(f"removed repo {path}")
+
+    # 5. Candidate-created systemd units + their helper scripts.
     actions.extend(clean_units(dry_run=dry_run))
 
     return actions

--- a/core/menu.py
+++ b/core/menu.py
@@ -655,10 +655,14 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             fmt.print_header("PRUNE HISTORY")
             print(fmt.bold("Remove:"))
             print("  1. A specific exam")
-            print("  2. All practice/adaptive attempts")
-            print("  3. Reset one category's adaptive (SM-2) state")
-            print("  4. Everything (wipe all progress)")
+            print("  2. Recent practice attempts (pick which — e.g. a botched session)")
+            print("  3. All practice/adaptive attempts")
+            print("  4. Reset one category's adaptive (SM-2) state")
+            print("  5. Everything (wipe all progress)")
             print("  0. Back")
+            print()
+            print(fmt.dim("Weak-area/SM-2 stats are recomputed from the surviving history"))
+            print(fmt.dim("after every prune, so removed attempts stop counting against you."))
             print()
             choice = input("Select option: ").strip()
 
@@ -683,11 +687,46 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
                         print(fmt.success("Deleted."))
                         input("\nPress Enter...")
             elif choice == '2':
-                if confirm_action("Delete ALL practice/adaptive attempts?", default=False):
-                    n = db.clear_practice_history()
-                    print(fmt.success(f"Removed {n} attempt(s)."))
+                attempts = db.list_recent_practice(limit=30)
+                if not attempts:
+                    print(fmt.dim("No practice attempts recorded."))
+                    input("\nPress Enter...")
+                    continue
+                print()
+                for i, a in enumerate(attempts, 1):
+                    status = 'PASS' if a['passed'] else 'FAIL'
+                    print(f"  {i:2d}. {(a['created_at'] or '')[:16]}  "
+                          f"{a['score']}/{a['max_score']} {status}  "
+                          f"{a['category']}  {a['task_id']}  ({a['mode']})")
+                print()
+                sel = input("Numbers to delete (e.g. 1,3 or 1-5; blank to cancel): ").strip()
+                picked = set()
+                for part in sel.split(','):
+                    part = part.strip()
+                    if '-' in part:
+                        lo, _, hi = part.partition('-')
+                        if lo.strip().isdigit() and hi.strip().isdigit():
+                            picked.update(range(int(lo), int(hi) + 1))
+                    elif part.isdigit():
+                        picked.add(int(part))
+                ids = [attempts[i - 1]['id'] for i in sorted(picked)
+                       if 1 <= i <= len(attempts)]
+                if ids and confirm_action(f"Delete {len(ids)} attempt(s)?",
+                                          default=False):
+                    n = db.delete_practice_attempts(ids)
+                    db.rebuild_weak_areas()
+                    print(fmt.success(f"Removed {n} attempt(s); weak areas recomputed."))
+                    input("\nPress Enter...")
+                elif not ids:
+                    print(fmt.dim("Nothing selected."))
                     input("\nPress Enter...")
             elif choice == '3':
+                if confirm_action("Delete ALL practice/adaptive attempts?", default=False):
+                    n = db.clear_practice_history()
+                    db.rebuild_weak_areas()
+                    print(fmt.success(f"Removed {n} attempt(s); weak areas recomputed."))
+                    input("\nPress Enter...")
+            elif choice == '4':
                 stats = db.get_all_category_stats()
                 if not stats:
                     print(fmt.dim("No category state recorded."))
@@ -705,7 +744,7 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
                         db.reset_category(cat)
                         print(fmt.success("Reset."))
                         input("\nPress Enter...")
-            elif choice == '4':
+            elif choice == '5':
                 print(fmt.warning("This wipes ALL exams, attempts, and adaptive state."))
                 if confirm_action("Type-safe confirm: wipe everything?", default=False):
                     db.clear_all_progress()

--- a/core/results_db.py
+++ b/core/results_db.py
@@ -204,15 +204,18 @@ class ResultsDB:
         except Exception:
             pass
 
-    def _update_weak_area(self, category, score, max_score, passed):
-        """Update weak area stats using SM-2 algorithm."""
+    def _update_weak_area(self, category, score, max_score, passed, when=None):
+        """Update weak area stats using SM-2 algorithm.
+
+        `when` (ISO string) backdates the attempt — used when replaying
+        history in rebuild_weak_areas(); defaults to now for live updates."""
         conn = self._get_conn()
         try:
             row = conn.execute(
                 "SELECT * FROM weak_areas WHERE category = ?", (category,)
             ).fetchone()
 
-            now = datetime.now().isoformat()
+            now = when or datetime.now().isoformat()
 
             if row is None:
                 ef = 2.5
@@ -248,7 +251,8 @@ class ResultsDB:
                 interval = 1
 
             ef = max(1.3, ef + (0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02)))
-            due = (datetime.now() + timedelta(days=interval)).isoformat()
+            base = datetime.fromisoformat(now) if when else datetime.now()
+            due = (base + timedelta(days=interval)).isoformat()
 
             attempts = (row['attempts'] + 1) if row else 1
             passes = (row['passes'] + (1 if passed else 0)) if row else (1 if passed else 0)
@@ -267,6 +271,65 @@ class ResultsDB:
             conn.commit()
         finally:
             conn.close()
+
+    def list_recent_practice(self, limit=30):
+        """Most recent practice/adaptive attempts, newest first (for pruning)."""
+        conn = self._get_conn()
+        try:
+            rows = conn.execute("""
+                SELECT id, task_id, category, score, max_score, passed, mode,
+                       created_at
+                FROM practice_history ORDER BY id DESC LIMIT ?
+            """, (limit,)).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    def delete_practice_attempts(self, ids):
+        """Delete specific practice attempts by row id. Returns rows deleted.
+        Callers should rebuild_weak_areas() afterwards."""
+        if not ids:
+            return 0
+        conn = self._get_conn()
+        try:
+            marks = ','.join('?' for _ in ids)
+            cur = conn.execute(
+                f"DELETE FROM practice_history WHERE id IN ({marks})",
+                list(ids))
+            conn.commit()
+        finally:
+            conn.close()
+        self._autosave()
+        return cur.rowcount
+
+    def rebuild_weak_areas(self):
+        """Recompute ALL weak-area/SM-2 state from the surviving practice
+        history. Without this, pruned attempts kept polluting the adaptive
+        stats: deleting rows never touched weak_areas. Replays every attempt
+        in order, backdated to its original timestamp."""
+        conn = self._get_conn()
+        try:
+            conn.execute("DELETE FROM weak_areas")
+            conn.commit()
+            rows = conn.execute(
+                "SELECT category, score, max_score, passed, created_at "
+                "FROM practice_history ORDER BY created_at ASC, id ASC"
+            ).fetchall()
+        finally:
+            conn.close()
+        for r in rows:
+            when = None
+            try:
+                # SQLite CURRENT_TIMESTAMP is 'YYYY-MM-DD HH:MM:SS'
+                when = datetime.strptime(
+                    r['created_at'], '%Y-%m-%d %H:%M:%S').isoformat()
+            except (TypeError, ValueError):
+                pass
+            self._update_weak_area(r['category'], r['score'],
+                                   r['max_score'], bool(r['passed']),
+                                   when=when)
+        self._autosave()
+        return len(rows)
 
     def get_recent_exams(self, limit=10):
         """Get recent exam results."""
@@ -491,9 +554,10 @@ class ResultsDB:
             conn.execute("DELETE FROM task_results WHERE exam_id=?", (exam_id,))
             cur = conn.execute("DELETE FROM exam_results WHERE exam_id=?", (exam_id,))
             conn.commit()
-            return cur.rowcount
         finally:
             conn.close()
+        self._autosave()
+        return cur.rowcount
 
     def clear_practice_history(self):
         """Delete all practice/adaptive attempts. Returns rows deleted."""
@@ -501,9 +565,10 @@ class ResultsDB:
         try:
             cur = conn.execute("DELETE FROM practice_history")
             conn.commit()
-            return cur.rowcount
         finally:
             conn.close()
+        self._autosave()
+        return cur.rowcount
 
     def reset_category(self, category):
         """Clear the SM-2 / weak-area state for one category."""
@@ -511,9 +576,10 @@ class ResultsDB:
         try:
             cur = conn.execute("DELETE FROM weak_areas WHERE category=?", (category,))
             conn.commit()
-            return cur.rowcount
         finally:
             conn.close()
+        self._autosave()
+        return cur.rowcount
 
     def clear_all_progress(self):
         """Wipe every progress table (used before a full restore)."""
@@ -525,6 +591,7 @@ class ResultsDB:
             conn.commit()
         finally:
             conn.close()
+        self._autosave()
 
 
 _results_db = None

--- a/tasks/filesystems.py
+++ b/tasks/filesystems.py
@@ -57,10 +57,7 @@ class CreateFilesystemTask(BaseTask):
         self.device = params.get('device') or get_practice_device() or '/dev/vdb1'
 
         self.description = (
-            f"Create a filesystem:\n"
-            f"  - Device: {self.device}\n"
-            f"  - Filesystem type: {fstype_desc}\n"
-            f"  - Ensure the filesystem is properly formatted"
+            f"Format {self.device} with a {fstype_desc} filesystem."
         )
 
         self.hints = [
@@ -129,11 +126,7 @@ class MountFilesystemTask(BaseTask):
         self.mount_point = params.get('mount_point', f'/mnt/data{random.randint(1,99)}')
 
         self.description = (
-            f"Mount a filesystem:\n"
-            f"  - Device: {self.device}\n"
-            f"  - Mount point: {self.mount_point}\n"
-            f"  - Create mount point if it doesn't exist\n"
-            f"  - Mount the filesystem"
+            f"Mount {self.device} at {self.mount_point}."
         )
 
         self.hints = [
@@ -231,14 +224,9 @@ class PersistentMountTask(BaseTask):
         self.options = params.get('options', 'defaults')
 
         self.description = (
-            f"Configure persistent filesystem mount:\n"
-            f"  - Device: {self.device}\n"
-            f"  - Mount point: {self.mount_point}\n"
-            f"  - Filesystem type: {self.fstype}\n"
-            f"  - Mount options: {self.options}\n"
-            f"  - Use UUID in /etc/fstab (not device name)\n"
-            f"  - Mount the filesystem now\n"
-            f"  - Ensure it mounts automatically at boot"
+            f"Mount {self.device} ({self.fstype}, options: {self.options}) at "
+            f"{self.mount_point}, now and persistently across reboots. "
+            f"Identify the device by UUID."
         )
 
         self.hints = [
@@ -503,12 +491,10 @@ class ExtendFilesystemTask(BaseTask):
         self.expected_size_mb = params.get('size', random.choice([250, 300, 350]))
 
         self.description = (
-            f"Extend a filesystem:\n"
-            f"  - Device: {self.device}\n"
-            f"  - Mount point: {self.mount_point}\n"
-            f"  - Filesystem type: {self.fstype}  (currently {self._INITIAL_MB}MB)\n"
-            f"  - Resize to approximately {self.expected_size_mb}MB\n"
-            f"  - Keep the filesystem mounted — data must not be lost"
+            f"Extend the {self.fstype} filesystem on {self.device} (mounted at "
+            f"{self.mount_point}, currently {self._INITIAL_MB}MB) to "
+            f"approximately {self.expected_size_mb}MB without unmounting it or "
+            f"losing data."
         )
         self.hints = [
             f"Step 1 — extend the LV: lvextend -L {self.expected_size_mb}M /dev/{self.vg_name}/{self.lv_name}",
@@ -798,11 +784,8 @@ class UnmountFilesystemTask(BaseTask):
         self.mount_point = params.get('mount_point', f'/mnt/data{random.randint(1,99)}')
 
         self.description = (
-            f"Unmount a filesystem:\n"
-            f"  - Mount point: {self.mount_point}\n"
-            f"  - Ensure no processes are using the filesystem\n"
-            f"  - Safely unmount the filesystem\n"
-            f"  - Remove the mount point directory (optional)"
+            f"Safely unmount the filesystem at {self.mount_point}, dealing "
+            f"with any processes still using it."
         )
 
         self.hints = [
@@ -874,12 +857,7 @@ class CreateVFATFilesystemTask(BaseTask):
         self.mount_point = params.get('mount_point', f'/mnt/vfat{random.randint(1,99)}')
 
         self.description = (
-            f"Create and mount a VFAT filesystem:\n"
-            f"  - Device: {self.device}\n"
-            f"  - Filesystem type: VFAT\n"
-            f"  - Mount point: {self.mount_point}\n"
-            f"  - Create the mount point if it does not exist\n"
-            f"  - Format the device as VFAT and mount it there"
+            f"Format {self.device} as VFAT and mount it at {self.mount_point}."
         )
 
         self.hints = [

--- a/tasks/networking.py
+++ b/tasks/networking.py
@@ -399,10 +399,8 @@ class SetHostnameTask(BaseTask):
         self.hostname = params.get('hostname', _random_hostname())
 
         self.description = (
-            f"Set the system hostname:\n"
-            f"  - Hostname: {self.hostname}\n"
-            f"  - Use hostnamectl command\n"
-            f"  - Must persist across reboots"
+            f"Set the system hostname to {self.hostname}, persistently "
+            f"across reboots."
         )
 
         self.hints = [
@@ -478,7 +476,6 @@ class ConfigureDNSTask(BaseTask):
             f"Configure DNS servers for connection '{self.connection_name}':\n"
             f"  - Primary DNS: {self.dns_servers[0]}\n"
             f"  - Secondary DNS: {self.dns_servers[1] if len(self.dns_servers) > 1 else 'N/A'}\n"
-            f"  - Use nmcli to configure (do NOT edit resolv.conf directly)\n"
             f"  - Activate the connection\n"
             f"  - Configuration must persist across reboots"
         )
@@ -1241,7 +1238,6 @@ class ConfigureSearchDomainTask(BaseTask):
             f"Configure a DNS search domain:\n"
             f"  - Connection: {self.connection_name}\n"
             f"  - Search domain: {self.search_domain}\n"
-            f"  - Use nmcli (do NOT edit resolv.conf directly)\n"
             f"  - Activate the connection\n"
             f"  - Must persist across reboots"
         )

--- a/tasks/partitioning.py
+++ b/tasks/partitioning.py
@@ -80,13 +80,9 @@ class CreateMBRPartitionTask(BaseTask):
         pnum = self.params["part_num"]
 
         self.description = (
-            f"Create an MBR partition on {dev}:\n"
-            f"  - Partition table type: msdos (MBR)\n"
-            f"  - Partition number: {pnum}\n"
-            f"  - Type: {ptype}\n"
-            f"  - Size: {size} MiB\n"
-            f"  - Use fdisk or parted to complete the task\n"
-            f"  - Run partprobe after writing changes"
+            f"Using an MBR (msdos) partition table, create a {size} MiB "
+            f"{ptype} partition (number {pnum}) on {dev}. The kernel must "
+            f"recognise the new partition."
         )
 
         self.hints = [
@@ -182,11 +178,8 @@ class CreateGPTPartitionTask(BaseTask):
         name = self.params["part_name"]
 
         self.description = (
-            f"Create a GPT partition on {dev}:\n"
-            f"  - Create a GPT (gpt) partition table on the disk\n"
-            f"  - Create one partition named '{name}'\n"
-            f"  - Size: {size} MiB\n"
-            f"  - Use parted or gdisk"
+            f"Create a GPT partition table on {dev} with one {size} MiB "
+            f"partition named '{name}'."
         )
 
         self.hints = [
@@ -281,11 +274,8 @@ class ResizePartitionTask(BaseTask):
         part_dev = _partition_dev(dev, pnum)
 
         self.description = (
-            f"Resize partition {part_dev}:\n"
-            f"  - Grow partition {pnum} on {dev} to {new_size} MiB\n"
-            f"  - Ensure no data loss\n"
-            f"  - Resize the filesystem after growing the partition\n"
-            f"  - The filesystem may be xfs or ext4"
+            f"Grow partition {pnum} on {dev} to {new_size} MiB and resize its "
+            f"filesystem (xfs or ext4) to match, without data loss."
         )
 
         self.hints = [
@@ -378,11 +368,9 @@ class DeletePartitionTask(BaseTask):
         part_dev = _partition_dev(dev, pnum)
 
         self.description = (
-            f"Delete partition {pnum} on {dev}:\n"
-            f"  - Unmount {part_dev} if currently mounted\n"
-            f"  - Remove any /etc/fstab entry for {part_dev}\n"
-            f"  - Delete partition {pnum}\n"
-            f"  - Run partprobe to update kernel"
+            f"Completely remove partition {pnum} on {dev}, including any "
+            f"mount and /etc/fstab entry for {part_dev}. The kernel must "
+            f"recognise the change."
         )
 
         self.hints = [
@@ -467,13 +455,9 @@ class PartitionAndFormatTask(BaseTask):
         part_dev = _partition_dev(dev, pnum)
 
         self.description = (
-            f"Create a partition, format, mount, and persist:\n"
-            f"  1. Create a {size} MiB partition (number {pnum}) on {dev}\n"
-            f"  2. Format {part_dev} with {fs}\n"
-            f"  3. Create mount point {mp}\n"
-            f"  4. Mount {part_dev} at {mp}\n"
-            f"  5. Add an /etc/fstab entry using the partition UUID\n"
-            f"  6. Configuration must survive a reboot"
+            f"Use {dev} to create a {size} MiB partition (number {pnum}) "
+            f"formatted with {fs} and mounted at {mp}, persistently across "
+            f"reboots. Identify it by UUID in /etc/fstab."
         )
 
         self.hints = [

--- a/tasks/processes.py
+++ b/tasks/processes.py
@@ -369,24 +369,19 @@ class FindProcessByUserTask(BaseTask):
             )
 
         if self.action == 'list':
-            task_desc = (
-                f"List all processes owned by user '{self.username}'\n"
-                f"  - Save the output to: {self.output_file}"
+            self.description = (
+                f"Save a list of all processes owned by user "
+                f"'{self.username}' to {self.output_file}."
             )
         elif self.action == 'count':
-            task_desc = (
-                f"Count processes owned by user '{self.username}'\n"
-                f"  - Save the count to: {self.output_file}"
+            self.description = (
+                f"Count the processes owned by user '{self.username}' and "
+                f"save the number to {self.output_file}."
             )
         else:  # kill
-            task_desc = f"Terminate all processes owned by user '{self.username}'"
-
-        self.description = (
-            f"Process management by user:\n"
-            f"  - Task: {task_desc}\n"
-            f"  - User: {self.username}\n"
-            f"  - Use appropriate ps/pkill commands"
-        )
+            self.description = (
+                f"Terminate all processes owned by user '{self.username}'."
+            )
 
         if self.action == 'list':
             self.hints = [

--- a/tasks/repos.py
+++ b/tasks/repos.py
@@ -586,9 +586,12 @@ class ConfigureBaseOSAppStreamTask(BaseTask):
         self.baseos_url = f"{self.server_url}/BaseOS/x86_64/os/"
         self.appstream_url = f"{self.server_url}/AppStream/x86_64/os/"
 
+        # No 'rhel-*' names here: Reset Machine deliberately preserves repo
+        # files with the rhel-/redhat- system prefixes, so a task-created
+        # rhel-baseos.repo would survive every reset.
         repo_id_sets = [
             ('baseos', 'appstream'),
-            ('rhel-baseos', 'rhel-appstream'),
+            ('lab-baseos', 'lab-appstream'),
             ('BaseOS', 'AppStream'),
             ('local-baseos', 'local-appstream'),
         ]

--- a/tasks/scheduling.py
+++ b/tasks/scheduling.py
@@ -350,11 +350,8 @@ class CreateAtJobTask(BaseTask):
         self.command = params.get('command', 'echo "At job executed" >> /tmp/atjob.log')
 
         self.description = (
-            f"Schedule a one-time task:\n"
-            f"  - Time: {time_desc}\n"
-            f"  - At spec: {self.time_spec}\n"
-            f"  - Command: {self.command}\n"
-            f"  - Use the 'at' command"
+            f"Schedule a one-time job for {time_desc} (at spec: "
+            f"'{self.time_spec}') that runs: {self.command}"
         )
 
         self.hints = [

--- a/tasks/services.py
+++ b/tasks/services.py
@@ -125,9 +125,8 @@ class EnableServiceTask(BaseTask):
         self.service_name = params.get('service', random.choice(_STARTABLE_SERVICES))
 
         self.description = (
-            f"Enable the '{self.service_name}' service to start automatically at boot.\n"
-            f"  - Use the appropriate systemctl command.\n"
-            f"  - Verify the service is enabled."
+            f"Enable the '{self.service_name}' service to start "
+            f"automatically at boot."
         )
 
         self.hints = [

--- a/tasks/systemd_timers.py
+++ b/tasks/systemd_timers.py
@@ -643,10 +643,8 @@ class ListActiveTimersTask(BaseTask):
         )
 
         self.description = (
-            f"List all active systemd timers:\n"
-            f"  - Use the appropriate systemctl command to list timers\n"
-            f"  - Save the output to: {self.output_file}\n"
-            f"  - The file should include next-trigger and last-trigger columns"
+            f"Save a listing of all active systemd timers (including their "
+            f"next and last trigger times) to {self.output_file}."
         )
 
         self.hints = [

--- a/tasks/users_groups.py
+++ b/tasks/users_groups.py
@@ -571,15 +571,16 @@ class ConfigureSudoTask(BaseTask):
         passwd_note = " without a password" if self.nopasswd else " (password required)"
 
         self.description = (
-            f"Grant '{self.username}' sudo access to run {self.allowed_cmds} as root"
-            f"{passwd_note}. Place the rule in /etc/sudoers.d/{self.username}."
+            f"Grant '{self.username}' sudo access to run {self.allowed_cmds} "
+            f"as root{passwd_note}."
         )
 
         self.hints = [
-            f"Drop-in sudoers files go in /etc/sudoers.d/, not /etc/sudoers",
+            "Drop-in sudoers files go in /etc/sudoers.d/, not /etc/sudoers",
             "sudoers rule format: user ALL=(ALL) [NOPASSWD:] command[,command]",
             "File permissions must be 0440 — world-writable files are ignored",
-            f"Validate syntax before relying on it: visudo -cf /etc/sudoers.d/{self.username}",
+            f"Check the effective rules: sudo -l -U {self.username}",
+            "Validate syntax before relying on it: visudo -cf <file>",
         ]
         return self
 
@@ -598,68 +599,70 @@ class ConfigureSudoTask(BaseTask):
                           f"User '{self.username}' does not exist", max_points=2))
             return ValidationResult(self.id, False, total, self.points, checks)
 
-        # Check 2: sudoers file exists (3 pts)
-        sudo_file = f"/etc/sudoers.d/{self.username}"
-        stat_result = execute_safe(["stat", sudo_file])
-        if stat_result.success:
-            checks.append(ValidationCheck("sudo_file_exists", True, 3,
-                          f"Sudoers file exists: {sudo_file}"))
-            total += 3
+        # Check 2: the EFFECTIVE rule is right (6 pts) — graded via
+        # `sudo -l -U`, so any valid placement (any drop-in name, or even
+        # /etc/sudoers) counts. The question no longer dictates the file.
+        sudo_check = execute_safe(["sudo", "-l", "-U", self.username])
+        listing = sudo_check.stdout if sudo_check.success else ""
+        if self.allowed_cmds == "ALL":
+            cmds_ok = "ALL" in listing
         else:
-            checks.append(ValidationCheck("sudo_file_exists", False, 0,
-                          f"Sudoers file not found: {sudo_file}", max_points=3))
-            return ValidationResult(self.id, False, total, self.points, checks)
+            cmds_ok = all(c.strip() in listing
+                          for c in self.allowed_cmds.split(","))
+        nopasswd_ok = (("NOPASSWD" in listing) == self.nopasswd)
+        may_run = "may run the following" in listing
 
-        # Check 3: file permissions are 0440 (2 pts)
-        perm_result = execute_safe(["stat", "-c", "%a", sudo_file])
-        actual_perms = perm_result.stdout.strip() if perm_result.success else ""
-        if actual_perms in ("440", "0440"):
-            checks.append(ValidationCheck("sudo_perms", True, 2,
-                          "File permissions are 0440"))
+        if may_run and cmds_ok and nopasswd_ok:
+            checks.append(ValidationCheck("sudo_rule", True, 6,
+                          f"'{self.username}' may run {self.allowed_cmds}"
+                          f"{' without a password' if self.nopasswd else ' (password required)'}"))
+            total += 6
+        elif may_run and cmds_ok:
+            checks.append(ValidationCheck("sudo_rule", True, 4,
+                          "Rule grants the commands but the NOPASSWD setting "
+                          "doesn't match the question", max_points=6))
+            total += 4
+        elif may_run:
+            checks.append(ValidationCheck("sudo_rule", False, 2,
+                          f"'{self.username}' has sudo rules, but not for the "
+                          f"requested commands ({self.allowed_cmds})",
+                          max_points=6))
             total += 2
-        else:
-            checks.append(ValidationCheck("sudo_perms", False, 0,
-                          f"Permissions are {actual_perms}, expected 440",
-                          max_points=2))
-
-        # Check 4: file contains correct rule (3 pts)
-        cat_result = execute_safe(["cat", f"/etc/sudoers.d/{self.username}"])
-        if cat_result.success:
-            content = cat_result.stdout
-            nopasswd_str = "NOPASSWD:" if self.nopasswd else ""
-            user_found = self.username in content
-            cmd_found = self.allowed_cmds in content or (
-                self.allowed_cmds == "ALL" and "ALL" in content)
-            nopasswd_ok = True
-            if self.nopasswd:
-                nopasswd_ok = "NOPASSWD" in content
-            elif not self.nopasswd:
-                nopasswd_ok = "NOPASSWD" not in content
-
-            if user_found and cmd_found and nopasswd_ok:
-                checks.append(ValidationCheck("sudo_rule", True, 3,
-                              "Sudo rule is correct"))
-                total += 3
-            elif user_found and cmd_found:
-                checks.append(ValidationCheck("sudo_rule", True, 2,
-                              "Sudo rule partially correct (NOPASSWD mismatch)"))
-                total += 2
-            else:
-                checks.append(ValidationCheck("sudo_rule", False, 0,
-                              "Sudo rule content is incorrect", max_points=3))
         else:
             checks.append(ValidationCheck("sudo_rule", False, 0,
-                          f"Cannot read sudoers file", max_points=3))
+                          f"No effective sudo rule for '{self.username}' "
+                          f"(checked with sudo -l -U)", max_points=6))
 
-        # Check 5: sudo -l works for user (2 pts)
-        sudo_check = execute_safe(["sudo", "-l", "-U", self.username])
-        if sudo_check.success and "not allowed" not in sudo_check.stdout.lower():
-            checks.append(ValidationCheck("sudo_access", True, 2,
-                          "Sudo access verified"))
+        # Check 3: rule lives in a /etc/sudoers.d/ drop-in (best practice, 2 pts)
+        import glob as _glob
+        in_dropin = False
+        for f in _glob.glob('/etc/sudoers.d/*'):
+            try:
+                with open(f) as fh:
+                    if any(ln.strip().startswith(self.username)
+                           for ln in fh if not ln.strip().startswith('#')):
+                        in_dropin = True
+                        break
+            except OSError:
+                continue
+        if in_dropin:
+            checks.append(ValidationCheck("sudo_dropin", True, 2,
+                          "Rule is in a /etc/sudoers.d/ drop-in"))
             total += 2
         else:
-            checks.append(ValidationCheck("sudo_access", False, 0,
-                          "Sudo access verification failed", max_points=2))
+            checks.append(ValidationCheck("sudo_dropin", False, 0,
+                          "Rule not found under /etc/sudoers.d/ — drop-ins "
+                          "are safer than editing /etc/sudoers", max_points=2))
+
+        # Check 4: whole sudoers config parses (2 pts)
+        syntax = execute_safe(["visudo", "-c"])
+        if syntax.success:
+            checks.append(ValidationCheck("sudo_syntax", True, 2,
+                          "sudoers syntax is valid (visudo -c)"))
+            total += 2
+        else:
+            checks.append(ValidationCheck("sudo_syntax", False, 0,
+                          "visudo -c reports a syntax error", max_points=2))
 
         passed = total >= (self.points * 0.7)
         return ValidationResult(self.id, passed, total, self.points, checks)

--- a/tests/unit/test_full_reset.py
+++ b/tests/unit/test_full_reset.py
@@ -31,6 +31,10 @@ class TestPracticeGroupMatching:
 
 class TestRepoKeepList:
     def test_system_repos_are_kept(self, tmp_path, monkeypatch):
+        # rhel-baseos.repo is REMOVABLE despite the protected rhel- prefix:
+        # it's a name the dual-repo task generates (real RHEL repos only live
+        # in redhat.repo), and treating it as a system repo made it survive
+        # every reset.
         repo_dir = tmp_path
         for f in ('redhat.repo', 'rhel-baseos.repo', 'redhat-extra.repo',
                   'docker-ce.repo', 'epel.repo', 'notes.txt'):
@@ -40,7 +44,7 @@ class TestRepoKeepList:
         monkeypatch.setattr(fr.os, 'listdir',
                             lambda d: real_listdir(repo_dir) if d == '/etc/yum.repos.d' else real_listdir(d))
         found = {fr.os.path.basename(p) for p in fr.list_nondefault_repos()}
-        assert found == {'docker-ce.repo', 'epel.repo'}
+        assert found == {'docker-ce.repo', 'epel.repo', 'rhel-baseos.repo'}
 
 
 class TestSystemSwapGuard:


### PR DESCRIPTION
Batch of fixes from live exam feedback.

## Questions read like the real exam
- Storage tasks are one/two sentences now: *"Use /dev/loop1 to create a 450 MiB partition (number 1) formatted with xfs and mounted at /mnt/data70, persistently across reboots. Identify it by UUID in /etc/fstab."* No more 6-bullet tutorials.
- Removed every command giveaway from question text: "Use fdisk or parted", "Run partprobe", "Use appropriate ps/pkill commands", "Use nmcli", "Use hostnamectl", "Use the 'at' command", "Use the appropriate systemctl command". Requirements stay ("the kernel must recognise the new partition"); the how lives in hints.
- Process-by-user task: now just *"Count the processes owned by user 'pracproc' and save the number to /tmp/..."*.
- Sudoers task no longer dictates the file. Validation grades the **effective** rule via `sudo -l -U <user>` (6 pts — any valid placement works), plus 2 pts for using a `/etc/sudoers.d/` drop-in (any filename) and 2 pts for `visudo -c` passing.

## Cleanup fixes
- **/mnt practice dirs**: the cleanup manifest listed exact names but generators randomise suffixes (`/mnt/data90`, `/mnt/practice_extend7503`) — nothing ever matched, hence hundreds of leftovers. Manifest now uses globs for the simulator's name families.
- **.repo files**: session reset now removes task-created repo files by exact-name manifest (the only /etc paths lab_cleanup touches). Root cause of the reported leftovers: the dual-repo task could generate `rhel-baseos.repo`/`rhel-appstream.repo`, and Reset Machine deliberately preserves the `rhel-` prefix as a system repo — so those two survived every reset. The task no longer generates `rhel-*` names, and reset treats the two legacy names as removable (real RHEL repos only live in `redhat.repo`).

## History pruning without weak-area pollution
- New prune option: **remove recent practice attempts** — pick from the last 30 (ranges like `1-5` supported), e.g. to erase a session where the environment glitched.
- Every prune now **rebuilds weak-area/SM-2 state** by replaying the surviving history (backdated to original timestamps). Previously, deleting attempts never touched `weak_areas`, so a botched session kept dragging the adaptive stats down even after deletion.
- All prune paths refresh the progress autosave, so launch never offers to restore what you just deleted.

## Verification
- 254 tests pass (one updated: it asserted the old keep-`rhel-baseos.repo` behavior that caused the bug).
- Dry run on a live box correctly targets 4 leftover `/mnt/practice_extend*` dirs and the stray `rhel-baseos/appstream.repo` files, and nothing else.
- Prune round-trip: seeded 3 passes + 4 fails (42% success rate), removed the 4 fails via the new picker, rebuild restored the category to 100% with 3 attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPJtUZJjkRGuqZAWzRN3Wi