### PR TITLE
Auto-resume Claude issue runs interrupted by the 5-hour usage limit

### DIFF
--- a/.github/scripts/claude_usage_limit.py
+++ b/.github/scripts/claude_usage_limit.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Detect a Claude Code subscription usage-limit stop in an execution log.
+
+Usage:  claude_usage_limit.py <execution_file>
+
+Reads the claude-code-action execution file (a JSON transcript, but treated
+as plain text so upstream format changes don't break detection) and appends
+GitHub Actions outputs to $GITHUB_OUTPUT:
+
+    rate_limited=true|false
+    reset_epoch=<unix seconds, UTC>            (only when rate_limited)
+    reset_human=<e.g. 2026-07-07 17:00 SAST>   (only when rate_limited)
+
+Known message shapes handled:
+  * "Claude AI usage limit reached|1751890000"          (epoch after a pipe)
+  * "5-hour limit reached ∙ resets 3pm"
+  * "... usage limit reached ... resets at 3:30pm (Africa/Johannesburg)"
+
+If a limit is detected but no reset time can be parsed, fall back to
+now + 30 minutes: the scheduled resumer will retry, hit the limit again if
+it is still active, and re-persist a fresh state comment. Self-correcting.
+"""
+
+import os
+import re
+import sys
+import time
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+# Timezone assumed when the CLI prints a bare wall-clock time with no zone.
+DEFAULT_TZ = os.environ.get("CLAUDE_RESET_TZ", "Africa/Johannesburg")
+
+# A grace margin so we never resume seconds *before* the window actually opens.
+MARGIN_SECONDS = 120
+
+LIMIT_RE = re.compile(
+    r"usage limit reached|5-hour limit reached|limit will reset", re.IGNORECASE
+)
+EPOCH_RE = re.compile(r"limit reached\|(\d{9,11})")
+WALL_RE = re.compile(
+    r"resets?\s+(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)(?:\s*\(([^)]+)\))?",
+    re.IGNORECASE,
+)
+
+
+def emit(**outputs):
+    with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+        for key, value in outputs.items():
+            fh.write(f"{key}={value}\n")
+
+
+def parse_wall_time(match, now_ts):
+    hour = int(match.group(1)) % 12
+    if match.group(3).lower() == "pm":
+        hour += 12
+    minute = int(match.group(2) or 0)
+    tz_name = (match.group(4) or DEFAULT_TZ).strip()
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        tz = ZoneInfo(DEFAULT_TZ)
+    now = datetime.fromtimestamp(now_ts, tz)
+    candidate = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if candidate <= now:
+        candidate += timedelta(days=1)
+    return int(candidate.timestamp())
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else ""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+    except OSError:
+        text = ""
+
+    if not LIMIT_RE.search(text):
+        emit(rate_limited="false")
+        print("No usage-limit message found.")
+        return
+
+    now_ts = time.time()
+    epoch = None
+
+    epoch_match = EPOCH_RE.search(text)
+    if epoch_match:
+        epoch = int(epoch_match.group(1))
+    else:
+        wall_match = WALL_RE.search(text)
+        if wall_match:
+            epoch = parse_wall_time(wall_match, now_ts)
+
+    if epoch is None or epoch <= now_ts:
+        epoch = int(now_ts) + 30 * 60
+        print("Limit detected but reset time unparseable; retrying in 30 min.")
+
+    epoch += MARGIN_SECONDS
+    human = datetime.fromtimestamp(epoch, ZoneInfo(DEFAULT_TZ)).strftime(
+        "%Y-%m-%d %H:%M %Z"
+    )
+    emit(rate_limited="true", reset_epoch=str(epoch), reset_human=human)
+    print(f"Usage limit detected; window resets at {human} (epoch {epoch}).")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -18,12 +18,23 @@ name: Claude issue worker
 #   * CLAUDE_CODE_OAUTH_TOKEN  — from `claude setup-token` (uses your Claude
 #     subscription), OR
 #   * ANTHROPIC_API_KEY        — pay-as-you-go Anthropic API key.
+#
+# The actual Claude run lives in the reusable claude-worker.yml, which also
+# handles the subscription's 5-hour usage limit: on a limit hit it saves
+# progress and exits green, and claude-resume.yml (scheduled) continues the
+# work after the limit window resets.
 
 on:
   issues:
     types: [labeled]
   issue_comment:
     types: [created]
+
+# Serialize all Claude runs (fresh + resumes) — they share one subscription
+# budget, so parallel runs would just trip the limit for each other.
+concurrency:
+  group: claude-work
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -43,46 +54,7 @@ jobs:
         (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude') ||
         (github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.comment.body, '@claude'))
       )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Work the issue with Claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: >-
-            --allowedTools "Bash,Read,Edit,Write,Grep,Glob"
-            --max-turns 80
-          prompt: |
-            You are working GitHub issue #${{ github.event.issue.number }} in
-            this repository — the RHCSA EX200 v10 exam simulator (Python,
-            standard library only, tests via `python3 -m pytest -q`).
-
-            Steps:
-            1. Read the issue and any discussion:
-                 gh issue view ${{ github.event.issue.number }} --comments
-            2. Understand what is being asked. If it is a bug, reproduce/locate
-               it; if it is a feature, find the right module (core/, tasks/,
-               validators/, utils/). Follow the conventions already in the file
-               you are editing.
-            3. Implement the smallest correct change that satisfies the issue.
-               Do not make unrelated changes.
-            4. Add or update tests under tests/ to cover the change, then run
-               `python3 -m pytest -q` and make sure the whole suite passes.
-            5. Create a branch  claude/issue-${{ github.event.issue.number }},
-               commit, and open a PR whose body starts with
-               "Closes #${{ github.event.issue.number }}" and explains what you
-               changed and why, using `gh pr create`.
-            6. Post a short comment on the issue linking the PR:
-                 gh issue comment ${{ github.event.issue.number }} --body "..."
-
-            If the issue is unclear, under-specified, or you are not confident a
-            change is correct, do NOT open a speculative PR — instead post a
-            comment asking the specific clarifying question(s) and stop.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/claude-worker.yml
+    with:
+      issue_number: ${{ github.event.issue.number }}
+    secrets: inherit

--- a/.github/workflows/claude-resume.yml
+++ b/.github/workflows/claude-resume.yml
@@ -1,0 +1,90 @@
+name: Claude resume scheduler
+
+# Companion to claude-issue.yml. When a Claude run hits the subscription's
+# 5-hour usage limit, claude-worker.yml saves its progress, posts a hidden
+# state comment on the issue, labels it  claude-resume-pending , and exits
+# green (instead of burning runner minutes sleeping through the reset window —
+# GitHub-hosted jobs are capped at 6 hours anyway, and every sleeping minute
+# bills).
+#
+# This workflow polls every 15 minutes: if a pending issue's stored reset
+# epoch has passed, it re-runs the worker with a "resume" prompt that points
+# Claude at the saved WIP branch. It resumes at most ONE issue per tick —
+# parallel runs would share the same usage budget and re-trip the limit.
+#
+# The scan uses only the GITHUB_TOKEN. Note we run the Claude action directly
+# here rather than re-adding the `claude` label, because events created with
+# GITHUB_TOKEN deliberately do not trigger other workflows.
+#
+# Must live on the DEFAULT branch for the schedule to fire.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: claude-work
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    outputs:
+      found: ${{ steps.scan.outputs.found }}
+      issue: ${{ steps.scan.outputs.issue }}
+      wip_branch: ${{ steps.scan.outputs.wip_branch }}
+      attempts: ${{ steps.scan.outputs.attempts }}
+    steps:
+      - name: Find a pending issue whose usage-limit window has reset
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          now=$(date +%s)
+
+          for n in $(gh issue list -R "$REPO" --label claude-resume-pending \
+                       --state open --json number --jq 'sort_by(.number) | .[].number'); do
+            # Latest hidden state comment wins (each pause posts a fresh one).
+            state=$(gh api "repos/$REPO/issues/$n/comments" --paginate \
+                      --jq '[.[].body | try (capture("<!-- claude-resume-state (?<j>\\{.+?\\}) -->").j)] | last // empty')
+            if [ -z "$state" ]; then
+              echo "Issue #$n is labeled but has no state comment; skipping."
+              continue
+            fi
+            reset=$(jq -r '.reset_epoch' <<<"$state")
+            if [ "$now" -lt "$reset" ]; then
+              echo "Issue #$n resets at epoch $reset (now $now); not yet."
+              continue
+            fi
+            {
+              echo "found=true"
+              echo "issue=$n"
+              echo "wip_branch=$(jq -r '.wip_branch // ""' <<<"$state")"
+              echo "attempts=$(jq -r '.attempts // 0' <<<"$state")"
+            } >> "$GITHUB_OUTPUT"
+            echo "Resuming issue #$n."
+            break
+          done
+
+  resume:
+    needs: scan
+    if: needs.scan.outputs.found == 'true'
+    uses: ./.github/workflows/claude-worker.yml
+    with:
+      issue_number: ${{ needs.scan.outputs.issue }}
+      resume: true
+      wip_branch: ${{ needs.scan.outputs.wip_branch }}
+      attempts: ${{ needs.scan.outputs.attempts }}
+    secrets: inherit

--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -1,0 +1,191 @@
+name: Claude worker (reusable)
+
+# Shared "run Claude on an issue" job used by two callers:
+#   * claude-issue.yml  — fresh work, triggered by the owner labeling/mentioning
+#   * claude-resume.yml — scheduled resumer that continues runs interrupted by
+#                         the Claude subscription's 5-hour usage limit
+#
+# Usage-limit resilience: the Claude step runs with continue-on-error. If it
+# fails, .github/scripts/claude_usage_limit.py greps the execution log for the
+# "usage limit reached ... resets ..." message. On a limit hit the job:
+#   1. commits/pushes any uncommitted or unpushed work to claude/issue-N-wip,
+#   2. posts a hidden machine-readable state comment on the issue
+#      (<!-- claude-resume-state {...} -->) with the reset time as a UTC epoch,
+#   3. adds the  claude-resume-pending  label, and exits GREEN.
+# The scheduled resumer picks it up once the stored reset epoch has passed.
+# Any other failure stays a real, red failure.
+
+on:
+  workflow_call:
+    inputs:
+      issue_number:
+        required: true
+        type: string
+      resume:
+        type: boolean
+        default: false
+      wip_branch:
+        type: string
+        default: ''
+      attempts:
+        description: How many usage-limit interruptions this issue has already had
+        type: string
+        default: '0'
+
+env:
+  MAX_ATTEMPTS: 6
+
+jobs:
+  work:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      # Remove the pending label up front so the next scheduler tick doesn't
+      # start a duplicate resume while this one is still running. If we hit
+      # the limit again, the save step below re-adds it with fresh state.
+      - name: Clear pending-resume label
+        if: inputs.resume
+        run: gh issue edit "${{ inputs.issue_number }}" --remove-label claude-resume-pending || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Written by a step (not an inline ${{ }} ternary) because GitHub
+      # expression string literals don't reliably support newlines.
+      - name: Compose resume preamble for the prompt
+        id: preamble
+        env:
+          RESUME: ${{ inputs.resume }}
+          WIP: ${{ inputs.wip_branch }}
+          ATTEMPTS: ${{ inputs.attempts }}
+        run: |
+          {
+            echo "text<<PREAMBLE_EOF"
+            if [ "$RESUME" = "true" ]; then
+              echo "RESUMING AN INTERRUPTED RUN: an earlier run on this issue was stopped by the Claude usage limit (interruption $ATTEMPTS)."
+              if [ -n "$WIP" ]; then
+                echo "Partial work was saved on branch \`$WIP\` — start with \`git fetch origin $WIP && git checkout $WIP\`, then review \`git log\` and \`git diff origin/master...HEAD\` to see the progress so far."
+              else
+                echo "No work-in-progress branch was saved; check for existing claude/issue-* branches with \`git branch -r\`."
+              fi
+              echo "Re-read the issue comments to see what was already done or posted. Verify what is complete, do NOT redo it, and continue from where the previous run stopped."
+              echo ""
+            fi
+            echo "PREAMBLE_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Work the issue with Claude
+        id: claude
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: >-
+            --allowedTools "Bash,Read,Edit,Write,Grep,Glob"
+            --max-turns 80
+          prompt: |
+            ${{ steps.preamble.outputs.text }}You are working GitHub issue #${{ inputs.issue_number }} in
+            this repository — the RHCSA EX200 v10 exam simulator (Python,
+            standard library only, tests via `python3 -m pytest -q`).
+
+            Steps:
+            1. Read the issue and any discussion:
+                 gh issue view ${{ inputs.issue_number }} --comments
+            2. Understand what is being asked. If it is a bug, reproduce/locate
+               it; if it is a feature, find the right module (core/, tasks/,
+               validators/, utils/). Follow the conventions already in the file
+               you are editing.
+            3. Implement the smallest correct change that satisfies the issue.
+               Do not make unrelated changes.
+            4. Add or update tests under tests/ to cover the change, then run
+               `python3 -m pytest -q` and make sure the whole suite passes.
+            5. Create a branch  claude/issue-${{ inputs.issue_number }},
+               commit, and open a PR whose body starts with
+               "Closes #${{ inputs.issue_number }}" and explains what you
+               changed and why, using `gh pr create`.
+            6. Post a short comment on the issue linking the PR:
+                 gh issue comment ${{ inputs.issue_number }} --body "..."
+
+            If the issue is unclear, under-specified, or you are not confident a
+            change is correct, do NOT open a speculative PR — instead post a
+            comment asking the specific clarifying question(s) and stop.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check whether the failure was a usage-limit stop
+        id: limit
+        if: steps.claude.outcome == 'failure'
+        run: python3 .github/scripts/claude_usage_limit.py "${{ steps.claude.outputs.execution_file }}"
+
+      - name: Save progress and schedule auto-resume
+        if: steps.limit.outputs.rate_limited == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ inputs.issue_number }}
+          ATTEMPTS: ${{ inputs.attempts }}
+          RESET_EPOCH: ${{ steps.limit.outputs.reset_epoch }}
+          RESET_HUMAN: ${{ steps.limit.outputs.reset_human }}
+          DEFAULT_BRANCH: ${{ github.ref_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          attempts=$(( ATTEMPTS + 1 ))
+
+          if [ "$attempts" -gt "$MAX_ATTEMPTS" ]; then
+            gh issue comment "$ISSUE" --body "🛑 Claude hit the usage limit ${MAX_ATTEMPTS}+ times on this issue; giving up on auto-resume. Re-add the \`claude\` label to start over, or the \`claude-resume-pending\` label to keep the saved state. ($RUN_URL)"
+            exit 1
+          fi
+
+          # Persist whatever Claude got done: commit uncommitted changes and
+          # push any local-only commits to a WIP branch.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          wip=""
+          if [ -n "$(git status --porcelain)" ] || ! git merge-base --is-ancestor HEAD "origin/$DEFAULT_BRANCH"; then
+            cur=$(git branch --show-current || true)
+            if [ -z "$cur" ] || [ "$cur" = "$DEFAULT_BRANCH" ]; then
+              cur="claude/issue-${ISSUE}-wip"
+              git checkout -B "$cur"
+            fi
+            git add -A
+            git diff --cached --quiet || git commit -m "WIP: issue #${ISSUE} (auto-saved at usage-limit pause)"
+            git push -f origin "$cur"
+            wip="$cur"
+          fi
+
+          state=$(printf '{"issue":%s,"reset_epoch":%s,"wip_branch":"%s","attempts":%s}' \
+                  "$ISSUE" "$RESET_EPOCH" "$wip" "$attempts")
+          {
+            echo "<!-- claude-resume-state $state -->"
+            echo "⏸️ Claude hit the subscription usage limit while working this issue (interruption #${attempts})."
+            echo ""
+            echo "Auto-resume is scheduled for after **${RESET_HUMAN}** — the resume workflow checks every 15 minutes."
+            if [ -n "$wip" ]; then
+              echo "Partial work was saved on branch \`$wip\`."
+            fi
+            echo ""
+            echo "_Interrupted run: ${RUN_URL}_"
+          } > /tmp/resume-comment.md
+          gh issue comment "$ISSUE" --body-file /tmp/resume-comment.md
+
+          gh label create claude-resume-pending \
+            --description "Claude run paused by usage limit; auto-resumes after reset" \
+            --color FBCA04 || true
+          gh issue edit "$ISSUE" --add-label claude-resume-pending
+          echo "Paused. Resume scheduled after $RESET_HUMAN."
+
+      - name: Fail on real (non-limit) errors
+        if: steps.claude.outcome == 'failure' && steps.limit.outputs.rate_limited != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if ${{ inputs.resume }}; then
+            gh issue comment "${{ inputs.issue_number }}" --body "❌ Auto-resume failed for a reason other than the usage limit — see $RUN_URL. Re-add the \`claude-resume-pending\` label to retry with the saved state, or \`claude\` to start over." || true
+          fi
+          echo "Claude step failed and no usage-limit message was found in the execution log."
+          exit 1


### PR DESCRIPTION
When a Claude issue run hits the subscription's 5-hour usage limit, the job now pauses gracefully instead of failing, and a scheduled workflow resumes the work once the limit window resets.

- **`claude-worker.yml`** (new, reusable): shared Claude run. On a usage-limit stop it pushes progress to a `claude/issue-N-wip` branch, posts a hidden state comment with the reset time (UTC epoch), adds a `claude-resume-pending` label, and exits green. Any other failure stays red. Capped at 6 resume attempts per issue.
- **`claude-resume.yml`** (new): cron every 15 min + manual dispatch. Picks at most one pending issue whose reset time has passed and re-runs the worker with a resume prompt pointing at the saved WIP branch.
- **`claude-issue.yml`**: unchanged triggers and owner-only gate; now delegates to the worker.
- **`.github/scripts/claude_usage_limit.py`**: parses both known limit-message shapes (`…limit reached|<epoch>` and `resets 3pm (Africa/Johannesburg)`) with proper `zoneinfo` handling (default `Africa/Johannesburg`), plus a self-correcting now+30min fallback.

No in-job sleeping: a limit hit ends the job in seconds; the cron does the waiting, so nothing approaches the 6-hour job cap and no runner minutes burn idle.

Validated with actionlint, parser unit runs against four message formats, jq state-extraction tests, and the git WIP-save logic exercised against a local bare origin (dirty tree / unpushed branch / clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDRAgpTjA8EsWBUdyh3L3e