### PR TITLE
LVM extents, Boot Rescue Lab (2nd machine), remote tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ SELinux).
   [Package & service requirements for task scenarios](#package--service-requirements-for-task-scenarios)
   below — several troubleshooting tasks expect packages a minimal install
   doesn't ship with.
+- **A second VM (optional):** the real exam runs across two nodes. Link a
+  second throwaway VM (**Setup → Link second lab machine**) to unlock the
+  [Boot Rescue Lab](#boot-rescue-lab-second-machine) — real root-password
+  recovery at that machine's console — and to serve as the NFS server for
+  network-storage tasks. Console access to it (virt-manager/VNC) is required.
 - **Snapshot first:** take a VM snapshot before a session so you can revert.
 - **SELinux:** leave it **Enforcing** for realistic SELinux tasks.
 - **Networking:** any NAT/bridged setup; only needed if you want the optional
@@ -246,6 +251,8 @@ collide. Loop images live in `/var/lib/rhcsa-simulator/loops/`.
   OS, and all real accounts. Previews everything and requires typing `RESET`.
 - **Configure remote NFS server** — SSH into a RHEL box you control and provision
   real, seeded NFS exports for the network-storage tasks (refreshed each exam).
+- **Link second lab machine** — register a second box for the Boot Rescue Lab
+  and remote scenarios (see below). Can be the same VM as the NFS server.
 - **Populate Practice Environment** (DNF history).
 
 ### When does the machine get cleaned?
@@ -260,6 +267,47 @@ collide. Loop images live in `/var/lib/rhcsa-simulator/loops/`.
   tasks. Practice disks are the one exception: they're wiped between disk tasks
   so the next one gets a clean device.
 - **Every session start** restores anything a previous session left behind.
+
+---
+
+## Boot Rescue Lab (second machine)
+
+The real exam expects you to recover a lost root password by interrupting boot
+at the console — something a simulator can't fake on its own machine. So the
+simulator does it for real, on a **second machine you control**:
+
+1. **Requirements:** a second RHEL/Rocky/Alma VM (or box) on your network that
+   you have **console access** to (virt-manager, VNC, or a physical keyboard —
+   SSH won't help once the password is gone), plus root SSH once for linking.
+2. **Link it** via **Setup → Link second lab machine**. This runs `ssh-copy-id`
+   (you type the root password one time) and from then on the simulator uses
+   key-based SSH only. The key is its *only* footprint — no agent, nothing
+   installed on the lab machine.
+3. **Start a scenario** from the main menu (**R — Boot Rescue Lab**): the
+   simulator sets a random root password on the lab machine. Go to its console
+   and recover it by interrupting boot.
+4. **Validate**: over its retained key, the simulator checks that the root hash
+   changed, the machine rebooted into a working system, and `/etc/shadow` has
+   the correct SELinux label (proof you handled the relabel). Which method you
+   used is detected best-effort from the journal and reported as info only.
+   Optionally type your new password and it is proven against the live hash.
+
+Both recovery methods are taught and accepted (the walkthrough is built in):
+
+- **`rd.break`** — the classic method: break before `switch_root`, remount
+  `/sysroot` rw, `chroot`, `passwd`, `touch /.autorelabel`. **Note:** on some
+  builds `rd.break` drops you into a *password-gated* maintenance shell
+  ("Give root password for maintenance") instead of a free shell — real exams
+  have shipped such machines. When that happens, use:
+- **`init=/bin/bash`** — works on every build: bash runs as PID 1, remount `/`
+  rw, `passwd`, `restorecon /etc/shadow`. Since systemd isn't running,
+  `reboot` fails — reboot with `sync; echo b > /proc/sysrq-trigger` (or
+  `/usr/sbin/reboot -f`).
+
+**Safety:** the scenario refuses to start unless key-based SSH works, the
+original root hash is kept locally (root-only, 0600), and **Give up** — or
+**Reset Machine** — reveals the planted password and restores the original
+hash exactly. You cannot be permanently locked out of a bootable machine.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,15 @@ original root hash is kept locally (root-only, 0600), and **Give up** — or
 **Reset Machine** — reveals the planted password and restores the original
 hash exactly. You cannot be permanently locked out of a bootable machine.
 
+### Remote tasks (two-node exams)
+
+With a lab machine linked, exams and practice sessions also mix in **remote
+tasks** — "On the lab machine (…): set the static hostname / create this user /
+set the timezone" — just like the real exam's second node. You SSH to the
+machine yourself and do the work there; the simulator validates over its own
+key and restores the machine's original state at session end (or on Reset
+Machine). Without a linked machine these tasks are simply never offered.
+
 ---
 
 ## Task domains & categories

--- a/core/boot_rescue.py
+++ b/core/boot_rescue.py
@@ -1,0 +1,419 @@
+"""
+Boot-rescue lab: real root-password recovery on the linked lab machine.
+
+The simulator sets a random root password on the second machine over SSH
+(keeping its own key-based access), and the candidate must recover it at
+that machine's console by interrupting boot — exactly like the real exam.
+
+Both recovery methods are taught and accepted:
+
+  * rd.break — the classic Red Hat method: break into the initramfs before
+    switch_root, remount /sysroot rw, chroot, passwd, handle the SELinux
+    relabel. On some builds rd.break lands in a password-gated maintenance
+    shell instead of a free shell, in which case…
+  * init=/bin/bash — always works: the kernel runs bash as PID 1, remount
+    / rw, passwd, restorecon /etc/shadow, then reboot WITHOUT systemd
+    (sync; echo b > /proc/sysrq-trigger  — or  /usr/sbin/reboot -f).
+
+Validation runs over the retained SSH key: the root hash must differ from
+the planted one, the machine must have rebooted into a working system, and
+/etc/shadow must carry the right SELinux label (proof the relabel was
+handled). Which method was used is detected best-effort from the journal
+(rd.break shows in a recovered boot's kernel cmdline; init=/bin/bash leaves
+no journal for that boot, so it is reported as inferred) — informational
+only, never pass/fail.
+
+Safety: the original root hash is stored locally (root-only, 0600) so
+"give up" can reveal the planted password and restore the machine exactly
+as it was. The scenario refuses to start unless key-based SSH works, so
+the simulator can never lock itself (or the user) out of a bootable box.
+"""
+
+import os
+import json
+import secrets
+import string
+import time
+
+from core import lab_machine
+
+STATE_PATH = os.path.join(lab_machine.STATE_DIR, 'boot_rescue.json')
+
+# Typable at any console layout: no ambiguous glyphs, no shell metacharacters.
+_ALPHABET = ''.join(c for c in string.ascii_lowercase + string.digits
+                    if c not in 'l1o0')
+
+_INFO_SCRIPT = r"""
+echo "BOOT_ID=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)"
+echo "ROOT_HASH=$(awk -F: '$1=="root"{print $2}' /etc/shadow 2>/dev/null)"
+echo "SHADOW_CTX=$(stat -c %C /etc/shadow 2>/dev/null)"
+echo "SYS_STATE=$(systemctl is-system-running 2>/dev/null)"
+echo "RELABEL_PENDING=$([ -e /.autorelabel ] && echo yes || echo no)"
+echo "RDBREAK_BOOTS=$(journalctl -k -g 'Command line' -o cat --no-pager 2>/dev/null | grep -c 'rd\.break')"
+"""
+
+
+# --------------------------------------------------------------------------
+# Scenario state
+# --------------------------------------------------------------------------
+
+def load_state():
+    try:
+        with open(STATE_PATH) as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def _save_state(state):
+    os.makedirs(lab_machine.STATE_DIR, exist_ok=True)
+    fd = os.open(STATE_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, 'w') as fh:
+        json.dump(state, fh, indent=2)
+
+
+def clear_state():
+    try:
+        os.remove(STATE_PATH)
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def is_active():
+    return load_state() is not None
+
+
+def generate_password(length=10):
+    return ''.join(secrets.choice(_ALPHABET) for _ in range(length))
+
+
+# --------------------------------------------------------------------------
+# Scenario lifecycle
+# --------------------------------------------------------------------------
+
+def start():
+    """Scramble root's password on the lab machine. Returns (ok, message).
+
+    Refuses unless key-based SSH works (that key is the only way back in for
+    validation and give-up, and must be planted BEFORE we change anything)."""
+    cfg = lab_machine.load_config()
+    if not cfg:
+        return False, "No lab machine linked. Run Setup → Link second lab machine first."
+    if is_active():
+        return False, ("A rescue scenario is already active. Validate it or give "
+                       "up before starting another.")
+    if not lab_machine.key_works():
+        return False, (f"Key-based SSH to {cfg['host']} is not working. Re-run "
+                       "Setup → Link second lab machine (ssh-copy-id) first — "
+                       "the key is the only way back in after the scramble.")
+
+    ok, before, out = lab_machine.read_values(_INFO_SCRIPT)
+    if not ok or not before.get('ROOT_HASH'):
+        return False, f"Could not read the current state of {cfg['host']}:\n{out[-500:]}"
+
+    password = generate_password()
+    # The script travels over stdin (never argv), so the secret is not
+    # exposed in `ps` on either machine. Alphabet is shell-safe by design.
+    script = (f"printf 'root:{password}' | chpasswd || exit 1\n"
+              f"awk -F: '$1==\"root\"{{print \"NEW_HASH=\" $2}}' /etc/shadow\n")
+    ok, values, out = lab_machine.read_values(script)
+    new_hash = values.get('NEW_HASH', '')
+    if not ok or not new_hash or new_hash == before['ROOT_HASH']:
+        return False, f"Failed to set the scenario password on {cfg['host']}:\n{out[-500:]}"
+
+    _save_state({
+        'host': cfg['host'],
+        'user': cfg.get('user', 'root'),
+        'planted_password': password,
+        'planted_hash': new_hash,
+        'original_hash': before['ROOT_HASH'],
+        'boot_id': before.get('BOOT_ID', ''),
+        'planted_at': time.strftime('%Y-%m-%d %H:%M:%S'),
+        'rdbreak_boots': before.get('RDBREAK_BOOTS', '0'),
+    })
+    return True, (f"The root password on {cfg['host']} has been changed to a "
+                  "random value. Go to that machine's console and recover it.")
+
+
+def validate():
+    """Check the recovery over the retained SSH key.
+
+    Returns (checks, method, error) where checks is a list of
+    (name, passed_or_None, message) — None = informational/warning only."""
+    state = load_state()
+    if not state:
+        return None, None, "No rescue scenario is active."
+
+    ok, now, out = lab_machine.read_values(_INFO_SCRIPT, host=state['host'],
+                                           user=state.get('user', 'root'))
+    if not ok:
+        return None, None, (f"Cannot reach {state['host']} over SSH yet — finish "
+                            f"the recovery and make sure it boots normally.\n{out[-300:]}")
+
+    checks = []
+
+    cur_hash = now.get('ROOT_HASH', '')
+    if cur_hash and cur_hash != state['planted_hash']:
+        checks.append(('password_changed', True, 'root password was changed'))
+    else:
+        checks.append(('password_changed', False,
+                       'root password is still the planted one — it was not reset'))
+
+    if now.get('BOOT_ID') and now['BOOT_ID'] != state.get('boot_id'):
+        checks.append(('rebooted', True, 'machine was rebooted'))
+    else:
+        checks.append(('rebooted', False,
+                       'machine has not rebooted since the scenario started'))
+
+    ctx = now.get('SHADOW_CTX', '')
+    if 'shadow_t' in ctx:
+        checks.append(('selinux_context', True,
+                       '/etc/shadow has the correct SELinux context (relabel handled)'))
+    elif ctx in ('', '?', 'unlabeled'):
+        checks.append(('selinux_context', None,
+                       f"could not determine /etc/shadow SELinux context ({ctx or 'n/a'})"))
+    else:
+        checks.append(('selinux_context', False,
+                       f"/etc/shadow context is '{ctx}' — the SELinux relabel was not "
+                       "handled (touch /.autorelabel or restorecon /etc/shadow)"))
+
+    sys_state = now.get('SYS_STATE', '')
+    if sys_state in ('running', 'degraded'):
+        checks.append(('system_up', True, f'system is up (state: {sys_state})'))
+    else:
+        checks.append(('system_up', False,
+                       f"system state is '{sys_state or 'unknown'}' — expected a "
+                       "normal multi-user boot"))
+
+    if now.get('RELABEL_PENDING') == 'yes':
+        checks.append(('relabel_pending', None,
+                       '/.autorelabel exists — a full relabel will run on the next '
+                       'boot (fine, but the exam expects you to let it finish)'))
+
+    # Informational method detection, never pass/fail.
+    try:
+        rd_before = int(state.get('rdbreak_boots', '0') or 0)
+        rd_now = int(now.get('RDBREAK_BOOTS', '0') or 0)
+    except ValueError:
+        rd_before = rd_now = 0
+    if rd_now > rd_before:
+        method = 'rd.break (found in a recovery boot kernel cmdline)'
+    else:
+        method = 'init=/bin/bash or console method (inferred — no rd.break boot in the journal)'
+
+    return checks, method, None
+
+
+def verify_password(password):
+    """Prove the candidate's new password actually works, by checking it
+    against root's hash ON the lab machine (crypt runs there; the password
+    travels only over the encrypted SSH stdin). Returns True/False/None."""
+    state = load_state() or {}
+    script = ("python3 -W ignore - <<'RHCSA_PW_EOF'\n"
+              "import crypt\n"
+              f"pw = {password!r}\n"
+              "h = ''\n"
+              "for line in open('/etc/shadow'):\n"
+              "    if line.startswith('root:'):\n"
+              "        h = line.split(':')[1]\n"
+              "        break\n"
+              "try:\n"
+              "    print('PWOK=' + ('yes' if h and crypt.crypt(pw, h) == h else 'no'))\n"
+              "except Exception:\n"
+              "    print('PWOK=unknown')\n"
+              "RHCSA_PW_EOF\n")
+    ok, values, _ = lab_machine.read_values(
+        script, host=state.get('host'), user=state.get('user', 'root'))
+    answer = values.get('PWOK')
+    if not ok or answer not in ('yes', 'no'):
+        return None
+    return answer == 'yes'
+
+
+def give_up(restore=True):
+    """Reveal the planted password and (optionally) restore the original root
+    hash exactly as it was. Returns (ok, message)."""
+    state = load_state()
+    if not state:
+        return False, "No rescue scenario is active."
+    password = state['planted_password']
+    msg = f"The planted root password on {state['host']} is: {password}"
+    if restore:
+        # Shadow hashes never contain single quotes, so this embeds safely.
+        script = f"usermod -p '{state['original_hash']}' root && echo RESTORED=yes"
+        ok, values, out = lab_machine.read_values(
+            script, host=state['host'], user=state.get('user', 'root'))
+        if ok and values.get('RESTORED') == 'yes':
+            msg += "\nThe original root password has been restored."
+        else:
+            msg += ("\nCould not restore the original password over SSH (machine "
+                    "down?) — log in with the planted password above and set it "
+                    "yourself.")
+    clear_state()
+    return True, msg
+
+
+def reset_for_machine_reset(progress=lambda m: None):
+    """full_reset hook: if a scenario is active, put the lab machine's root
+    password back and drop the local state."""
+    if not is_active():
+        return
+    progress("  restoring lab machine root password (boot-rescue scenario)")
+    ok, msg = give_up(restore=True)
+    if not ok:
+        progress(f"    {msg}")
+
+
+# --------------------------------------------------------------------------
+# Walkthrough content (both methods)
+# --------------------------------------------------------------------------
+
+WALKTHROUGH = """\
+GOAL: at the lab machine's console, reset the (unknown) root password by
+interrupting the boot process, then let it boot normally.
+
+METHOD A — rd.break (the classic Red Hat way)
+  1. Reboot; at the GRUB menu press  e  on the default entry
+  2. On the line starting with  linux , append:   rd.break
+     (removing  rhgb quiet  makes the console easier to read)
+  3. Boot with  Ctrl-x  → you land in a switch_root:/# emergency shell
+       If instead you get "Give root password for maintenance", this build
+       gates the shell — reboot and use METHOD B.
+  4. mount -o remount,rw /sysroot
+  5. chroot /sysroot
+  6. passwd root
+  7. touch /.autorelabel      (SELinux: relabels on next boot; without this
+                               the new /etc/shadow is mislabeled and logins
+                               can fail. Alternative: load_policy -i then
+                               restorecon /etc/shadow)
+  8. exit   then   exit       (boot continues; the relabel adds one reboot)
+
+METHOD B — init=/bin/bash (works on every build)
+  1. Reboot; at GRUB press  e ; on the  linux  line append:   init=/bin/bash
+  2. Boot with  Ctrl-x  → bash IS pid 1 (no systemd is running)
+  3. mount -o remount,rw /
+  4. passwd root
+  5. restorecon /etc/shadow    (or: touch /.autorelabel)
+  6. Reboot — systemd is NOT running, so  reboot/systemctl  will fail. Use:
+       sync
+       echo b > /proc/sysrq-trigger
+     (or:  /usr/sbin/reboot -f )
+
+Then log in as root at the console with your new password, and validate
+from the simulator."""
+
+
+# --------------------------------------------------------------------------
+# Interactive UI
+# --------------------------------------------------------------------------
+
+def interactive():
+    """The Boot Rescue Lab menu loop."""
+    import getpass
+    from utils import formatters as fmt
+    from utils.helpers import confirm_action
+
+    while True:
+        fmt.clear_screen()
+        fmt.print_header("BOOT RESCUE LAB (second machine)")
+
+        cfg = lab_machine.load_config()
+        state = load_state()
+        if cfg:
+            print(f"Lab machine: {fmt.bold(cfg['host'])} "
+                  f"(user: {cfg.get('user', 'root')})")
+        else:
+            print(fmt.warning("No lab machine linked — run Setup → Link second "
+                              "lab machine first."))
+        if state:
+            print(fmt.warning(f"Scenario ACTIVE since {state['planted_at']} — "
+                              f"recover root at {state['host']}'s console."))
+        else:
+            print(fmt.dim("No scenario active."))
+        print()
+        print("  1. Start scenario (scramble root password on the lab machine)")
+        print("  2. Validate my recovery")
+        print("  3. Show the recovery walkthrough (both methods)")
+        print("  4. Give up (reveal password & restore the machine)")
+        print("  0. Back")
+        print()
+        choice = input("Select option: ").strip()
+
+        if choice == '1':
+            print()
+            print(fmt.warning("This sets a RANDOM root password on the lab machine."))
+            print("You will need CONSOLE access to that machine to recover it")
+            print("(virt-manager, VNC, or a physical keyboard — not SSH).")
+            print(fmt.dim("The simulator keeps its own SSH key planted, so 'give up' "
+                          "can always restore the machine."))
+            print()
+            if confirm_action("Scramble the root password now?", default=False):
+                ok, msg = start()
+                print()
+                print(fmt.success(msg) if ok else fmt.error(msg))
+                if ok:
+                    print()
+                    print(fmt.dim("Tip: option 3 shows the full walkthrough for both"))
+                    print(fmt.dim("rd.break and init=/bin/bash."))
+            input("\nPress Enter to continue...")
+
+        elif choice == '2':
+            print()
+            checks, method, err = validate()
+            if err:
+                print(fmt.warning(err))
+                input("\nPress Enter to continue...")
+                continue
+            all_ok = True
+            for name, passed, message in checks:
+                if passed is True:
+                    print(f"  {fmt.success('PASS')}  {message}")
+                elif passed is False:
+                    print(f"  {fmt.error('FAIL')}  {message}")
+                    all_ok = False
+                else:
+                    print(f"  {fmt.warning('NOTE')}  {message}")
+            print()
+            print(f"  Method detected: {fmt.dim(method)}")
+            print()
+            if all_ok:
+                pw = getpass.getpass(
+                    "Optionally type the new root password to prove it works "
+                    "(Enter to skip): ")
+                if pw:
+                    result = verify_password(pw)
+                    if result is True:
+                        print(fmt.success("  Password verified — it matches root's hash."))
+                    elif result is False:
+                        print(fmt.error("  That password does NOT match root's current hash."))
+                    else:
+                        print(fmt.warning("  Could not verify (python3 missing on the "
+                                          "lab machine?)."))
+                print()
+                print(fmt.success("Recovery complete — scenario closed. Nice work."))
+                clear_state()
+            else:
+                print(fmt.warning("Not there yet — the scenario stays active."))
+            input("\nPress Enter to continue...")
+
+        elif choice == '3':
+            print()
+            print(WALKTHROUGH)
+            input("\nPress Enter to continue...")
+
+        elif choice == '4':
+            if not state:
+                print(fmt.dim("No scenario active."))
+                input("\nPress Enter to continue...")
+                continue
+            print()
+            if confirm_action("Reveal the password and restore the original one?",
+                              default=False):
+                ok, msg = give_up(restore=True)
+                print()
+                print(msg)
+            input("\nPress Enter to continue...")
+
+        elif choice == '0' or choice == '':
+            return

--- a/core/full_reset.py
+++ b/core/full_reset.py
@@ -559,6 +559,13 @@ def run_all(progress=_noop, remove_users=True):
             return 0
     step("Remote NFS exports", _nfs)
 
+    # 7b. Active boot-rescue scenario: put the lab machine's root password back.
+    def _rescue():
+        from core import boot_rescue
+        boot_rescue.reset_for_machine_reset(progress)
+        return 1
+    step("Boot-rescue scenario", _rescue)
+
     # 8. Practice users / groups (optional).
     if remove_users:
         step("Practice users / groups",

--- a/core/full_reset.py
+++ b/core/full_reset.py
@@ -84,14 +84,23 @@ def _noop(_msg):
 
 def list_nondefault_repos():
     """Third-party .repo files under /etc/yum.repos.d (RHEL system repos kept)."""
+    # Task-created repo files are removable even when their name collides with
+    # a protected system prefix (older task builds generated rhel-baseos/
+    # rhel-appstream; real RHEL repos only ever live in redhat.repo).
+    try:
+        from core.lab_cleanup import _PRACTICE_REPO_SET
+    except Exception:
+        _PRACTICE_REPO_SET = set()
     out, d = [], '/etc/yum.repos.d'
     try:
         for f in sorted(os.listdir(d)):
             if not f.endswith('.repo'):
                 continue
-            if f in _KEEP_REPO_FILES or f.startswith(_KEEP_REPO_PREFIXES):
+            full = os.path.join(d, f)
+            if full not in _PRACTICE_REPO_SET and (
+                    f in _KEEP_REPO_FILES or f.startswith(_KEEP_REPO_PREFIXES)):
                 continue
-            out.append(os.path.join(d, f))
+            out.append(full)
     except Exception:
         pass
     return out

--- a/core/lab_cleanup.py
+++ b/core/lab_cleanup.py
@@ -10,7 +10,8 @@ can interfere with the next run.
 Rather than snapshot the whole filesystem and diff it (which risks deleting
 unrelated user data), this module removes ONLY the specific paths the
 simulator's own tasks define — a curated manifest derived from the task set.
-It never touches /etc (fstab is handled separately by the fstab guard) and never
+The only /etc paths it touches are the exact task-created repo files in
+PRACTICE_REPO_FILES (fstab is handled separately by the fstab guard); it never
 touches shell dotfiles, SSH keys, or anything outside the manifest.
 """
 
@@ -23,16 +24,42 @@ SWAP_FILES = ['/swapfile', '/var/swap', '/swap.img']
 
 # Mount points / directories tasks create. Unmounted first if mounted, then the
 # directory tree is removed (these are simulator-owned scratch locations).
+# Globs, not exact names: the generators randomise a numeric suffix
+# (/mnt/data90, /mnt/vfat97, /mnt/practice_extend7503, ...), and without the
+# glob every one of them lingered forever.
 DIR_ARTIFACTS = [
-    '/mnt/data', '/mnt/nfsdata', '/mnt/shared', '/mnt/persistent',
-    '/mnt/practice_extend', '/mnt/vfat', '/mnt/external', '/mnt/faulttest',
-    '/mnt/recovery', '/mnt/rescue', '/mnt/sysimage', '/mnt/nonexistent',
+    '/mnt/data*', '/mnt/nfsdata*', '/mnt/shared*', '/mnt/persistent*',
+    '/mnt/practice_extend*', '/mnt/vfat*', '/mnt/external*', '/mnt/faulttest*',
+    '/mnt/recovery*', '/mnt/rescue*', '/mnt/sysimage', '/mnt/nonexistent',
     '/mnt/lvm*',
     '/opt/appdata', '/opt/webdata',
     '/srv/nfs', '/srv/samba', '/srv/website', '/srv/web', '/srv/webapp',
     '/srv/shares', '/srv/ftp', '/srv/acltest*',
     '/home/guests',
 ]
+
+# Task-created DNF repo files (tasks/repos.py generates exactly these repo
+# IDs; the file is always /etc/yum.repos.d/<id>.repo). EXACT names only —
+# never a glob, and never subscription-manager's redhat.repo. Note that
+# 'rhel-baseos'/'rhel-appstream' really are task names: genuine RHEL system
+# repos live in redhat.repo, never in files named like these.
+PRACTICE_REPO_FILES = [
+    f'/etc/yum.repos.d/{rid}.repo' for rid in (
+        'rocky10-baseos', 'rocky10-appstream', 'rocky10-crb',
+        'rocky10-extras', 'rocky10-devel',
+        'alma10-baseos', 'alma10-appstream', 'alma10-crb', 'alma10-extras',
+        'epel', 'epel9', 'grafana', 'nodesource-nodejs', 'vscode',
+        'kubernetes', 'hashicorp', 'docker-ce', 'elrepo', 'rpmfusion-free',
+        'pgdg17', 'mariadb', 'nginx', 'tailscale', 'google-cloud-cli',
+        'packages-microsoft-com-prod',
+        'broken-baseos', 'broken-appstream', 'broken-crb', 'broken-extras',
+        'broken-epel',
+        'baseos', 'appstream', 'BaseOS', 'AppStream',
+        'local-baseos', 'local-appstream', 'lab-baseos', 'lab-appstream',
+        'rhel-baseos', 'rhel-appstream',
+    )
+]
+_PRACTICE_REPO_SET = set(PRACTICE_REPO_FILES)
 
 # Individual files/dirs under /tmp and a couple of /root, /home markers. Globs
 # cover the randomised name families (journal_*, scp_*, top_*, etc.).
@@ -102,6 +129,9 @@ def _is_safe(path):
         return False
     if path in SWAP_FILES:
         return True
+    # The only /etc paths ever touched: the exact task-created repo files.
+    if path in _PRACTICE_REPO_SET:
+        return True
     return path.startswith(_ALLOWED_PREFIXES)
 
 
@@ -158,7 +188,8 @@ def _find_units():
 def find_leftovers():
     """Existing artifact paths cleanup would act on (timeout-guarded)."""
     found = set()
-    for pattern in SWAP_FILES + DIR_ARTIFACTS + FILE_ARTIFACTS:
+    for pattern in (SWAP_FILES + DIR_ARTIFACTS + FILE_ARTIFACTS
+                    + PRACTICE_REPO_FILES):
         for match in _expand(pattern):
             if _is_safe(match) and _exists(match):
                 found.add(os.path.normpath(match))
@@ -215,7 +246,16 @@ def clean(dry_run=False):
             elif _sh(['rm', '-rf', '--', path], 15) == 0:
                 actions.append(f"removed file {path}")
 
-    # 4. Candidate-created systemd units + their helper scripts.
+    # 4. Task-created DNF repo files (exact names from the manifest only).
+    for path in PRACTICE_REPO_FILES:
+        if not _is_safe(path) or not _exists(path):
+            continue
+        if dry_run:
+            actions.append(f"would remove repo {path}")
+        elif _sh(['rm', '-f', '--', path], 15) == 0:
+            actions.append(f"removed repo {path}")
+
+    # 5. Candidate-created systemd units + their helper scripts.
     actions.extend(clean_units(dry_run=dry_run))
 
     return actions

--- a/core/lab_machine.py
+++ b/core/lab_machine.py
@@ -1,0 +1,152 @@
+"""
+Shared "lab machine" link — a second box the simulator can reach as root
+over SSH.
+
+One link serves every feature that needs a remote machine: the boot-rescue
+lab, remote fault injection/validation, and (as a host default) the NFS
+server provisioning. It can be the same VM already used as the NFS server.
+
+Design:
+  * Linking plants THIS machine's SSH public key on the lab machine
+    (ssh-copy-id), so everything afterwards runs unattended with key-based
+    BatchMode auth. The key is the simulator's only footprint on the lab
+    machine — no agent, nothing installed, nothing to keep updated.
+  * The key MUST verify before any scenario is allowed to scramble
+    credentials on the lab machine, otherwise we could lose our way back in.
+  * Scripts are fed to `bash -s` over stdin (never the command line), so
+    secrets embedded in a script are not visible in `ps` on either side.
+"""
+
+import os
+import json
+import glob
+import subprocess
+
+STATE_DIR = '/var/lib/rhcsa-simulator'
+CONFIG_PATH = os.path.join(STATE_DIR, 'lab_machine.conf')
+
+
+# --------------------------------------------------------------------------
+# Config
+# --------------------------------------------------------------------------
+
+def load_config():
+    """Return {'host': ..., 'user': ...} or None. Falls back to an existing
+    NFS-server link so users who already set that up are linked implicitly."""
+    try:
+        with open(CONFIG_PATH) as fh:
+            return json.load(fh)
+    except Exception:
+        pass
+    # Adopt the NFS server link if one exists (same box, per design).
+    try:
+        from core import nfs_server
+        cfg = nfs_server.load_config()
+        if cfg and cfg.get('host'):
+            return {'host': cfg['host'], 'user': cfg.get('user', 'root'),
+                    'adopted_from': 'nfs_server'}
+    except Exception:
+        pass
+    return None
+
+
+def save_config(host, user='root'):
+    os.makedirs(STATE_DIR, exist_ok=True)
+    fd = os.open(CONFIG_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, 'w') as fh:
+        json.dump({'host': host, 'user': user}, fh, indent=2)
+    return {'host': host, 'user': user}
+
+
+def clear_config():
+    try:
+        os.remove(CONFIG_PATH)
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def get_host():
+    cfg = load_config()
+    return cfg.get('host') if cfg else None
+
+
+# --------------------------------------------------------------------------
+# Key management
+# --------------------------------------------------------------------------
+
+def _have_local_key():
+    home = os.path.expanduser('~/.ssh')
+    return bool(glob.glob(os.path.join(home, 'id_*.pub')))
+
+
+def ensure_local_key():
+    """Make sure this machine has an SSH keypair to plant. Returns True if a
+    key exists (or was just generated)."""
+    if _have_local_key():
+        return True
+    path = os.path.expanduser('~/.ssh/id_ed25519')
+    os.makedirs(os.path.dirname(path), mode=0o700, exist_ok=True)
+    r = subprocess.run(['ssh-keygen', '-t', 'ed25519', '-N', '', '-f', path],
+                       capture_output=True, text=True)
+    return r.returncode == 0
+
+
+def copy_key(host, user='root'):
+    """Interactive ssh-copy-id (the one step that may prompt for a password)."""
+    ensure_local_key()
+    try:
+        return subprocess.run(['ssh-copy-id', f'{user}@{host}']).returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def key_works(host=None, user=None, timeout=20):
+    """True if unattended key-based SSH to the lab machine works right now."""
+    cfg = load_config() or {}
+    host = host or cfg.get('host')
+    user = user or cfg.get('user', 'root')
+    if not host:
+        return False
+    rc, _ = run('true', host=host, user=user, timeout=timeout)
+    return rc == 0
+
+
+# --------------------------------------------------------------------------
+# Remote execution
+# --------------------------------------------------------------------------
+
+def run(script, host=None, user=None, timeout=120):
+    """Run `script` on the lab machine over key-auth SSH (BatchMode — never
+    prompts). Returns (returncode, combined_output); rc None on launch error.
+
+    The script goes over stdin, so it may safely contain secrets."""
+    cfg = load_config() or {}
+    host = host or cfg.get('host')
+    user = user or cfg.get('user', 'root')
+    if not host:
+        return None, 'no lab machine linked (Setup → Link second lab machine)'
+    cmd = ['ssh', '-o', 'StrictHostKeyChecking=accept-new',
+           '-o', 'ConnectTimeout=15', '-o', 'BatchMode=yes',
+           f'{user}@{host}', 'bash -s']
+    try:
+        res = subprocess.run(cmd, input=script, text=True,
+                             capture_output=True, timeout=timeout)
+        return res.returncode, (res.stdout or '') + (res.stderr or '')
+    except FileNotFoundError:
+        return None, "'ssh' not found on this machine."
+    except subprocess.TimeoutExpired:
+        return None, f'Timed out talking to {host}.'
+
+
+def read_values(script, host=None, user=None, timeout=120):
+    """Run a script that prints KEY=VALUE lines; return (ok, dict, output).
+    Only lines matching ^[A-Z_]+= are collected, so command noise is ignored."""
+    rc, out = run(script, host=host, user=user, timeout=timeout)
+    values = {}
+    for line in (out or '').splitlines():
+        if '=' in line:
+            key, _, val = line.partition('=')
+            if key and key.isupper() and key.replace('_', '').isalnum():
+                values[key] = val.strip()
+    return rc == 0, values, out

--- a/core/menu.py
+++ b/core/menu.py
@@ -36,6 +36,7 @@ class MenuSystem:
             fmt.print_menu_option(1, "Learn Mode", "Domain-based study with SM-2 indicators")
             fmt.print_menu_option(2, "Practice Mode", "Category-focused with retry & hints")
             fmt.print_menu_option(3, "Adaptive Mode", "SM-2 driven weak-area practice")
+            fmt.print_menu_option('R', "Boot Rescue Lab", "Recover root on the linked 2nd machine")
             print()
 
             # Progress section
@@ -63,6 +64,8 @@ class MenuSystem:
                 return 'practice'
             elif choice == '3':
                 return 'adaptive'
+            elif choice == 'r':
+                return 'boot_rescue'
             elif choice == '4':
                 return 'dashboard'
             elif choice == '5':
@@ -211,10 +214,13 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
         fmt.clear_screen()
         fmt.print_header("SETUP")
 
-        from core import nfs_server
+        from core import nfs_server, lab_machine
         cfg = nfs_server.load_config()
         nfs_status = (fmt.success(f"configured: {cfg['host']}") if cfg
                       else fmt.dim("not configured"))
+        lab_cfg = lab_machine.load_config()
+        lab_status = (fmt.success(f"linked: {lab_cfg['host']}") if lab_cfg
+                      else fmt.dim("not linked"))
 
         print(fmt.bold("Options"))
         print("  1. Setup Practice Disks (loop devices for LVM)")
@@ -223,6 +229,7 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
         print("  4. Reset Machine (undo ALL practice changes, back to a clean box)")
         print("  5. Populate Practice Environment (DNF history)")
         print(f"  6. Configure remote NFS server for NFS tasks ({nfs_status})")
+        print(f"  7. Link second lab machine — boot rescue & remote tasks ({lab_status})")
         print("  0. Return to Menu")
         print()
 
@@ -240,6 +247,8 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             self.populate_practice_environment()
         elif choice == '6':
             self.configure_nfs_server()
+        elif choice == '7':
+            self.link_lab_machine()
 
     def reset_machine(self):
         """THE single reset. Restores any active faults/preconditions, removes
@@ -310,6 +319,98 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
         print(fmt.info("connectivity were left intact."))
         print()
         input("Press Enter to return...")
+
+    def link_lab_machine(self):
+        """Link (or unlink) the second lab machine used by the boot-rescue lab
+        and remote tasks. Linking plants this machine's SSH key so everything
+        afterwards runs unattended — the key is the only footprint."""
+        from core import lab_machine, boot_rescue
+        from utils.helpers import confirm_action
+
+        fmt.clear_screen()
+        fmt.print_header("LINK SECOND LAB MACHINE")
+
+        existing = lab_machine.load_config()
+        if existing:
+            adopted = existing.get('adopted_from')
+            print(f"Currently linked: {fmt.bold(existing['host'])} "
+                  f"(user: {existing.get('user', 'root')})"
+                  + (f"  [adopted from the {adopted} config]" if adopted else ""))
+            print()
+            print("  T. Test the link now (key-based SSH)")
+            print("  R. Re-link / change machine")
+            print("  X. Unlink")
+            print("  0. Back")
+            print()
+            sub = input("Select: ").strip().lower()
+            if sub == 't':
+                print(f"\nTesting key-based SSH to {existing['host']}…")
+                if lab_machine.key_works():
+                    print(fmt.success("OK — unattended SSH works."))
+                else:
+                    print(fmt.error("Key-based SSH failed. Re-link to run "
+                                    "ssh-copy-id again."))
+                input("\nPress Enter to return...")
+                return
+            if sub == 'x':
+                if boot_rescue.is_active():
+                    print(fmt.warning("\nA boot-rescue scenario is active on this "
+                                      "machine — resolve it first (validate or "
+                                      "give up)."))
+                    input("\nPress Enter to return...")
+                    return
+                lab_machine.clear_config()
+                print(fmt.success("Unlinked."))
+                input("\nPress Enter to return...")
+                return
+            if sub != 'r':
+                return
+            fmt.clear_screen()
+            fmt.print_header("LINK SECOND LAB MACHINE")
+
+        print("The lab machine is a second box on your network that the simulator")
+        print("reaches as root over SSH. It powers the Boot Rescue Lab and remote")
+        print("tasks, and can be the same VM you use as the NFS server.")
+        print()
+        print("Linking copies this machine's SSH key over (ssh-copy-id — you'll")
+        print("type the root password once). Nothing is installed on the machine.")
+        print()
+        print(fmt.warning("Use a practice box you control — scenarios MODIFY it."))
+        print()
+
+        default_host = ''
+        try:
+            from core import nfs_server
+            nfs_cfg = nfs_server.load_config()
+            if nfs_cfg and nfs_cfg.get('host'):
+                default_host = nfs_cfg['host']
+        except Exception:
+            pass
+        prompt = (f"Lab machine hostname or IP [{default_host}]: " if default_host
+                  else "Lab machine hostname or IP: ")
+        host = input(prompt).strip() or default_host
+        if not host:
+            print(fmt.dim("Cancelled."))
+            input("\nPress Enter to return...")
+            return
+        user = input("SSH login user [root]: ").strip() or 'root'
+
+        if not lab_machine.key_works(host=host, user=user):
+            print()
+            if confirm_action(f"Run ssh-copy-id to {user}@{host} now?", default=True):
+                lab_machine.copy_key(host, user)
+
+        print(f"\nVerifying unattended SSH to {user}@{host}…")
+        if not lab_machine.key_works(host=host, user=user):
+            print(fmt.error("Key-based SSH still fails — not saving the link."))
+            print(fmt.dim("Check: root login allowed (PermitRootLogin), the machine "
+                          "is reachable, and ssh-copy-id succeeded."))
+            input("\nPress Enter to return...")
+            return
+
+        lab_machine.save_config(host, user)
+        print(fmt.success(f"Linked {user}@{host}. Boot Rescue Lab is ready (menu R)."))
+        input("\nPress Enter to return...")
 
     def configure_nfs_server(self):
         """SSH into a user-named RHEL box and provision it as a real NFS server

--- a/core/menu.py
+++ b/core/menu.py
@@ -184,6 +184,9 @@ LEARN & PRACTICE
      get instant feedback with retry & solution hints.
   3. Adaptive Mode - SM-2 selects your weakest/due categories.
      Difficulty adjusts to your performance. Best for review.
+  R. Boot Rescue Lab - the simulator scrambles root's password on a
+     linked second machine; you recover it at that machine's console
+     (rd.break or init=/bin/bash). Link the machine in Setup first.
 
 PROGRESS
   4. Dashboard - View exam history, success rates, weak areas,

--- a/core/menu.py
+++ b/core/menu.py
@@ -655,10 +655,14 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
             fmt.print_header("PRUNE HISTORY")
             print(fmt.bold("Remove:"))
             print("  1. A specific exam")
-            print("  2. All practice/adaptive attempts")
-            print("  3. Reset one category's adaptive (SM-2) state")
-            print("  4. Everything (wipe all progress)")
+            print("  2. Recent practice attempts (pick which — e.g. a botched session)")
+            print("  3. All practice/adaptive attempts")
+            print("  4. Reset one category's adaptive (SM-2) state")
+            print("  5. Everything (wipe all progress)")
             print("  0. Back")
+            print()
+            print(fmt.dim("Weak-area/SM-2 stats are recomputed from the surviving history"))
+            print(fmt.dim("after every prune, so removed attempts stop counting against you."))
             print()
             choice = input("Select option: ").strip()
 
@@ -683,11 +687,46 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
                         print(fmt.success("Deleted."))
                         input("\nPress Enter...")
             elif choice == '2':
-                if confirm_action("Delete ALL practice/adaptive attempts?", default=False):
-                    n = db.clear_practice_history()
-                    print(fmt.success(f"Removed {n} attempt(s)."))
+                attempts = db.list_recent_practice(limit=30)
+                if not attempts:
+                    print(fmt.dim("No practice attempts recorded."))
+                    input("\nPress Enter...")
+                    continue
+                print()
+                for i, a in enumerate(attempts, 1):
+                    status = 'PASS' if a['passed'] else 'FAIL'
+                    print(f"  {i:2d}. {(a['created_at'] or '')[:16]}  "
+                          f"{a['score']}/{a['max_score']} {status}  "
+                          f"{a['category']}  {a['task_id']}  ({a['mode']})")
+                print()
+                sel = input("Numbers to delete (e.g. 1,3 or 1-5; blank to cancel): ").strip()
+                picked = set()
+                for part in sel.split(','):
+                    part = part.strip()
+                    if '-' in part:
+                        lo, _, hi = part.partition('-')
+                        if lo.strip().isdigit() and hi.strip().isdigit():
+                            picked.update(range(int(lo), int(hi) + 1))
+                    elif part.isdigit():
+                        picked.add(int(part))
+                ids = [attempts[i - 1]['id'] for i in sorted(picked)
+                       if 1 <= i <= len(attempts)]
+                if ids and confirm_action(f"Delete {len(ids)} attempt(s)?",
+                                          default=False):
+                    n = db.delete_practice_attempts(ids)
+                    db.rebuild_weak_areas()
+                    print(fmt.success(f"Removed {n} attempt(s); weak areas recomputed."))
+                    input("\nPress Enter...")
+                elif not ids:
+                    print(fmt.dim("Nothing selected."))
                     input("\nPress Enter...")
             elif choice == '3':
+                if confirm_action("Delete ALL practice/adaptive attempts?", default=False):
+                    n = db.clear_practice_history()
+                    db.rebuild_weak_areas()
+                    print(fmt.success(f"Removed {n} attempt(s); weak areas recomputed."))
+                    input("\nPress Enter...")
+            elif choice == '4':
                 stats = db.get_all_category_stats()
                 if not stats:
                     print(fmt.dim("No category state recorded."))
@@ -705,7 +744,7 @@ For RHCSA exam info: https://www.redhat.com/rhcsa
                         db.reset_category(cat)
                         print(fmt.success("Reset."))
                         input("\nPress Enter...")
-            elif choice == '4':
+            elif choice == '5':
                 print(fmt.warning("This wipes ALL exams, attempts, and adaptive state."))
                 if confirm_action("Type-safe confirm: wipe everything?", default=False):
                     db.clear_all_progress()

--- a/core/results_db.py
+++ b/core/results_db.py
@@ -204,15 +204,18 @@ class ResultsDB:
         except Exception:
             pass
 
-    def _update_weak_area(self, category, score, max_score, passed):
-        """Update weak area stats using SM-2 algorithm."""
+    def _update_weak_area(self, category, score, max_score, passed, when=None):
+        """Update weak area stats using SM-2 algorithm.
+
+        `when` (ISO string) backdates the attempt — used when replaying
+        history in rebuild_weak_areas(); defaults to now for live updates."""
         conn = self._get_conn()
         try:
             row = conn.execute(
                 "SELECT * FROM weak_areas WHERE category = ?", (category,)
             ).fetchone()
 
-            now = datetime.now().isoformat()
+            now = when or datetime.now().isoformat()
 
             if row is None:
                 ef = 2.5
@@ -248,7 +251,8 @@ class ResultsDB:
                 interval = 1
 
             ef = max(1.3, ef + (0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02)))
-            due = (datetime.now() + timedelta(days=interval)).isoformat()
+            base = datetime.fromisoformat(now) if when else datetime.now()
+            due = (base + timedelta(days=interval)).isoformat()
 
             attempts = (row['attempts'] + 1) if row else 1
             passes = (row['passes'] + (1 if passed else 0)) if row else (1 if passed else 0)
@@ -267,6 +271,65 @@ class ResultsDB:
             conn.commit()
         finally:
             conn.close()
+
+    def list_recent_practice(self, limit=30):
+        """Most recent practice/adaptive attempts, newest first (for pruning)."""
+        conn = self._get_conn()
+        try:
+            rows = conn.execute("""
+                SELECT id, task_id, category, score, max_score, passed, mode,
+                       created_at
+                FROM practice_history ORDER BY id DESC LIMIT ?
+            """, (limit,)).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    def delete_practice_attempts(self, ids):
+        """Delete specific practice attempts by row id. Returns rows deleted.
+        Callers should rebuild_weak_areas() afterwards."""
+        if not ids:
+            return 0
+        conn = self._get_conn()
+        try:
+            marks = ','.join('?' for _ in ids)
+            cur = conn.execute(
+                f"DELETE FROM practice_history WHERE id IN ({marks})",
+                list(ids))
+            conn.commit()
+        finally:
+            conn.close()
+        self._autosave()
+        return cur.rowcount
+
+    def rebuild_weak_areas(self):
+        """Recompute ALL weak-area/SM-2 state from the surviving practice
+        history. Without this, pruned attempts kept polluting the adaptive
+        stats: deleting rows never touched weak_areas. Replays every attempt
+        in order, backdated to its original timestamp."""
+        conn = self._get_conn()
+        try:
+            conn.execute("DELETE FROM weak_areas")
+            conn.commit()
+            rows = conn.execute(
+                "SELECT category, score, max_score, passed, created_at "
+                "FROM practice_history ORDER BY created_at ASC, id ASC"
+            ).fetchall()
+        finally:
+            conn.close()
+        for r in rows:
+            when = None
+            try:
+                # SQLite CURRENT_TIMESTAMP is 'YYYY-MM-DD HH:MM:SS'
+                when = datetime.strptime(
+                    r['created_at'], '%Y-%m-%d %H:%M:%S').isoformat()
+            except (TypeError, ValueError):
+                pass
+            self._update_weak_area(r['category'], r['score'],
+                                   r['max_score'], bool(r['passed']),
+                                   when=when)
+        self._autosave()
+        return len(rows)
 
     def get_recent_exams(self, limit=10):
         """Get recent exam results."""
@@ -491,9 +554,10 @@ class ResultsDB:
             conn.execute("DELETE FROM task_results WHERE exam_id=?", (exam_id,))
             cur = conn.execute("DELETE FROM exam_results WHERE exam_id=?", (exam_id,))
             conn.commit()
-            return cur.rowcount
         finally:
             conn.close()
+        self._autosave()
+        return cur.rowcount
 
     def clear_practice_history(self):
         """Delete all practice/adaptive attempts. Returns rows deleted."""
@@ -501,9 +565,10 @@ class ResultsDB:
         try:
             cur = conn.execute("DELETE FROM practice_history")
             conn.commit()
-            return cur.rowcount
         finally:
             conn.close()
+        self._autosave()
+        return cur.rowcount
 
     def reset_category(self, category):
         """Clear the SM-2 / weak-area state for one category."""
@@ -511,9 +576,10 @@ class ResultsDB:
         try:
             cur = conn.execute("DELETE FROM weak_areas WHERE category=?", (category,))
             conn.commit()
-            return cur.rowcount
         finally:
             conn.close()
+        self._autosave()
+        return cur.rowcount
 
     def clear_all_progress(self):
         """Wipe every progress table (used before a full restore)."""
@@ -525,6 +591,7 @@ class ResultsDB:
             conn.commit()
         finally:
             conn.close()
+        self._autosave()
 
 
 _results_db = None

--- a/rhcsa_simulator.py
+++ b/rhcsa_simulator.py
@@ -409,6 +409,10 @@ def main():
             elif choice == 'adaptive':
                 run_adaptive_mode()
 
+            elif choice == 'boot_rescue':
+                from core import boot_rescue
+                boot_rescue.interactive()
+
             elif choice == 'dashboard':
                 menu.show_dashboard()
 

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -40,6 +40,11 @@ class BaseTask(ABC):
     # fabricated log evidence, or descriptive-only.
     required_packages = []
 
+    # True for tasks performed ON the linked second lab machine (over SSH).
+    # They are only offered when a lab machine is linked (Setup → Link second
+    # lab machine); the registry filters them out otherwise.
+    requires_lab_machine = False
+
     def __init__(self, id, category, difficulty, points):
         self.id = id
         self.category = category

--- a/tasks/filesystems.py
+++ b/tasks/filesystems.py
@@ -57,10 +57,7 @@ class CreateFilesystemTask(BaseTask):
         self.device = params.get('device') or get_practice_device() or '/dev/vdb1'
 
         self.description = (
-            f"Create a filesystem:\n"
-            f"  - Device: {self.device}\n"
-            f"  - Filesystem type: {fstype_desc}\n"
-            f"  - Ensure the filesystem is properly formatted"
+            f"Format {self.device} with a {fstype_desc} filesystem."
         )
 
         self.hints = [
@@ -129,11 +126,7 @@ class MountFilesystemTask(BaseTask):
         self.mount_point = params.get('mount_point', f'/mnt/data{random.randint(1,99)}')
 
         self.description = (
-            f"Mount a filesystem:\n"
-            f"  - Device: {self.device}\n"
-            f"  - Mount point: {self.mount_point}\n"
-            f"  - Create mount point if it doesn't exist\n"
-            f"  - Mount the filesystem"
+            f"Mount {self.device} at {self.mount_point}."
         )
 
         self.hints = [
@@ -231,14 +224,9 @@ class PersistentMountTask(BaseTask):
         self.options = params.get('options', 'defaults')
 
         self.description = (
-            f"Configure persistent filesystem mount:\n"
-            f"  - Device: {self.device}\n"
-            f"  - Mount point: {self.mount_point}\n"
-            f"  - Filesystem type: {self.fstype}\n"
-            f"  - Mount options: {self.options}\n"
-            f"  - Use UUID in /etc/fstab (not device name)\n"
-            f"  - Mount the filesystem now\n"
-            f"  - Ensure it mounts automatically at boot"
+            f"Mount {self.device} ({self.fstype}, options: {self.options}) at "
+            f"{self.mount_point}, now and persistently across reboots. "
+            f"Identify the device by UUID."
         )
 
         self.hints = [
@@ -503,12 +491,10 @@ class ExtendFilesystemTask(BaseTask):
         self.expected_size_mb = params.get('size', random.choice([250, 300, 350]))
 
         self.description = (
-            f"Extend a filesystem:\n"
-            f"  - Device: {self.device}\n"
-            f"  - Mount point: {self.mount_point}\n"
-            f"  - Filesystem type: {self.fstype}  (currently {self._INITIAL_MB}MB)\n"
-            f"  - Resize to approximately {self.expected_size_mb}MB\n"
-            f"  - Keep the filesystem mounted — data must not be lost"
+            f"Extend the {self.fstype} filesystem on {self.device} (mounted at "
+            f"{self.mount_point}, currently {self._INITIAL_MB}MB) to "
+            f"approximately {self.expected_size_mb}MB without unmounting it or "
+            f"losing data."
         )
         self.hints = [
             f"Step 1 — extend the LV: lvextend -L {self.expected_size_mb}M /dev/{self.vg_name}/{self.lv_name}",
@@ -798,11 +784,8 @@ class UnmountFilesystemTask(BaseTask):
         self.mount_point = params.get('mount_point', f'/mnt/data{random.randint(1,99)}')
 
         self.description = (
-            f"Unmount a filesystem:\n"
-            f"  - Mount point: {self.mount_point}\n"
-            f"  - Ensure no processes are using the filesystem\n"
-            f"  - Safely unmount the filesystem\n"
-            f"  - Remove the mount point directory (optional)"
+            f"Safely unmount the filesystem at {self.mount_point}, dealing "
+            f"with any processes still using it."
         )
 
         self.hints = [
@@ -874,12 +857,7 @@ class CreateVFATFilesystemTask(BaseTask):
         self.mount_point = params.get('mount_point', f'/mnt/vfat{random.randint(1,99)}')
 
         self.description = (
-            f"Create and mount a VFAT filesystem:\n"
-            f"  - Device: {self.device}\n"
-            f"  - Filesystem type: VFAT\n"
-            f"  - Mount point: {self.mount_point}\n"
-            f"  - Create the mount point if it does not exist\n"
-            f"  - Format the device as VFAT and mount it there"
+            f"Format {self.device} as VFAT and mount it at {self.mount_point}."
         )
 
         self.hints = [

--- a/tasks/lvm.py
+++ b/tasks/lvm.py
@@ -17,10 +17,11 @@ def _uid(n=4):
     return ''.join(random.choices(string.digits, k=n))
 
 
-def _scratch_setup(task, device, vg, lv=None, lv_mb=150, fstype=None):
+def _scratch_setup(task, device, vg, lv=None, lv_mb=150, fstype=None, pe_mib=None):
     """Provision a practice VG (and optional LV) on `device` for a task that
     would otherwise assume pre-existing LVM. Records fault state for crash
-    recovery. Returns (ok, message)."""
+    recovery. `pe_mib` sets an explicit physical extent size on the VG for
+    extent-phrased questions. Returns (ok, message)."""
     import subprocess as _sp
     from tasks.troubleshooting import save_fault_state
     if not device:
@@ -28,7 +29,11 @@ def _scratch_setup(task, device, vg, lv=None, lv_mb=150, fstype=None):
     r = _sp.run(['pvcreate', '-ff', '-y', device], capture_output=True, text=True)
     if r.returncode != 0:
         return False, f"pvcreate {device} failed: {r.stderr.strip()}"
-    r = _sp.run(['vgcreate', vg, device], capture_output=True, text=True)
+    vg_cmd = ['vgcreate']
+    if pe_mib:
+        vg_cmd += ['-s', f'{pe_mib}M']
+    vg_cmd += [vg, device]
+    r = _sp.run(vg_cmd, capture_output=True, text=True)
     if r.returncode != 0:
         return False, f"vgcreate {vg} failed: {r.stderr.strip()}"
     if lv:
@@ -56,6 +61,31 @@ def _scratch_teardown(task, vg, device):
         _sp.run(['wipefs', '-a', device], capture_output=True)
     clear_fault_state(task.id)
     return True, f"Removed {vg}"
+
+
+def _vg_extent_size_mib(vg):
+    """Physical extent size of `vg` in MiB, or None."""
+    r = execute_safe(['vgs', '--noheadings', '--nosuffix', '--units', 'm',
+                      '-o', 'vg_extent_size', vg])
+    if r.success and r.stdout.strip():
+        try:
+            return float(r.stdout.strip())
+        except ValueError:
+            pass
+    return None
+
+
+def _lv_extent_count(vg, lv):
+    """Number of logical extents in vg/lv (lvdisplay 'Current LE'), or None."""
+    r = execute_safe(['lvs', '--noheadings', '--nosuffix', '--units', 'm',
+                      '-o', 'lv_size', f'{vg}/{lv}'])
+    pe = _vg_extent_size_mib(vg)
+    if r.success and r.stdout.strip() and pe:
+        try:
+            return round(float(r.stdout.strip()) / pe)
+        except (ValueError, ZeroDivisionError):
+            pass
+    return None
 
 
 @TaskRegistry.register("lvm")
@@ -226,6 +256,7 @@ class CreateVGTask(BaseTask):
         self.exam_tips = [
             "Use 'vgcreate' to create a volume group from one or more physical volumes",
             "Physical volumes must be initialized with pvcreate first",
+            "vgcreate -s <size>M sets a custom physical extent size (default 4MiB)",
             "Verify with 'vgs' or 'vgdisplay' to see VG size and free space",
         ]
         self.requires_persistence = True
@@ -302,6 +333,8 @@ class CreateLVTask(BaseTask):
         self.vg_name = None
         self.lv_name = None
         self.lv_size_mb = None
+        self.pe_mib = None
+        self.extents = None
 
     def generate(self, **params):
         # Self-contained: a scratch VG is provisioned on an allocated device at
@@ -310,24 +343,42 @@ class CreateLVTask(BaseTask):
         uid = _uid()
         self.vg_name = params.get('vg_name', f'vg_prac{uid}')
         self.lv_name = params.get('lv_name', f'lv_data{uid}')
-        self.lv_size_mb = params.get('size', random.choice([300, 350, 400]))
 
-        self.description = (
-            f"Create a {self.lv_size_mb}MB logical volume named '{self.lv_name}' "
-            f"in volume group '{self.vg_name}'."
-        )
-
-        self.hints = [
-            "lvcreate creates a logical volume in an existing VG",
-            "Use -L for size in MB and -n for the LV name",
-            "LV device path: /dev/<vg_name>/<lv_name>",
-            "Verify with: lvs or lvdisplay",
-        ]
+        # Some of the time, phrase the size in extents (real exams do this):
+        # the scratch VG is then built with a non-default PE size.
+        use_extents = params.get('use_extents', random.random() < 0.4)
+        if use_extents:
+            self.pe_mib = random.choice([8, 16])
+            self.extents = random.choice([40, 50] if self.pe_mib == 8 else [20, 25])
+            self.lv_size_mb = self.pe_mib * self.extents
+            self.description = (
+                f"Volume group '{self.vg_name}' uses a physical extent size of "
+                f"{self.pe_mib} MiB. Create a logical volume named '{self.lv_name}' "
+                f"consisting of {self.extents} extents in that volume group."
+            )
+            self.hints = [
+                "lvcreate -l <count> sizes the LV in extents",
+                f"{self.extents} extents × {self.pe_mib}MiB = {self.lv_size_mb}MiB",
+                "Check the VG's extent size with: vgdisplay (PE Size)",
+                "Verify with: lvdisplay (Current LE)",
+            ]
+        else:
+            self.lv_size_mb = params.get('size', random.choice([300, 350, 400]))
+            self.description = (
+                f"Create a {self.lv_size_mb}MB logical volume named '{self.lv_name}' "
+                f"in volume group '{self.vg_name}'."
+            )
+            self.hints = [
+                "lvcreate creates a logical volume in an existing VG",
+                "Use -L for size in MB and -n for the LV name",
+                "LV device path: /dev/<vg_name>/<lv_name>",
+                "Verify with: lvs or lvdisplay",
+            ]
 
         return self
 
     def inject_fault(self):
-        return _scratch_setup(self, self.device, self.vg_name)
+        return _scratch_setup(self, self.device, self.vg_name, pe_mib=self.pe_mib)
 
     def restore_fault(self):
         return _scratch_teardown(self, self.vg_name, self.device)
@@ -386,6 +437,8 @@ class ExtendLVTask(BaseTask):
         self.lv_name = None
         self.target_mb = None
         self.extend_by_mb = None
+        self.pe_mib = None
+        self.initial_mb = self._INITIAL_MB
 
     def generate(self, **params):
         # Self-contained: provision a small scratch LV that the candidate extends.
@@ -393,30 +446,55 @@ class ExtendLVTask(BaseTask):
         uid = _uid()
         self.vg_name = params.get('vg_name', f'vg_prac{uid}')
         self.lv_name = params.get('lv_name', f'lv_data{uid}')
-        self.extend_by_mb = params.get('extend_by', random.choice([100, 150]))
-        self.target_mb = self._INITIAL_MB + self.extend_by_mb
 
-        self.description = (
-            f"Extend a logical volume:\n"
-            f"  - Volume group: {self.vg_name}\n"
-            f"  - Logical volume: {self.lv_name}  (currently {self._INITIAL_MB}MB)\n"
-            f"  - Task: extend by {self.extend_by_mb}MB (to ~{self.target_mb}MB)\n"
-            f"  - Ensure LV is extended"
-        )
-
-        self.hints = [
-            f"Extend LV: lvextend -L +{self.extend_by_mb}M /dev/{self.vg_name}/{self.lv_name}",
-            "Check current size: lvs or lvdisplay",
-            "Extend by amount: lvextend -L +<size>M /dev/vg/lv",
-            "Use all free space: lvextend -l +100%FREE /dev/vg/lv",
-            "After extending, resize filesystem with xfs_growfs or resize2fs"
-        ]
+        # Some of the time, phrase the growth in extents instead of MB.
+        use_extents = params.get('use_extents', random.random() < 0.4)
+        if use_extents:
+            self.pe_mib = 16
+            initial_le = 6                                   # 96MB scratch LV
+            extend_by_le = random.choice([8, 10])
+            self.initial_mb = initial_le * self.pe_mib
+            self.extend_by_mb = extend_by_le * self.pe_mib
+            self.target_mb = self.initial_mb + self.extend_by_mb
+            self.description = (
+                f"Extend a logical volume (extent-based):\n"
+                f"  - Volume group: {self.vg_name}  (extent size {self.pe_mib}MiB)\n"
+                f"  - Logical volume: {self.lv_name}  (currently {initial_le} extents)\n"
+                f"  - Task: extend it by {extend_by_le} extents\n"
+                f"    (to {initial_le + extend_by_le} extents total)"
+            )
+            self.hints = [
+                f"Extend by extents: lvextend -l +{extend_by_le} /dev/{self.vg_name}/{self.lv_name}",
+                "lvextend -l <count> sets a total, -l +<count> adds extents",
+                f"{extend_by_le} extents × {self.pe_mib}MiB = +{self.extend_by_mb}MB",
+                "Check current extents: lvdisplay (Current LE)",
+                "After extending, resize the filesystem with xfs_growfs or resize2fs",
+            ]
+        else:
+            self.initial_mb = self._INITIAL_MB
+            self.extend_by_mb = params.get('extend_by', random.choice([100, 150]))
+            self.target_mb = self.initial_mb + self.extend_by_mb
+            self.description = (
+                f"Extend a logical volume:\n"
+                f"  - Volume group: {self.vg_name}\n"
+                f"  - Logical volume: {self.lv_name}  (currently {self.initial_mb}MB)\n"
+                f"  - Task: extend by {self.extend_by_mb}MB (to ~{self.target_mb}MB)\n"
+                f"  - Ensure LV is extended"
+            )
+            self.hints = [
+                f"Extend LV: lvextend -L +{self.extend_by_mb}M /dev/{self.vg_name}/{self.lv_name}",
+                "Check current size: lvs or lvdisplay",
+                "Extend by amount: lvextend -L +<size>M /dev/vg/lv",
+                "Use all free space: lvextend -l +100%FREE /dev/vg/lv",
+                "After extending, resize filesystem with xfs_growfs or resize2fs"
+            ]
 
         return self
 
     def inject_fault(self):
         return _scratch_setup(self, self.device, self.vg_name,
-                              lv=self.lv_name, lv_mb=self._INITIAL_MB)
+                              lv=self.lv_name, lv_mb=self.initial_mb,
+                              pe_mib=self.pe_mib)
 
     def restore_fault(self):
         return _scratch_teardown(self, self.vg_name, self.device)
@@ -579,6 +657,157 @@ class LVMFullWorkflowTask(BaseTask):
             total_points += 3
         else:
             checks.append(ValidationCheck("persistent_mount", False, 0, "No valid fstab entry", max_points=3))
+
+        passed = total_points >= (self.points * 0.7)
+        return ValidationResult(self.id, passed, total_points, self.points, checks)
+
+
+@TaskRegistry.register("lvm")
+class LVMExtentWorkflowTask(BaseTask):
+    """Exam-style workflow with explicit extent sizing: VG with a set PE size,
+    LV specified as a number of extents, formatted and mounted persistently."""
+
+    disk_slots = 1
+
+    # (pe_mib, extents) combos all yield 320MiB: fits a 500MB practice disk and
+    # clears the RHEL 10 mkfs.xfs 300MB minimum.
+    _COMBOS = [(16, 20), (8, 40), (32, 10)]
+
+    def __init__(self):
+        super().__init__(
+            id="lvm_extent_workflow_001",
+            category="lvm",
+            difficulty="exam",
+            points=20
+        )
+        self.task_order = 37
+        self.tags = ['lvm-workflow', 'lvm-extents', 'exam-critical', 'fstab']
+        self.exam_tips = [
+            "vgcreate -s <size>M sets the physical extent (PE) size of the VG",
+            "lvcreate -l <count> sizes the LV in extents instead of bytes",
+            "LV size = extent count × PE size — check with vgdisplay/lvdisplay",
+            "vgdisplay shows 'PE Size' and 'Total PE'; lvdisplay shows 'Current LE'",
+            "Real exams phrase LV sizes in extents — know -l as well as -L",
+        ]
+        self.requires_persistence = True
+        self.device = None
+        self.vg_name = None
+        self.lv_name = None
+        self.pe_mib = None
+        self.extents = None
+        self.mount_point = None
+        self.fstype = None
+
+    def generate(self, **params):
+        self.device = params.get('device') or get_practice_device() or '/dev/vdb'
+        uid = _uid()
+        self.vg_name = params.get('vg_name', f'vg_ext{uid}')
+        self.lv_name = params.get('lv_name', f'lv_data{uid}')
+        self.pe_mib, self.extents = params.get('combo', random.choice(self._COMBOS))
+        self.fstype = params.get('fstype', 'xfs')
+        self.mount_point = params.get('mount', f'/mnt/lvm{random.randint(1,99)}')
+
+        self.description = (
+            f"Create a logical volume sized in extents:\n"
+            f"  1. Create volume group '{self.vg_name}' on {self.device} with a\n"
+            f"     physical extent size of {self.pe_mib} MiB\n"
+            f"  2. Create logical volume '{self.lv_name}' consisting of\n"
+            f"     {self.extents} extents\n"
+            f"  3. Format it with {self.fstype} and mount it persistently at\n"
+            f"     {self.mount_point}"
+        )
+
+        self.hints = [
+            f"Set the extent size at VG creation: vgcreate -s {self.pe_mib}M ...",
+            f"Size the LV in extents: lvcreate -l {self.extents} -n <name> <vg>",
+            f"{self.extents} extents × {self.pe_mib}MiB = "
+            f"{self.extents * self.pe_mib}MiB total",
+            "Verify: vgdisplay (PE Size) and lvdisplay (Current LE)",
+            "Then mkfs, mount, and add a UUID entry to /etc/fstab; test with mount -a",
+        ]
+
+        return self
+
+    def validate(self):
+        checks = []
+        total_points = 0
+        from validators.system_validators import get_filesystem_type, get_mounted_devices
+
+        # Check 1: VG exists with the requested PE size (5 points)
+        actual_pe = _vg_extent_size_mib(self.vg_name)
+        if actual_pe is None:
+            checks.append(ValidationCheck("vg_extent_size", False, 0,
+                          f"Volume group '{self.vg_name}' not found", max_points=5))
+        elif abs(actual_pe - self.pe_mib) < 0.01:
+            checks.append(ValidationCheck("vg_extent_size", True, 5,
+                          f"VG extent size is {self.pe_mib}MiB"))
+            total_points += 5
+        else:
+            checks.append(ValidationCheck("vg_extent_size", False, 0,
+                          f"VG extent size is {actual_pe:g}MiB (expected {self.pe_mib}MiB — "
+                          f"set with vgcreate -s)", max_points=5))
+
+        # Check 2: LV exists (3 points)
+        if validate_lv_exists(self.vg_name, self.lv_name):
+            checks.append(ValidationCheck("lv_exists", True, 3, "Logical volume created"))
+            total_points += 3
+
+            # Check 3: LV has the requested number of extents (4 points)
+            actual_le = _lv_extent_count(self.vg_name, self.lv_name)
+            if actual_le == self.extents:
+                checks.append(ValidationCheck("lv_extents", True, 4,
+                              f"LV has {self.extents} extents"))
+                total_points += 4
+            else:
+                checks.append(ValidationCheck("lv_extents", False, 0,
+                              f"LV has {actual_le} extents (expected {self.extents})",
+                              max_points=4))
+        else:
+            checks.append(ValidationCheck("lv_exists", False, 0,
+                          "Logical volume not found", max_points=3))
+            checks.append(ValidationCheck("lv_extents", False, 0,
+                          "Cannot check extents — LV missing", max_points=4))
+
+        # Check 4: Filesystem (3 points)
+        lv_path = f'/dev/{self.vg_name}/{self.lv_name}'
+        if get_filesystem_type(lv_path) == self.fstype:
+            checks.append(ValidationCheck("fs_formatted", True, 3,
+                          f"Formatted as {self.fstype}"))
+            total_points += 3
+        else:
+            checks.append(ValidationCheck("fs_formatted", False, 0,
+                          "Filesystem not formatted or wrong type", max_points=3))
+
+        # Check 5: Mounted (2 points)
+        mounts = get_mounted_devices()
+        if any(m['mount_point'] == self.mount_point for m in mounts):
+            checks.append(ValidationCheck("lv_mounted", True, 2,
+                          f"Mounted at {self.mount_point}"))
+            total_points += 2
+        else:
+            checks.append(ValidationCheck("lv_mounted", False, 0,
+                          "Not mounted", max_points=2))
+
+        # Check 6: Persistent mount with a real source field (3 points)
+        fstab_ok = False
+        try:
+            with open('/etc/fstab') as f:
+                for line in f:
+                    s = line.split('#', 1)[0].split()
+                    if len(s) >= 2 and s[1] == self.mount_point:
+                        source = s[0]
+                        if source and source not in ('UUID=', 'LABEL='):
+                            fstab_ok = True
+                            break
+        except OSError:
+            pass
+        if fstab_ok:
+            checks.append(ValidationCheck("persistent_mount", True, 3,
+                          "Valid entry in /etc/fstab"))
+            total_points += 3
+        else:
+            checks.append(ValidationCheck("persistent_mount", False, 0,
+                          "No valid fstab entry", max_points=3))
 
         passed = total_points >= (self.points * 0.7)
         return ValidationResult(self.id, passed, total_points, self.points, checks)

--- a/tasks/networking.py
+++ b/tasks/networking.py
@@ -399,10 +399,8 @@ class SetHostnameTask(BaseTask):
         self.hostname = params.get('hostname', _random_hostname())
 
         self.description = (
-            f"Set the system hostname:\n"
-            f"  - Hostname: {self.hostname}\n"
-            f"  - Use hostnamectl command\n"
-            f"  - Must persist across reboots"
+            f"Set the system hostname to {self.hostname}, persistently "
+            f"across reboots."
         )
 
         self.hints = [
@@ -478,7 +476,6 @@ class ConfigureDNSTask(BaseTask):
             f"Configure DNS servers for connection '{self.connection_name}':\n"
             f"  - Primary DNS: {self.dns_servers[0]}\n"
             f"  - Secondary DNS: {self.dns_servers[1] if len(self.dns_servers) > 1 else 'N/A'}\n"
-            f"  - Use nmcli to configure (do NOT edit resolv.conf directly)\n"
             f"  - Activate the connection\n"
             f"  - Configuration must persist across reboots"
         )
@@ -1241,7 +1238,6 @@ class ConfigureSearchDomainTask(BaseTask):
             f"Configure a DNS search domain:\n"
             f"  - Connection: {self.connection_name}\n"
             f"  - Search domain: {self.search_domain}\n"
-            f"  - Use nmcli (do NOT edit resolv.conf directly)\n"
             f"  - Activate the connection\n"
             f"  - Must persist across reboots"
         )

--- a/tasks/partitioning.py
+++ b/tasks/partitioning.py
@@ -80,13 +80,9 @@ class CreateMBRPartitionTask(BaseTask):
         pnum = self.params["part_num"]
 
         self.description = (
-            f"Create an MBR partition on {dev}:\n"
-            f"  - Partition table type: msdos (MBR)\n"
-            f"  - Partition number: {pnum}\n"
-            f"  - Type: {ptype}\n"
-            f"  - Size: {size} MiB\n"
-            f"  - Use fdisk or parted to complete the task\n"
-            f"  - Run partprobe after writing changes"
+            f"Using an MBR (msdos) partition table, create a {size} MiB "
+            f"{ptype} partition (number {pnum}) on {dev}. The kernel must "
+            f"recognise the new partition."
         )
 
         self.hints = [
@@ -182,11 +178,8 @@ class CreateGPTPartitionTask(BaseTask):
         name = self.params["part_name"]
 
         self.description = (
-            f"Create a GPT partition on {dev}:\n"
-            f"  - Create a GPT (gpt) partition table on the disk\n"
-            f"  - Create one partition named '{name}'\n"
-            f"  - Size: {size} MiB\n"
-            f"  - Use parted or gdisk"
+            f"Create a GPT partition table on {dev} with one {size} MiB "
+            f"partition named '{name}'."
         )
 
         self.hints = [
@@ -281,11 +274,8 @@ class ResizePartitionTask(BaseTask):
         part_dev = _partition_dev(dev, pnum)
 
         self.description = (
-            f"Resize partition {part_dev}:\n"
-            f"  - Grow partition {pnum} on {dev} to {new_size} MiB\n"
-            f"  - Ensure no data loss\n"
-            f"  - Resize the filesystem after growing the partition\n"
-            f"  - The filesystem may be xfs or ext4"
+            f"Grow partition {pnum} on {dev} to {new_size} MiB and resize its "
+            f"filesystem (xfs or ext4) to match, without data loss."
         )
 
         self.hints = [
@@ -378,11 +368,9 @@ class DeletePartitionTask(BaseTask):
         part_dev = _partition_dev(dev, pnum)
 
         self.description = (
-            f"Delete partition {pnum} on {dev}:\n"
-            f"  - Unmount {part_dev} if currently mounted\n"
-            f"  - Remove any /etc/fstab entry for {part_dev}\n"
-            f"  - Delete partition {pnum}\n"
-            f"  - Run partprobe to update kernel"
+            f"Completely remove partition {pnum} on {dev}, including any "
+            f"mount and /etc/fstab entry for {part_dev}. The kernel must "
+            f"recognise the change."
         )
 
         self.hints = [
@@ -467,13 +455,9 @@ class PartitionAndFormatTask(BaseTask):
         part_dev = _partition_dev(dev, pnum)
 
         self.description = (
-            f"Create a partition, format, mount, and persist:\n"
-            f"  1. Create a {size} MiB partition (number {pnum}) on {dev}\n"
-            f"  2. Format {part_dev} with {fs}\n"
-            f"  3. Create mount point {mp}\n"
-            f"  4. Mount {part_dev} at {mp}\n"
-            f"  5. Add an /etc/fstab entry using the partition UUID\n"
-            f"  6. Configuration must survive a reboot"
+            f"Use {dev} to create a {size} MiB partition (number {pnum}) "
+            f"formatted with {fs} and mounted at {mp}, persistently across "
+            f"reboots. Identify it by UUID in /etc/fstab."
         )
 
         self.hints = [

--- a/tasks/processes.py
+++ b/tasks/processes.py
@@ -369,24 +369,19 @@ class FindProcessByUserTask(BaseTask):
             )
 
         if self.action == 'list':
-            task_desc = (
-                f"List all processes owned by user '{self.username}'\n"
-                f"  - Save the output to: {self.output_file}"
+            self.description = (
+                f"Save a list of all processes owned by user "
+                f"'{self.username}' to {self.output_file}."
             )
         elif self.action == 'count':
-            task_desc = (
-                f"Count processes owned by user '{self.username}'\n"
-                f"  - Save the count to: {self.output_file}"
+            self.description = (
+                f"Count the processes owned by user '{self.username}' and "
+                f"save the number to {self.output_file}."
             )
         else:  # kill
-            task_desc = f"Terminate all processes owned by user '{self.username}'"
-
-        self.description = (
-            f"Process management by user:\n"
-            f"  - Task: {task_desc}\n"
-            f"  - User: {self.username}\n"
-            f"  - Use appropriate ps/pkill commands"
-        )
+            self.description = (
+                f"Terminate all processes owned by user '{self.username}'."
+            )
 
         if self.action == 'list':
             self.hints = [

--- a/tasks/registry.py
+++ b/tasks/registry.py
@@ -102,6 +102,19 @@ class TaskRegistry:
         if not task_classes:
             return None
 
+        # Remote tasks are only offered when a lab machine is linked.
+        if any(getattr(tc, 'requires_lab_machine', False) for tc in task_classes):
+            try:
+                from core import lab_machine
+                linked = bool(lab_machine.get_host())
+            except Exception:
+                linked = False
+            if not linked:
+                task_classes = [tc for tc in task_classes
+                                if not getattr(tc, 'requires_lab_machine', False)]
+                if not task_classes:
+                    return None
+
         # Filter by difficulty
         if difficulty:
             filtered = []

--- a/tasks/remote.py
+++ b/tasks/remote.py
@@ -1,0 +1,301 @@
+"""
+Remote tasks — performed ON the linked second lab machine, like the real
+exam's second node.
+
+The candidate SSHes (or consoles) into the lab machine themselves and does
+the work there; the simulator injects/validates over its own key-based SSH
+link (core/lab_machine.py). These tasks are only offered when a lab machine
+is linked, and each records a remote restore script so session teardown /
+Reset Machine can put the lab machine back (best-effort if it is down).
+
+They register into their natural categories (networking, users_groups,
+time_services), so exams mix local and remote work exactly like the real
+two-node exam.
+"""
+
+import random
+
+from tasks.base import BaseTask
+from tasks.registry import TaskRegistry
+from core.validator import ValidationCheck, ValidationResult
+
+
+def _lab_host():
+    from core import lab_machine
+    return lab_machine.get_host()
+
+
+def _read_values(script):
+    from core import lab_machine
+    return lab_machine.read_values(script)
+
+
+def _save_restore(task_id, script, label):
+    from tasks.troubleshooting import save_fault_state
+    save_fault_state(task_id, {'remote_restore_script': script, 'label': label})
+
+
+def _replay_restore(task_id):
+    from tasks.troubleshooting import load_fault_state, clear_fault_state
+    from core import lab_machine
+    state = load_fault_state(task_id)
+    info = state.get('restore_info', {}) if state else {}
+    script = info.get('remote_restore_script')
+    if script:
+        lab_machine.run(script, timeout=60)
+    clear_fault_state(task_id)
+    return True, "restored remote state"
+
+
+def _unreachable_result(task, reason=''):
+    check = ValidationCheck(
+        'lab_machine_reachable', False, 0,
+        f"Cannot reach the lab machine over SSH — finish the task and make "
+        f"sure the machine is up. {reason}".strip(), max_points=task.points)
+    return ValidationResult(task.id, False, 0, task.points, [check])
+
+
+@TaskRegistry.register("networking")
+class RemoteHostnameTask(BaseTask):
+    """Set the static hostname on the lab machine."""
+
+    has_fault_injection = True
+    requires_lab_machine = True
+
+    def __init__(self):
+        super().__init__(
+            id="remote_hostname_001",
+            category="networking",
+            difficulty="exam",
+            points=8
+        )
+        self.tags = ['remote', 'hostname']
+        self.exam_tips = [
+            "hostnamectl set-hostname <name> sets the static hostname persistently",
+            "Verify with: hostnamectl status (or hostnamectl --static)",
+            "Real exams run across two nodes — read WHERE each task applies",
+        ]
+        self.requires_persistence = True
+        self.hostname = None
+
+    def generate(self, **params):
+        host = _lab_host() or '<lab machine>'
+        self.hostname = params.get(
+            'hostname', f'node{random.randint(2, 9)}.lab.example.com')
+        self.description = (
+            f"On the lab machine ({host}): set the static hostname to "
+            f"'{self.hostname}'. The change must persist across reboots."
+        )
+        self.hints = [
+            f"SSH to the lab machine first: ssh root@{host}",
+            "hostnamectl set-hostname sets the static hostname",
+            "Verify with: hostnamectl --static",
+        ]
+        return self
+
+    def inject_fault(self):
+        ok, values, out = _read_values(
+            'echo "STATIC=$(hostnamectl --static 2>/dev/null)"')
+        if not ok:
+            return False, f"lab machine unreachable — skipping ({out[-200:]})"
+        orig = values.get('STATIC', '') or 'localhost.localdomain'
+        _save_restore(self.id, f"hostnamectl set-hostname '{orig}'",
+                      f"hostname ({orig})")
+        return True, "recorded original hostname"
+
+    def restore_fault(self):
+        return _replay_restore(self.id)
+
+    def validate(self):
+        ok, values, out = _read_values(
+            'echo "STATIC=$(hostnamectl --static 2>/dev/null)"')
+        if not ok:
+            return _unreachable_result(self)
+        checks = []
+        total = 0
+        actual = values.get('STATIC', '')
+        if actual == self.hostname:
+            checks.append(ValidationCheck('hostname_set', True, 8,
+                          f"Static hostname is '{self.hostname}'"))
+            total += 8
+        else:
+            checks.append(ValidationCheck('hostname_set', False, 0,
+                          f"Static hostname is '{actual or 'unset'}' "
+                          f"(expected '{self.hostname}')", max_points=8))
+        return ValidationResult(self.id, total >= self.points * 0.8,
+                                total, self.points, checks)
+
+
+@TaskRegistry.register("users_groups")
+class RemoteUserTask(BaseTask):
+    """Create a user with a specific UID and supplementary group on the lab
+    machine, with a password set."""
+
+    has_fault_injection = True
+    requires_lab_machine = True
+
+    def __init__(self):
+        super().__init__(
+            id="remote_user_001",
+            category="users_groups",
+            difficulty="exam",
+            points=10
+        )
+        self.tags = ['remote', 'users']
+        self.exam_tips = [
+            "useradd -u <uid> -G <group> creates a user with a UID and a "
+            "supplementary group in one step",
+            "Set the password with passwd <user> (or echo 'u:p' | chpasswd)",
+            "Verify with: id <user>",
+        ]
+        self.requires_persistence = True
+        self.username = None
+        self.uid = None
+        self.group = None
+
+    def generate(self, **params):
+        host = _lab_host() or '<lab machine>'
+        self.username = params.get('username', f'rmuser{random.randint(10, 99)}')
+        self.uid = params.get('uid', random.randint(3000, 3999))
+        self.group = params.get('group', 'wheel')
+        self.description = (
+            f"On the lab machine ({host}): create user '{self.username}' with "
+            f"UID {self.uid} and supplementary group '{self.group}', and set "
+            f"any password for the account."
+        )
+        self.hints = [
+            f"SSH to the lab machine first: ssh root@{host}",
+            "useradd -u sets the UID, -G adds a supplementary group",
+            f"Verify with: id {self.username}",
+        ]
+        return self
+
+    def inject_fault(self):
+        ok, _, out = _read_values('echo "UP=yes"')
+        if not ok:
+            return False, f"lab machine unreachable — skipping ({out[-200:]})"
+        _save_restore(self.id,
+                      f"userdel -r '{self.username}' 2>/dev/null; true",
+                      f"practice user ({self.username})")
+        return True, "recorded cleanup for the practice user"
+
+    def restore_fault(self):
+        return _replay_restore(self.id)
+
+    def validate(self):
+        u = self.username
+        script = (
+            f'echo "UID=$(id -u {u} 2>/dev/null)"\n'
+            f'echo "GROUPS=$(id -nG {u} 2>/dev/null)"\n'
+            f'echo "HASH=$(awk -F: \'$1=="{u}"{{print $2}}\' /etc/shadow)"\n'
+        )
+        ok, values, out = _read_values(script)
+        if not ok:
+            return _unreachable_result(self)
+        checks = []
+        total = 0
+
+        if values.get('UID') == str(self.uid):
+            checks.append(ValidationCheck('uid', True, 4,
+                          f"User exists with UID {self.uid}"))
+            total += 4
+        elif values.get('UID'):
+            checks.append(ValidationCheck('uid', False, 0,
+                          f"User exists but UID is {values['UID']} "
+                          f"(expected {self.uid})", max_points=4))
+        else:
+            checks.append(ValidationCheck('uid', False, 0,
+                          f"User '{u}' does not exist", max_points=4))
+
+        if self.group in values.get('GROUPS', '').split():
+            checks.append(ValidationCheck('group', True, 3,
+                          f"'{self.group}' is a supplementary group"))
+            total += 3
+        else:
+            checks.append(ValidationCheck('group', False, 0,
+                          f"User is not in group '{self.group}'", max_points=3))
+
+        pw_hash = values.get('HASH', '')
+        if pw_hash.startswith('$'):
+            checks.append(ValidationCheck('password', True, 3, "Password is set"))
+            total += 3
+        else:
+            checks.append(ValidationCheck('password', False, 0,
+                          "No password set for the account", max_points=3))
+
+        return ValidationResult(self.id, total >= self.points * 0.7,
+                                total, self.points, checks)
+
+
+@TaskRegistry.register("time_services")
+class RemoteTimezoneTask(BaseTask):
+    """Set the system timezone on the lab machine."""
+
+    has_fault_injection = True
+    requires_lab_machine = True
+
+    # Rarely a default anywhere, so the candidate always has real work to do.
+    _ZONES = ['America/Phoenix', 'Australia/Adelaide', 'Europe/Vienna',
+              'Asia/Kolkata']
+
+    def __init__(self):
+        super().__init__(
+            id="remote_timezone_001",
+            category="time_services",
+            difficulty="exam",
+            points=8
+        )
+        self.tags = ['remote', 'timezone']
+        self.exam_tips = [
+            "timedatectl set-timezone <zone> sets the timezone persistently",
+            "List zones with: timedatectl list-timezones | grep <region>",
+            "Verify with: timedatectl (check the 'Time zone' line)",
+        ]
+        self.requires_persistence = True
+        self.timezone = None
+
+    def generate(self, **params):
+        host = _lab_host() or '<lab machine>'
+        self.timezone = params.get('timezone', random.choice(self._ZONES))
+        self.description = (
+            f"On the lab machine ({host}): set the system timezone to "
+            f"'{self.timezone}'."
+        )
+        self.hints = [
+            f"SSH to the lab machine first: ssh root@{host}",
+            "timedatectl set-timezone changes the timezone",
+            "Find the exact zone name: timedatectl list-timezones",
+        ]
+        return self
+
+    def inject_fault(self):
+        ok, values, out = _read_values(
+            'echo "TZ=$(timedatectl show -p Timezone --value 2>/dev/null)"')
+        if not ok:
+            return False, f"lab machine unreachable — skipping ({out[-200:]})"
+        orig = values.get('TZ', '') or 'UTC'
+        _save_restore(self.id, f"timedatectl set-timezone '{orig}'",
+                      f"timezone ({orig})")
+        return True, "recorded original timezone"
+
+    def restore_fault(self):
+        return _replay_restore(self.id)
+
+    def validate(self):
+        ok, values, out = _read_values(
+            'echo "TZ=$(timedatectl show -p Timezone --value 2>/dev/null)"')
+        if not ok:
+            return _unreachable_result(self)
+        checks = []
+        total = 0
+        actual = values.get('TZ', '')
+        if actual == self.timezone:
+            checks.append(ValidationCheck('timezone', True, 8,
+                          f"Timezone is {self.timezone}"))
+            total += 8
+        else:
+            checks.append(ValidationCheck('timezone', False, 0,
+                          f"Timezone is '{actual or 'unknown'}' "
+                          f"(expected '{self.timezone}')", max_points=8))
+        return ValidationResult(self.id, total >= self.points * 0.8,
+                                total, self.points, checks)

--- a/tasks/repos.py
+++ b/tasks/repos.py
@@ -586,9 +586,12 @@ class ConfigureBaseOSAppStreamTask(BaseTask):
         self.baseos_url = f"{self.server_url}/BaseOS/x86_64/os/"
         self.appstream_url = f"{self.server_url}/AppStream/x86_64/os/"
 
+        # No 'rhel-*' names here: Reset Machine deliberately preserves repo
+        # files with the rhel-/redhat- system prefixes, so a task-created
+        # rhel-baseos.repo would survive every reset.
         repo_id_sets = [
             ('baseos', 'appstream'),
-            ('rhel-baseos', 'rhel-appstream'),
+            ('lab-baseos', 'lab-appstream'),
             ('BaseOS', 'AppStream'),
             ('local-baseos', 'local-appstream'),
         ]

--- a/tasks/scheduling.py
+++ b/tasks/scheduling.py
@@ -350,11 +350,8 @@ class CreateAtJobTask(BaseTask):
         self.command = params.get('command', 'echo "At job executed" >> /tmp/atjob.log')
 
         self.description = (
-            f"Schedule a one-time task:\n"
-            f"  - Time: {time_desc}\n"
-            f"  - At spec: {self.time_spec}\n"
-            f"  - Command: {self.command}\n"
-            f"  - Use the 'at' command"
+            f"Schedule a one-time job for {time_desc} (at spec: "
+            f"'{self.time_spec}') that runs: {self.command}"
         )
 
         self.hints = [

--- a/tasks/services.py
+++ b/tasks/services.py
@@ -125,9 +125,8 @@ class EnableServiceTask(BaseTask):
         self.service_name = params.get('service', random.choice(_STARTABLE_SERVICES))
 
         self.description = (
-            f"Enable the '{self.service_name}' service to start automatically at boot.\n"
-            f"  - Use the appropriate systemctl command.\n"
-            f"  - Verify the service is enabled."
+            f"Enable the '{self.service_name}' service to start "
+            f"automatically at boot."
         )
 
         self.hints = [

--- a/tasks/systemd_timers.py
+++ b/tasks/systemd_timers.py
@@ -643,10 +643,8 @@ class ListActiveTimersTask(BaseTask):
         )
 
         self.description = (
-            f"List all active systemd timers:\n"
-            f"  - Use the appropriate systemctl command to list timers\n"
-            f"  - Save the output to: {self.output_file}\n"
-            f"  - The file should include next-trigger and last-trigger columns"
+            f"Save a listing of all active systemd timers (including their "
+            f"next and last trigger times) to {self.output_file}."
         )
 
         self.hints = [

--- a/tasks/troubleshooting.py
+++ b/tasks/troubleshooting.py
@@ -104,6 +104,20 @@ def restore_any_active_fault():
     return True, '\n'.join(msgs)
 
 
+def _restore_remote(info, msgs):
+    """Undo a remote task's change on the linked lab machine (best-effort —
+    the machine may be down; the record is cleared either way, matching how
+    unreachable local restores behave)."""
+    from core import lab_machine
+    label = info.get('label', 'remote task')
+    host = lab_machine.get_host() or 'lab machine'
+    rc, _ = lab_machine.run(info['remote_restore_script'], timeout=60)
+    if rc == 0:
+        msgs.append(f"Restored {label} on {host}")
+    else:
+        msgs.append(f"Could not restore {label} on {host} (unreachable?)")
+
+
 def _dispatch_restore(task_id, info, msgs):
     """Restore a single fault by task_id (crash-recovery dispatcher)."""
     # Generic environment-setup records (from positive-config tasks that
@@ -111,6 +125,10 @@ def _dispatch_restore(task_id, info, msgs):
     # are undone independently of their task_id.
     if isinstance(info, dict) and info.get('restore_type'):
         _restore_env_setup(info, msgs)
+        return
+    # Remote-task records: the restore runs on the linked lab machine.
+    if isinstance(info, dict) and info.get('remote_restore_script'):
+        _restore_remote(info, msgs)
         return
     # Dispatch to the right restorer
     if task_id.startswith('fault_selinux_context'):

--- a/tasks/users_groups.py
+++ b/tasks/users_groups.py
@@ -571,15 +571,16 @@ class ConfigureSudoTask(BaseTask):
         passwd_note = " without a password" if self.nopasswd else " (password required)"
 
         self.description = (
-            f"Grant '{self.username}' sudo access to run {self.allowed_cmds} as root"
-            f"{passwd_note}. Place the rule in /etc/sudoers.d/{self.username}."
+            f"Grant '{self.username}' sudo access to run {self.allowed_cmds} "
+            f"as root{passwd_note}."
         )
 
         self.hints = [
-            f"Drop-in sudoers files go in /etc/sudoers.d/, not /etc/sudoers",
+            "Drop-in sudoers files go in /etc/sudoers.d/, not /etc/sudoers",
             "sudoers rule format: user ALL=(ALL) [NOPASSWD:] command[,command]",
             "File permissions must be 0440 — world-writable files are ignored",
-            f"Validate syntax before relying on it: visudo -cf /etc/sudoers.d/{self.username}",
+            f"Check the effective rules: sudo -l -U {self.username}",
+            "Validate syntax before relying on it: visudo -cf <file>",
         ]
         return self
 
@@ -598,68 +599,70 @@ class ConfigureSudoTask(BaseTask):
                           f"User '{self.username}' does not exist", max_points=2))
             return ValidationResult(self.id, False, total, self.points, checks)
 
-        # Check 2: sudoers file exists (3 pts)
-        sudo_file = f"/etc/sudoers.d/{self.username}"
-        stat_result = execute_safe(["stat", sudo_file])
-        if stat_result.success:
-            checks.append(ValidationCheck("sudo_file_exists", True, 3,
-                          f"Sudoers file exists: {sudo_file}"))
-            total += 3
+        # Check 2: the EFFECTIVE rule is right (6 pts) — graded via
+        # `sudo -l -U`, so any valid placement (any drop-in name, or even
+        # /etc/sudoers) counts. The question no longer dictates the file.
+        sudo_check = execute_safe(["sudo", "-l", "-U", self.username])
+        listing = sudo_check.stdout if sudo_check.success else ""
+        if self.allowed_cmds == "ALL":
+            cmds_ok = "ALL" in listing
         else:
-            checks.append(ValidationCheck("sudo_file_exists", False, 0,
-                          f"Sudoers file not found: {sudo_file}", max_points=3))
-            return ValidationResult(self.id, False, total, self.points, checks)
+            cmds_ok = all(c.strip() in listing
+                          for c in self.allowed_cmds.split(","))
+        nopasswd_ok = (("NOPASSWD" in listing) == self.nopasswd)
+        may_run = "may run the following" in listing
 
-        # Check 3: file permissions are 0440 (2 pts)
-        perm_result = execute_safe(["stat", "-c", "%a", sudo_file])
-        actual_perms = perm_result.stdout.strip() if perm_result.success else ""
-        if actual_perms in ("440", "0440"):
-            checks.append(ValidationCheck("sudo_perms", True, 2,
-                          "File permissions are 0440"))
+        if may_run and cmds_ok and nopasswd_ok:
+            checks.append(ValidationCheck("sudo_rule", True, 6,
+                          f"'{self.username}' may run {self.allowed_cmds}"
+                          f"{' without a password' if self.nopasswd else ' (password required)'}"))
+            total += 6
+        elif may_run and cmds_ok:
+            checks.append(ValidationCheck("sudo_rule", True, 4,
+                          "Rule grants the commands but the NOPASSWD setting "
+                          "doesn't match the question", max_points=6))
+            total += 4
+        elif may_run:
+            checks.append(ValidationCheck("sudo_rule", False, 2,
+                          f"'{self.username}' has sudo rules, but not for the "
+                          f"requested commands ({self.allowed_cmds})",
+                          max_points=6))
             total += 2
-        else:
-            checks.append(ValidationCheck("sudo_perms", False, 0,
-                          f"Permissions are {actual_perms}, expected 440",
-                          max_points=2))
-
-        # Check 4: file contains correct rule (3 pts)
-        cat_result = execute_safe(["cat", f"/etc/sudoers.d/{self.username}"])
-        if cat_result.success:
-            content = cat_result.stdout
-            nopasswd_str = "NOPASSWD:" if self.nopasswd else ""
-            user_found = self.username in content
-            cmd_found = self.allowed_cmds in content or (
-                self.allowed_cmds == "ALL" and "ALL" in content)
-            nopasswd_ok = True
-            if self.nopasswd:
-                nopasswd_ok = "NOPASSWD" in content
-            elif not self.nopasswd:
-                nopasswd_ok = "NOPASSWD" not in content
-
-            if user_found and cmd_found and nopasswd_ok:
-                checks.append(ValidationCheck("sudo_rule", True, 3,
-                              "Sudo rule is correct"))
-                total += 3
-            elif user_found and cmd_found:
-                checks.append(ValidationCheck("sudo_rule", True, 2,
-                              "Sudo rule partially correct (NOPASSWD mismatch)"))
-                total += 2
-            else:
-                checks.append(ValidationCheck("sudo_rule", False, 0,
-                              "Sudo rule content is incorrect", max_points=3))
         else:
             checks.append(ValidationCheck("sudo_rule", False, 0,
-                          f"Cannot read sudoers file", max_points=3))
+                          f"No effective sudo rule for '{self.username}' "
+                          f"(checked with sudo -l -U)", max_points=6))
 
-        # Check 5: sudo -l works for user (2 pts)
-        sudo_check = execute_safe(["sudo", "-l", "-U", self.username])
-        if sudo_check.success and "not allowed" not in sudo_check.stdout.lower():
-            checks.append(ValidationCheck("sudo_access", True, 2,
-                          "Sudo access verified"))
+        # Check 3: rule lives in a /etc/sudoers.d/ drop-in (best practice, 2 pts)
+        import glob as _glob
+        in_dropin = False
+        for f in _glob.glob('/etc/sudoers.d/*'):
+            try:
+                with open(f) as fh:
+                    if any(ln.strip().startswith(self.username)
+                           for ln in fh if not ln.strip().startswith('#')):
+                        in_dropin = True
+                        break
+            except OSError:
+                continue
+        if in_dropin:
+            checks.append(ValidationCheck("sudo_dropin", True, 2,
+                          "Rule is in a /etc/sudoers.d/ drop-in"))
             total += 2
         else:
-            checks.append(ValidationCheck("sudo_access", False, 0,
-                          "Sudo access verification failed", max_points=2))
+            checks.append(ValidationCheck("sudo_dropin", False, 0,
+                          "Rule not found under /etc/sudoers.d/ — drop-ins "
+                          "are safer than editing /etc/sudoers", max_points=2))
+
+        # Check 4: whole sudoers config parses (2 pts)
+        syntax = execute_safe(["visudo", "-c"])
+        if syntax.success:
+            checks.append(ValidationCheck("sudo_syntax", True, 2,
+                          "sudoers syntax is valid (visudo -c)"))
+            total += 2
+        else:
+            checks.append(ValidationCheck("sudo_syntax", False, 0,
+                          "visudo -c reports a syntax error", max_points=2))
 
         passed = total >= (self.points * 0.7)
         return ValidationResult(self.id, passed, total, self.points, checks)

--- a/tests/unit/test_boot_rescue.py
+++ b/tests/unit/test_boot_rescue.py
@@ -1,0 +1,194 @@
+"""Boot-rescue lab: scenario lifecycle, validation and escape hatch, with the
+SSH layer faked so no network is touched."""
+
+import json
+
+import pytest
+
+from core import lab_machine, boot_rescue
+
+
+@pytest.fixture
+def state_file(tmp_path, monkeypatch):
+    path = tmp_path / 'boot_rescue.json'
+    monkeypatch.setattr(boot_rescue, 'STATE_PATH', str(path))
+    monkeypatch.setattr(lab_machine, 'STATE_DIR', str(tmp_path))
+    return path
+
+
+@pytest.fixture
+def linked(monkeypatch):
+    monkeypatch.setattr(lab_machine, 'load_config',
+                        lambda: {'host': 'labbox', 'user': 'root'})
+    monkeypatch.setattr(lab_machine, 'key_works', lambda **kw: True)
+
+
+class FakeRemote:
+    """Stands in for lab_machine.read_values; records scripts, plays a
+    machine whose root hash/boot id can be mutated by the test."""
+
+    def __init__(self, monkeypatch):
+        self.hash = '$6$orig$hash'
+        self.boot_id = 'boot-1'
+        self.ctx = 'system_u:object_r:shadow_t:s0'
+        self.sys_state = 'running'
+        self.relabel = 'no'
+        self.rdbreak = '0'
+        self.scripts = []
+        monkeypatch.setattr(lab_machine, 'read_values', self)
+
+    def __call__(self, script, host=None, user=None, timeout=120):
+        self.scripts.append(script)
+        if 'chpasswd' in script:
+            self.hash = '$6$planted$hash'
+            return True, {'NEW_HASH': self.hash}, ''
+        if 'usermod -p' in script:
+            self.hash = script.split("'")[1]
+            return True, {'RESTORED': 'yes'}, ''
+        return True, {
+            'BOOT_ID': self.boot_id,
+            'ROOT_HASH': self.hash,
+            'SHADOW_CTX': self.ctx,
+            'SYS_STATE': self.sys_state,
+            'RELABEL_PENDING': self.relabel,
+            'RDBREAK_BOOTS': self.rdbreak,
+        }, ''
+
+
+class TestPasswordGeneration:
+    def test_console_safe_alphabet(self):
+        for _ in range(50):
+            pw = boot_rescue.generate_password()
+            assert len(pw) == 10
+            assert not set(pw) & set("l1o0'\"\\$`| ;&<>")
+
+
+class TestStart:
+    def test_refuses_without_link(self, state_file, monkeypatch):
+        monkeypatch.setattr(lab_machine, 'load_config', lambda: None)
+        ok, msg = boot_rescue.start()
+        assert not ok and 'No lab machine linked' in msg
+
+    def test_refuses_without_working_key(self, state_file, monkeypatch):
+        monkeypatch.setattr(lab_machine, 'load_config',
+                            lambda: {'host': 'labbox', 'user': 'root'})
+        monkeypatch.setattr(lab_machine, 'key_works', lambda **kw: False)
+        ok, msg = boot_rescue.start()
+        assert not ok and 'Key-based SSH' in msg
+
+    def test_success_records_original_and_planted_hash(self, state_file, linked,
+                                                       monkeypatch):
+        remote = FakeRemote(monkeypatch)
+        ok, msg = boot_rescue.start()
+        assert ok and 'labbox' in msg
+        state = json.loads(state_file.read_text())
+        assert state['original_hash'] == '$6$orig$hash'
+        assert state['planted_hash'] == '$6$planted$hash'
+        assert state['planted_password']
+        # The secret travels inside the script (stdin), and the scramble ran.
+        assert any(state['planted_password'] in s for s in remote.scripts)
+
+    def test_refuses_double_start(self, state_file, linked, monkeypatch):
+        FakeRemote(monkeypatch)
+        assert boot_rescue.start()[0]
+        ok, msg = boot_rescue.start()
+        assert not ok and 'already active' in msg
+
+    def test_state_file_is_root_only(self, state_file, linked, monkeypatch):
+        FakeRemote(monkeypatch)
+        boot_rescue.start()
+        assert (state_file.stat().st_mode & 0o777) == 0o600
+
+
+class TestValidate:
+    def _start(self, monkeypatch):
+        remote = FakeRemote(monkeypatch)
+        assert boot_rescue.start()[0]
+        return remote
+
+    def test_no_scenario(self, state_file):
+        checks, method, err = boot_rescue.validate()
+        assert checks is None and 'No rescue scenario' in err
+
+    def test_unrecovered_machine_fails(self, state_file, linked, monkeypatch):
+        self._start(monkeypatch)
+        checks, method, err = boot_rescue.validate()
+        results = dict((n, p) for n, p, _ in checks)
+        assert results['password_changed'] is False
+        assert results['rebooted'] is False
+
+    def test_full_recovery_passes(self, state_file, linked, monkeypatch):
+        remote = self._start(monkeypatch)
+        remote.hash = '$6$candidate$new'
+        remote.boot_id = 'boot-2'
+        checks, method, err = boot_rescue.validate()
+        assert err is None
+        assert all(p is not False for _, p, _ in checks)
+        assert 'init=/bin/bash' in method  # no rd.break boot seen
+
+    def test_rdbreak_method_detected(self, state_file, linked, monkeypatch):
+        remote = self._start(monkeypatch)
+        remote.hash = '$6$candidate$new'
+        remote.boot_id = 'boot-2'
+        remote.rdbreak = '1'
+        _, method, _ = boot_rescue.validate()
+        assert method.startswith('rd.break')
+
+    def test_mislabeled_shadow_fails_selinux_check(self, state_file, linked,
+                                                   monkeypatch):
+        remote = self._start(monkeypatch)
+        remote.hash = '$6$candidate$new'
+        remote.boot_id = 'boot-2'
+        remote.ctx = 'system_u:object_r:etc_t:s0'
+        checks, _, _ = boot_rescue.validate()
+        results = dict((n, p) for n, p, _ in checks)
+        assert results['selinux_context'] is False
+
+    def test_pending_autorelabel_is_note_not_failure(self, state_file, linked,
+                                                     monkeypatch):
+        remote = self._start(monkeypatch)
+        remote.hash = '$6$candidate$new'
+        remote.boot_id = 'boot-2'
+        remote.relabel = 'yes'
+        checks, _, _ = boot_rescue.validate()
+        results = dict((n, p) for n, p, _ in checks)
+        assert results['relabel_pending'] is None
+
+
+class TestGiveUp:
+    def test_reveals_and_restores_original_hash(self, state_file, linked,
+                                                monkeypatch):
+        remote = FakeRemote(monkeypatch)
+        assert boot_rescue.start()[0]
+        planted = json.loads(state_file.read_text())['planted_password']
+        ok, msg = boot_rescue.give_up(restore=True)
+        assert ok and planted in msg
+        assert remote.hash == '$6$orig$hash'      # restored exactly
+        assert not boot_rescue.is_active()
+
+    def test_reset_hook_noop_without_scenario(self, state_file):
+        boot_rescue.reset_for_machine_reset()     # must not raise
+
+
+class TestReadValues:
+    def test_parses_only_key_value_lines(self, monkeypatch):
+        monkeypatch.setattr(lab_machine, 'run', lambda *a, **kw:
+                            (0, 'noise\nBOOT_ID=abc\nnot=this\nX Y=Z\nCTX=a b\n'))
+        ok, values, _ = lab_machine.read_values('x', host='h')
+        assert ok
+        assert values == {'BOOT_ID': 'abc', 'CTX': 'a b'}
+
+    def test_run_without_link_is_soft_error(self, monkeypatch):
+        monkeypatch.setattr(lab_machine, 'load_config', lambda: None)
+        rc, out = lab_machine.run('true')
+        assert rc is None and 'no lab machine linked' in out
+
+
+class TestWalkthrough:
+    def test_covers_both_methods_and_sysrq(self):
+        text = boot_rescue.WALKTHROUGH
+        assert 'rd.break' in text
+        assert 'init=/bin/bash' in text
+        assert 'echo b > /proc/sysrq-trigger' in text
+        assert 'autorelabel' in text
+        assert 'Give root password for maintenance' in text

--- a/tests/unit/test_full_reset.py
+++ b/tests/unit/test_full_reset.py
@@ -31,6 +31,10 @@ class TestPracticeGroupMatching:
 
 class TestRepoKeepList:
     def test_system_repos_are_kept(self, tmp_path, monkeypatch):
+        # rhel-baseos.repo is REMOVABLE despite the protected rhel- prefix:
+        # it's a name the dual-repo task generates (real RHEL repos only live
+        # in redhat.repo), and treating it as a system repo made it survive
+        # every reset.
         repo_dir = tmp_path
         for f in ('redhat.repo', 'rhel-baseos.repo', 'redhat-extra.repo',
                   'docker-ce.repo', 'epel.repo', 'notes.txt'):
@@ -40,7 +44,7 @@ class TestRepoKeepList:
         monkeypatch.setattr(fr.os, 'listdir',
                             lambda d: real_listdir(repo_dir) if d == '/etc/yum.repos.d' else real_listdir(d))
         found = {fr.os.path.basename(p) for p in fr.list_nondefault_repos()}
-        assert found == {'docker-ce.repo', 'epel.repo'}
+        assert found == {'docker-ce.repo', 'epel.repo', 'rhel-baseos.repo'}
 
 
 class TestSystemSwapGuard:

--- a/tests/unit/test_lvm_extents.py
+++ b/tests/unit/test_lvm_extents.py
@@ -1,0 +1,78 @@
+"""Extent-based LVM tasks: generation invariants and extent math."""
+
+import pytest
+
+import tasks.lvm as lvm
+from tasks.lvm import LVMExtentWorkflowTask, CreateLVTask, ExtendLVTask
+
+
+class _Result:
+    def __init__(self, stdout, success=True):
+        self.stdout = stdout
+        self.success = success
+
+
+class TestExtentWorkflowGeneration:
+    def test_all_combos_fit_practice_disk_and_xfs_minimum(self):
+        for pe, count in LVMExtentWorkflowTask._COMBOS:
+            total = pe * count
+            assert total == 320, f"combo ({pe},{count}) must total 320MiB"
+            assert total > 300  # RHEL 10 mkfs.xfs minimum
+            assert total < 480  # fits a 500MB loop disk incl. VG overhead
+
+    def test_description_states_pe_size_and_extent_count(self):
+        t = LVMExtentWorkflowTask().generate(device='/dev/loop9', combo=(16, 20))
+        assert '16 MiB' in t.description
+        assert '20 extents' in t.description
+        assert t.pe_mib == 16 and t.extents == 20
+
+    def test_hints_do_not_leak_beyond_commands(self):
+        t = LVMExtentWorkflowTask().generate(device='/dev/loop9', combo=(8, 40))
+        assert any('vgcreate -s 8M' in h for h in t.hints)
+        assert any('lvcreate -l 40' in h for h in t.hints)
+
+
+class TestExtentMath:
+    def test_vg_extent_size_parses_vgs_output(self, monkeypatch):
+        monkeypatch.setattr(lvm, 'execute_safe',
+                            lambda cmd: _Result('  16.00\n'))
+        assert lvm._vg_extent_size_mib('vg_x') == 16.0
+
+    def test_lv_extent_count_divides_size_by_pe(self, monkeypatch):
+        def fake(cmd):
+            if 'lv_size' in cmd:
+                return _Result('  320.00\n')
+            return _Result('  16.00\n')
+        monkeypatch.setattr(lvm, 'execute_safe', fake)
+        assert lvm._lv_extent_count('vg_x', 'lv_x') == 20
+
+    def test_missing_vg_returns_none(self, monkeypatch):
+        monkeypatch.setattr(lvm, 'execute_safe',
+                            lambda cmd: _Result('', success=False))
+        assert lvm._vg_extent_size_mib('vg_gone') is None
+        assert lvm._lv_extent_count('vg_gone', 'lv_gone') is None
+
+
+class TestExtentVariantsOfExistingTasks:
+    def test_create_lv_extent_phrasing_sets_consistent_size(self):
+        t = CreateLVTask().generate(use_extents=True, device='/dev/loop9')
+        assert t.pe_mib in (8, 16)
+        assert t.lv_size_mb == t.pe_mib * t.extents
+        assert f'{t.extents} extents' in t.description
+
+    def test_create_lv_classic_phrasing_has_no_pe(self):
+        t = CreateLVTask().generate(use_extents=False, device='/dev/loop9')
+        assert t.pe_mib is None
+        assert 'extent' not in t.description
+
+    def test_extend_lv_extent_phrasing_math(self):
+        t = ExtendLVTask().generate(use_extents=True, device='/dev/loop9')
+        assert t.pe_mib == 16
+        assert t.initial_mb == 96          # 6 extents x 16MiB
+        assert t.target_mb == t.initial_mb + t.extend_by_mb
+        assert 'extents' in t.description
+
+    def test_extend_lv_classic_unchanged(self):
+        t = ExtendLVTask().generate(use_extents=False, device='/dev/loop9')
+        assert t.pe_mib is None
+        assert t.initial_mb == 100

--- a/tests/unit/test_remote_tasks.py
+++ b/tests/unit/test_remote_tasks.py
@@ -1,0 +1,152 @@
+"""Remote (second-machine) tasks: registry gating, validation over the faked
+SSH layer, and restore records."""
+
+import pytest
+
+from core import lab_machine
+import tasks.troubleshooting as ts
+from tasks.registry import TaskRegistry
+from tasks.remote import RemoteHostnameTask, RemoteUserTask, RemoteTimezoneTask
+
+
+@pytest.fixture
+def fault_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(ts, 'FAULT_STATE_FILE', str(tmp_path / 'fault.json'))
+    return tmp_path / 'fault.json'
+
+
+@pytest.fixture
+def linked(monkeypatch):
+    monkeypatch.setattr(lab_machine, 'load_config',
+                        lambda: {'host': 'labbox', 'user': 'root'})
+
+
+class FakeRemote:
+    def __init__(self, monkeypatch, values=None, ok=True):
+        self.values = values or {}
+        self.ok = ok
+        self.run_scripts = []
+        monkeypatch.setattr(lab_machine, 'read_values',
+                            lambda script, **kw: (self.ok, self.values, ''))
+        monkeypatch.setattr(lab_machine, 'run',
+                            lambda script, **kw: (self.run_scripts.append(script)
+                                                  or (0, '')))
+
+
+class TestRegistryGating:
+    def test_remote_tasks_hidden_without_link(self, monkeypatch):
+        monkeypatch.setattr(lab_machine, 'get_host', lambda: None)
+        monkeypatch.setitem(TaskRegistry._tasks, '_test_remote_only',
+                            [RemoteHostnameTask])
+        assert TaskRegistry.get_random_task(category='_test_remote_only') is None
+
+    def test_remote_tasks_offered_when_linked(self, monkeypatch, linked):
+        monkeypatch.setattr(lab_machine, 'get_host', lambda: 'labbox')
+        monkeypatch.setitem(TaskRegistry._tasks, '_test_remote_only',
+                            [RemoteHostnameTask])
+        task = TaskRegistry.get_random_task(category='_test_remote_only')
+        assert task is not None and task.id == 'remote_hostname_001'
+
+    def test_all_remote_tasks_declare_the_flag(self):
+        for cls in (RemoteHostnameTask, RemoteUserTask, RemoteTimezoneTask):
+            assert cls.requires_lab_machine is True
+            assert cls.has_fault_injection is True
+
+
+class TestDescriptions:
+    def test_descriptions_name_the_lab_machine(self, monkeypatch, linked):
+        monkeypatch.setattr(lab_machine, 'get_host', lambda: '192.168.1.50')
+        for cls in (RemoteHostnameTask, RemoteUserTask, RemoteTimezoneTask):
+            t = cls().generate()
+            assert 'lab machine (192.168.1.50)' in t.description
+
+
+class TestHostnameTask:
+    def test_inject_records_original_and_restore_replays_it(
+            self, fault_file, linked, monkeypatch):
+        remote = FakeRemote(monkeypatch, {'STATIC': 'old.example.com'})
+        t = RemoteHostnameTask().generate(hostname='node2.lab.example.com')
+        ok, _ = t.inject_fault()
+        assert ok
+        state = ts.load_fault_state(t.id)
+        script = state['restore_info']['remote_restore_script']
+        assert "hostnamectl set-hostname 'old.example.com'" in script
+        ok, _ = t.restore_fault()
+        assert ok
+        assert any('old.example.com' in s for s in remote.run_scripts)
+        assert ts.load_fault_state(t.id) is None
+
+    def test_validate_pass_and_fail(self, linked, monkeypatch):
+        t = RemoteHostnameTask().generate(hostname='node2.lab.example.com')
+        FakeRemote(monkeypatch, {'STATIC': 'node2.lab.example.com'})
+        assert t.validate().passed
+        FakeRemote(monkeypatch, {'STATIC': 'wrong.example.com'})
+        assert not t.validate().passed
+
+    def test_unreachable_machine_fails_with_clear_message(self, linked,
+                                                          monkeypatch):
+        t = RemoteHostnameTask().generate(hostname='node2.lab.example.com')
+        FakeRemote(monkeypatch, ok=False)
+        result = t.validate()
+        assert not result.passed
+        assert 'Cannot reach the lab machine' in result.checks[0].message
+
+    def test_inject_skips_cleanly_when_unreachable(self, fault_file, linked,
+                                                   monkeypatch):
+        FakeRemote(monkeypatch, ok=False)
+        t = RemoteHostnameTask().generate()
+        ok, msg = t.inject_fault()
+        assert not ok and 'unreachable' in msg
+
+
+class TestUserTask:
+    def test_full_credit(self, linked, monkeypatch):
+        t = RemoteUserTask().generate(username='rmuser42', uid=3100, group='wheel')
+        FakeRemote(monkeypatch, {'UID': '3100',
+                                 'GROUPS': 'rmuser42 wheel',
+                                 'HASH': '$6$salt$hash'})
+        result = t.validate()
+        assert result.passed and result.score == 10
+
+    def test_wrong_uid_and_no_password(self, linked, monkeypatch):
+        t = RemoteUserTask().generate(username='rmuser42', uid=3100, group='wheel')
+        FakeRemote(monkeypatch, {'UID': '4000',
+                                 'GROUPS': 'rmuser42',
+                                 'HASH': '!!'})
+        result = t.validate()
+        assert not result.passed and result.score == 0
+
+    def test_restore_record_deletes_user(self, fault_file, linked, monkeypatch):
+        FakeRemote(monkeypatch, {'UP': 'yes'})
+        t = RemoteUserTask().generate(username='rmuser42', uid=3100)
+        assert t.inject_fault()[0]
+        script = ts.load_fault_state(t.id)['restore_info']['remote_restore_script']
+        assert "userdel -r 'rmuser42'" in script
+
+
+class TestTimezoneTask:
+    def test_validate(self, linked, monkeypatch):
+        t = RemoteTimezoneTask().generate(timezone='Europe/Vienna')
+        FakeRemote(monkeypatch, {'TZ': 'Europe/Vienna'})
+        assert t.validate().passed
+        FakeRemote(monkeypatch, {'TZ': 'UTC'})
+        assert not t.validate().passed
+
+    def test_inject_records_original_zone(self, fault_file, linked, monkeypatch):
+        FakeRemote(monkeypatch, {'TZ': 'America/New_York'})
+        t = RemoteTimezoneTask().generate(timezone='Asia/Kolkata')
+        assert t.inject_fault()[0]
+        script = ts.load_fault_state(t.id)['restore_info']['remote_restore_script']
+        assert "timedatectl set-timezone 'America/New_York'" in script
+
+
+class TestCrashRecoveryDispatch:
+    def test_restore_any_active_fault_replays_remote_records(
+            self, fault_file, linked, monkeypatch):
+        remote = FakeRemote(monkeypatch, {'STATIC': 'orig.example.com'})
+        t = RemoteHostnameTask().generate()
+        assert t.inject_fault()[0]
+        ok, msg = ts.restore_any_active_fault()
+        assert ok
+        assert any('orig.example.com' in s for s in remote.run_scripts)
+        assert 'labbox' in msg


### PR DESCRIPTION
Adds the two features from the real-exam debrief plus two-node task support.

## LVM extents
- New `LVMExtentWorkflowTask`: create a VG with an explicit physical extent size (`vgcreate -s`), an LV sized in extents (`lvcreate -l`), format + persistent mount. Validated on the actual PE size and extent count (verified end-to-end on real LVM: 20/20).
- `CreateLVTask`/`ExtendLVTask` now phrase sizes in extents ~40% of the time, with the scratch VG built at the stated PE size.
- Combos total 320MiB so they fit 500MB practice disks and clear RHEL 10's `mkfs.xfs` 300MB minimum.

## Boot Rescue Lab (second machine)
- **Setup → 7 Link second lab machine**: plants this box's SSH key via `ssh-copy-id` — the only footprint, no agent. Adopts an existing NFS-server config as default host.
- **Main menu → R**: the simulator sets a random root password on the lab machine; you recover it at that machine's console. Built-in walkthrough covers **both** `rd.break` and `init=/bin/bash` (incl. the no-systemd reboot: `sync; echo b > /proc/sysrq-trigger`), and notes the password-gated maintenance shell some builds show for rd.break.
- Validation over the retained key: hash changed, machine rebooted, `/etc/shadow` SELinux label correct, system up; method detection from journal kernel cmdlines is informational only. Optional proof: type your new password, it's checked against the live hash on the machine (secret travels only over SSH stdin).
- Safety: refuses to start unless key SSH works; original hash kept locally (0600); **Give up** and **Reset Machine** restore it exactly.

## Remote tasks (two-node exams)
- `requires_lab_machine` flag + registry gating (tasks only offered when linked).
- Generic `remote_restore_script` records replayed by session teardown / crash recovery / Reset Machine.
- First three remote tasks: static hostname, user with UID+group+password, timezone — registered into their natural categories so exams mix local and remote work like the real two-node exam.

Stacked on #67. Tests: 295 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fa3vkatEjPUKBufbsjUinT