### PR TITLE
Fix AlmaLinux install: sudo PATH and system-VG detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ python3 -m pytest -v            # Verbose output
 - `tasks/` — Task definitions (188 tasks, 25 categories, 8 domains)
 - `validators/` — Safe read-only system validators for each task type
 - `utils/` — AI feedback, progress reports, device detection
+- `utils/system_id.py` — distro + system-resource identification (see below)
 - `config/` — Settings and constants
 - `data/` — SQLite progress DB, bookmarks
 - `device/` — Loop device / practice disk setup
@@ -40,6 +41,16 @@ python3 -m pytest -v            # Verbose output
 ## Key Facts
 
 - **Target OS**: RHEL 10 / Rocky Linux 9-10 / AlmaLinux 9-10
+- **Never hardcode distro-specific names.** Anything that answers "is this the
+  box's own OS, or the candidate's practice storage?" goes through
+  `utils/system_id.py`, which *probes* — system VGs come from what actually
+  backs the mounted filesystems and active swap, the OS disk from what holds
+  `/` and `/boot`, the UEFI grub.cfg from a glob of `/boot/efi/EFI/*/`. The
+  static name lists in that module are fallbacks for unprobeable boxes only.
+  This existed as a hardcoded `{'rl','rl00','rhel','centos','fedora'}` set
+  copied into eight places; AlmaLinux's root VG is named `almalinux`, so on
+  Alma the simulator handed LVM tasks the system VG and considered the system
+  LVs cleanup fodder. Add detection, not another name.
 - **Requires root** — many validators run real system commands
 - **No internet needed** — fully offline; optional Claude AI feedback via `ANTHROPIC_API_KEY`
 - **Loop devices** — LVM tasks can use virtual disks (option 13 in menu) when no spare disk exists

--- a/README.md
+++ b/README.md
@@ -141,10 +141,24 @@ whatever state a fresh install puts it in (tasks manage state themselves):
 ./install.sh --no-populate   # skip the optional DNF-history setup
 ```
 
-The installer checks Python/OS, copies files to `/opt/rhcsa-simulator`, creates
-the `rhcsa-simulator` command in `/usr/local/bin`, and optionally builds some DNF
-transaction history for the package-history tasks. It auto-detects a
-non-interactive shell and runs unattended, so it won't stall in automation.
+The installer checks Python/OS, copies files to `/opt/rhcsa-simulator`, installs
+the `rhcsa-simulator` launcher, and optionally builds some DNF transaction
+history for the package-history tasks. It auto-detects a non-interactive shell
+and runs unattended, so it won't stall in automation.
+
+**Where the launcher goes:** `sudo` ignores your `PATH` and uses `secure_path`
+from `/etc/sudoers`, which on RHEL, AlmaLinux and Rocky is:
+
+```
+Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+```
+
+`/usr/local/bin` is not on it, so a launcher installed there works from a root
+shell but fails under `sudo` with `sudo: rhcsa-simulator: command not found`.
+The installer therefore checks `secure_path` and installs to `/usr/bin` when
+`/usr/local/bin` isn't searched, and to `/usr/local/bin` when it is. It prints
+the path it chose and verifies the command actually runs before reporting
+success.
 
 Run without installing: `sudo python3 rhcsa_simulator.py`.
 
@@ -422,6 +436,12 @@ Set `ANTHROPIC_API_KEY` to enable line-by-line command analysis. See
 ## Troubleshooting
 
 - **"must be run as root"** — launch with `sudo`.
+- **`sudo: rhcsa-simulator: command not found`** — you have an old install that
+  put the launcher in `/usr/local/bin`, which `sudo` does not search on
+  RHEL/Alma/Rocky (see [Installation](#installation)). Re-run `./install.sh`,
+  which relocates it and removes the stale copy. To confirm afterwards:
+  `sudo rhcsa-simulator --list-categories`. Until then, the full path works:
+  `sudo /usr/local/bin/rhcsa-simulator`.
 - **Storage tasks fail in a container** — loop devices/SELinux/systemd may be
   limited; use a real RHEL/Rocky/Alma VM.
 - **Messy state after a crash / want a clean box** — run **Setup → Reset

--- a/core/content/domain_4_storage.py
+++ b/core/content/domain_4_storage.py
@@ -115,6 +115,14 @@ TOOLS:
             "partprobe updates kernel without reboot",
             "GPT allows more partitions and larger disks",
             "Check with lsblk after partitioning",
+            "Not every task states a size. 'Create a backup partition on "
+            "/dev/sda' with no number is a real exam phrasing — it means the "
+            "size is yours to choose, not that you missed a line. Pick "
+            "something sensible, leave room for later tasks on the same disk, "
+            "and move on.",
+            "When a size IS given, treat it as exact and check the tolerance: "
+            "'1GiB' is 1024MiB, not 1000MiB. Mixing the two is a common "
+            "silent failure.",
         ],
     },
     "lvm": {
@@ -181,7 +189,15 @@ full LVM stack and resize volumes.
             "Insufficient space in VG for LV",
         ],
         "exam_tricks": [
-            "Exam specifies exact size - watch units (M vs MB vs MiB)",
+            "When a size is given, watch the units (M vs MB vs MiB)",
+            "But do NOT assume every task gives one. Some are deliberately "
+            "open ('create a backup volume in vg01'), leaving the size to "
+            "your judgement — that is not a missing detail. Size it to fit "
+            "the VG with room for later tasks, then say so and move on.",
+            "Sized in extents rather than bytes? -l takes extents, -L takes "
+            "bytes: lvcreate -l 128 (extents) vs lvcreate -L 512M. "
+            "-l 100%FREE takes whatever is left, which is often the right "
+            "answer for an open-ended 'use the remaining space' task.",
             "May ask to extend existing LV (not create new)",
             "Filesystem resize is separate step (unless -r flag)",
             "Path is /dev/vgname/lvname or /dev/mapper/vgname-lvname",

--- a/core/content/domain_8_automation.py
+++ b/core/content/domain_8_automation.py
@@ -241,6 +241,13 @@ EXIT CODES:
             "Exit 0 for success, non-zero for errors",
             "Use $? to check if previous command succeeded",
             "bash -n script.sh to check syntax without running",
+            "A directory the task tells you to read from may legitimately be "
+            "EMPTY. That is not a hint that you set something up wrong — you "
+            "are graded on the script, not on it having produced output. Write "
+            "it, make it executable, run it, confirm it exits 0, move on.",
+            "Don't hardcode around the data you happen to see. 'Copy the "
+            "contents of /foo to /bar' means cp -a /foo/. /bar/ (or rsync), "
+            "which is correct whether /foo holds 0 files or 500.",
         ],
     },
 }

--- a/core/full_reset.py
+++ b/core/full_reset.py
@@ -336,11 +336,16 @@ _PROTECTED_PREFIXES = ('/proc', '/sys', '/run', '/dev', '/boot', '/usr',
 _PRACTICE_TARGET_PREFIXES = ('/mnt/', '/media/', '/srv/', '/data', '/export',
                              '/shares', '/misc/', '/autofs')
 
-# System volume groups whose LVs must never be unmounted (mirror helpers).
+# System volume groups whose LVs must never be unmounted. Detected from the
+# live mounts (see utils.system_id), with a static name list as fallback.
 try:
-    from utils.helpers import _SYSTEM_VGS as _SYS_VGS
-except Exception:  # pragma: no cover - fallback if helpers changes
+    from utils.system_id import KNOWN_SYSTEM_VG_NAMES as _SYS_VGS
+    from utils.system_id import is_system_vg
+except Exception:  # pragma: no cover - fallback if system_id is unavailable
     _SYS_VGS = {'rl', 'rl00', 'rhel', 'centos', 'fedora', 'almalinux', 'rocky'}
+
+    def is_system_vg(vg):
+        return not vg or vg.strip() in _SYS_VGS
 
 
 def _dm_vg(source):
@@ -361,7 +366,7 @@ def _is_practice_mount(target, source, fstype):
     if re.match(r'^/dev/loop\d+', source or ''):
         return True
     if (source or '').startswith(('/dev/mapper/', '/dev/dm-')):
-        return _dm_vg(source) not in _SYS_VGS
+        return not is_system_vg(_dm_vg(source))
     if target.startswith(_PRACTICE_TARGET_PREFIXES):
         return True
     return False
@@ -411,6 +416,21 @@ def unmount_practice_mounts(progress=_noop):
 # ── Practice swap + fstab ────────────────────────────────────────────────────
 
 def _system_swap(device):
+    """True for the swap the OS installed itself, which must survive a reset.
+
+    Name matching alone ('rhel' in the path) only recognised RHEL's own
+    layout; an AlmaLinux swap partition on /dev/sda3 looked like practice
+    swap and got torn out of fstab. Ask what the device actually is first.
+    """
+    try:
+        from utils.system_id import is_system_disk, vg_of_device, is_system_vg
+        vg = vg_of_device(device)
+        if vg:
+            return is_system_vg(vg)
+        if is_system_disk(device):
+            return True
+    except Exception:
+        pass
     return any(x in device for x in ('/dev/nvme', 'rhel', 'dm-'))
 
 

--- a/core/preflight.py
+++ b/core/preflight.py
@@ -109,6 +109,30 @@ def offer_task_packages(tasks):
     return filter_missing(needed)
 
 
+def report_environment():
+    """Print what OS this is and which volume groups are being protected.
+
+    Every distro-specific decision the simulator makes (which VG is the
+    candidate's practice storage, which disk is the OS, where grub.cfg
+    lives) is derived from this. Showing it at startup means a box we've
+    mis-identified is visible immediately, instead of surfacing later as a
+    task that behaved strangely. Best-effort — never fails the launch.
+    """
+    try:
+        from utils import system_id
+        findings = system_id.check_environment()
+    except Exception:
+        return
+
+    for level, message in findings:
+        if level == 'error':
+            print(fmt.error(f"\n! {message}"))
+        elif level == 'warn':
+            print(fmt.warning(f"\n! {message}"))
+        else:
+            print(fmt.dim(f"  {message}"))
+
+
 def warn_missing(missing=None):
     """Print a one-time warning listing missing packages and how to install
     them. No-op if nothing is missing (or rpm status is unknown)."""

--- a/core/reboot_engine.py
+++ b/core/reboot_engine.py
@@ -162,16 +162,22 @@ class RebootEngine:
 
     def _check_grub(self):
         """Check that GRUB configuration is intact."""
-        # Check grub.cfg exists
+        # Check grub.cfg exists. On RHEL 9/10 the layout is unified and this
+        # is the canonical path for BIOS and UEFI alike.
         result = execute_safe(['test', '-f', '/boot/grub2/grub.cfg'])
-        if not result.success:
-            # Try EFI path
-            result = execute_safe(['test', '-f', '/boot/efi/EFI/redhat/grub.cfg'])
-            if not result.success:
-                result = execute_safe(['test', '-f', '/boot/efi/EFI/rocky/grub.cfg'])
-                if not result.success:
-                    return False
-        return True
+        if result.success:
+            return True
+
+        # Older/odd UEFI layouts keep it under a vendor directory named after
+        # the distro. That name was previously hardcoded to 'redhat' then
+        # 'rocky', so AlmaLinux (/boot/efi/EFI/almalinux) failed this check
+        # and every boot task on Alma reported a boot failure. Glob instead of
+        # guessing names one at a time.
+        from utils.system_id import efi_grub_configs
+        for cfg in efi_grub_configs():
+            if execute_safe(['test', '-f', cfg]).success:
+                return True
+        return False
 
     def get_reboot_report(self, reboot_result, tasks):
         """Generate a human-readable reboot simulation report."""

--- a/device/device_manager.py
+++ b/device/device_manager.py
@@ -23,6 +23,8 @@ from typing import List, Dict, Optional, Set, Tuple, Any
 from enum import Enum
 from contextlib import contextmanager
 
+from utils.system_id import system_vgs as get_system_vgs, is_system_disk
+
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +117,7 @@ class DeviceManager:
 
     def _detect_practice_device(self) -> Optional[str]:
         """Detect the practice device (empty disk or practice PV)."""
-        system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+        system_vgs = get_system_vgs()
 
         try:
             # Use lsblk to find available disks
@@ -140,8 +142,10 @@ class DeviceManager:
                     if dtype != 'disk':
                         continue
 
-                    # Skip system disks (first disk is usually OS)
-                    if any(x in device for x in ['vda', 'sda', 'nvme0n1', 'xvda']):
+                    # Skip the disk(s) the OS actually lives on. Determined
+                    # from the live mounts, not from the device name — the OS
+                    # is not always on the first disk.
+                    if is_system_disk(device):
                         continue
 
                     # Skip CD-ROM/removable
@@ -267,7 +271,7 @@ class DeviceManager:
         Called after task validation to catch any untracked resources.
         Scans ALL non-system LVM, not just the practice device.
         """
-        system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+        system_vgs = get_system_vgs()
         device = self.get_practice_device()
 
         # Check for ALL PVs on non-system VGs (including loop devices)
@@ -297,7 +301,7 @@ class DeviceManager:
                 ['vgs', '--noheadings', '-o', 'vg_name'],
                 capture_output=True, text=True, timeout=5
             )
-            system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+            system_vgs = get_system_vgs()
             for line in result.stdout.strip().splitlines():
                 vg = line.strip()
                 if vg and vg not in system_vgs:
@@ -311,7 +315,7 @@ class DeviceManager:
                 ['lvs', '--noheadings', '-o', 'lv_name,vg_name'],
                 capture_output=True, text=True, timeout=5
             )
-            system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+            system_vgs = get_system_vgs()
             for line in result.stdout.strip().splitlines():
                 parts = line.split()
                 if len(parts) >= 2:
@@ -500,7 +504,7 @@ class DeviceManager:
             devices_to_clean.add(device)
 
         # Find loop devices that have non-system LVM
-        system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+        system_vgs = get_system_vgs()
         try:
             result = subprocess.run(
                 ['pvs', '--noheadings', '-o', 'pv_name,vg_name'],
@@ -519,6 +523,16 @@ class DeviceManager:
                         devices_to_clean.add(pv_name)
         except Exception:
             pass
+
+        # Last line of defence before pvremove/wipefs: drop anything that is
+        # (or sits on) a disk the OS lives on. The VG-name checks above should
+        # already have excluded these, but steps 5 and 6 below are
+        # unrecoverable, so they get an independent check.
+        protected = {dev for dev in devices_to_clean if is_system_disk(dev)}
+        if protected:
+            self.logger.warning(
+                f"Refusing to clean system device(s): {sorted(protected)}")
+            devices_to_clean -= protected
 
         self.logger.info(f"Devices to clean: {devices_to_clean}")
 
@@ -555,7 +569,7 @@ class DeviceManager:
             self.logger.debug(f"Mount cleanup: {e}")
 
         # 2. Deactivate any swap on non-system VGs
-        system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+        system_vgs = get_system_vgs()
         try:
             result = subprocess.run(
                 ['swapon', '--show=NAME', '--noheadings'],
@@ -600,7 +614,7 @@ class DeviceManager:
                 ['lvs', '--noheadings', '-o', 'lv_path,vg_name'],
                 capture_output=True, text=True, timeout=5
             )
-            system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+            system_vgs = get_system_vgs()
             for line in result.stdout.strip().splitlines():
                 parts = line.split()
                 if len(parts) >= 2:
@@ -620,7 +634,7 @@ class DeviceManager:
                 ['vgs', '--noheadings', '-o', 'vg_name'],
                 capture_output=True, text=True, timeout=5
             )
-            system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+            system_vgs = get_system_vgs()
             for line in result.stdout.strip().splitlines():
                 vg = line.strip()
                 if vg and vg not in system_vgs:

--- a/install.sh
+++ b/install.sh
@@ -16,8 +16,18 @@ NC='\033[0m' # No Color
 
 # Configuration
 INSTALL_DIR="/opt/rhcsa-simulator"
-BIN_LINK="/usr/local/bin/rhcsa-simulator"
+CMD_NAME="rhcsa-simulator"
 REQUIRED_PYTHON_VERSION="3.6"
+
+# Where the launcher goes is decided below by pick_bin_dir(), because the
+# conventional choice (/usr/local/bin) is NOT on sudo's secure_path on
+# RHEL-family systems — see the comment there.
+BIN_DIR=""
+BIN_LINK=""
+
+# Candidate launcher locations, cleaned up on reinstall so an old copy in the
+# location we're no longer using can't shadow the new one.
+ALL_BIN_DIRS="/usr/local/bin /usr/bin"
 
 echo "========================================="
 echo "RHCSA Mock Exam Simulator - Installation"
@@ -39,27 +49,69 @@ if ! command -v python3 &> /dev/null; then
     exit 1
 fi
 
+# Resolve the interpreter to an absolute path — the launcher runs under sudo's
+# secure_path, which may not be the PATH that found python3 here.
+PYTHON_BIN=$(command -v python3)
 PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
-echo "Found Python ${PYTHON_VERSION}"
+echo "Found Python ${PYTHON_VERSION} at ${PYTHON_BIN}"
 
 if [ "$(printf '%s\n' "$REQUIRED_PYTHON_VERSION" "$PYTHON_VERSION" | sort -V | head -n1)" != "$REQUIRED_PYTHON_VERSION" ]; then
     echo -e "${RED}Error: Python ${REQUIRED_PYTHON_VERSION} or later is required${NC}"
     exit 1
 fi
 
-# Check OS
+# Check OS.
+#
+# /etc/redhat-release alone only tells us "some Red Hat derivative". Read
+# os-release too so the install names the distro and version it actually
+# found — a mis-identified box is the root of every "it didn't work on
+# <distro>" report, and it should be visible here rather than three tasks in.
 echo "Checking operating system..."
-if [ -f /etc/redhat-release ]; then
-    OS_INFO=$(cat /etc/redhat-release)
-    echo "Detected: ${OS_INFO}"
-else
-    echo -e "${YELLOW}Warning: This tool is designed for RHEL/Rocky/Alma Linux${NC}"
-    read -p "Continue anyway? [y/N]: " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        exit 1
-    fi
+OS_ID=""
+OS_MAJOR=""
+OS_PRETTY=""
+if [ -r /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    OS_ID="${ID:-}"
+    OS_MAJOR="${VERSION_ID%%.*}"
+    OS_PRETTY="${PRETTY_NAME:-${NAME:-}}"
 fi
+
+if [ -z "$OS_PRETTY" ] && [ -f /etc/redhat-release ]; then
+    OS_PRETTY=$(cat /etc/redhat-release)
+fi
+
+case "$OS_ID" in
+    rhel|almalinux|rocky|centos|ol|fedora)
+        echo "Detected: ${OS_PRETTY}"
+        case "$OS_MAJOR" in
+            9|10) ;;
+            *)
+                echo -e "${YELLOW}Warning: EX200 v10 targets major version 10 (9 is usable).${NC}"
+                echo -e "${YELLOW}Version ${OS_MAJOR} may not match what the tasks expect.${NC}"
+                read -p "Continue anyway? [y/N]: " -n 1 -r
+                echo
+                if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                    exit 1
+                fi
+                ;;
+        esac
+        ;;
+    *)
+        if [ -n "$OS_PRETTY" ]; then
+            echo -e "${YELLOW}Detected: ${OS_PRETTY}${NC}"
+        fi
+        echo -e "${YELLOW}Warning: This tool is designed for RHEL / AlmaLinux / Rocky Linux 9-10.${NC}"
+        echo -e "${YELLOW}Package names, SELinux, firewalld and boot layout differ elsewhere,${NC}"
+        echo -e "${YELLOW}so most tasks will not grade correctly.${NC}"
+        read -p "Continue anyway? [y/N]: " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+        ;;
+esac
 
 # Create installation directory
 echo "Creating installation directory..."
@@ -90,29 +142,120 @@ chmod -R 755 "$INSTALL_DIR"/{config,core,tasks,validators,utils}
 chmod -R 755 "$INSTALL_DIR"/data
 chmod 755 "$INSTALL_DIR/rhcsa_simulator.py"
 
-# Create symlink
-echo "Creating symlink..."
-if [ -L "$BIN_LINK" ] || [ -f "$BIN_LINK" ]; then
-    rm -f "$BIN_LINK"
-fi
+# Install the launcher
+#
+# This used to be a bare symlink into /usr/local/bin. `sudo rhcsa-simulator`
+# then failed with "command not found", because sudo does not use your PATH —
+# it uses secure_path from /etc/sudoers, and on RHEL/AlmaLinux/Rocky that is:
+#
+#     Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+#
+# No /usr/local/bin. So the one command the README told people to run was the
+# one that could not resolve. (It works from a root login shell, which is why
+# it went unnoticed.) Pick a directory sudo will actually search.
+# Overridable so this can be exercised against fixture files in a test.
+SUDOERS_PATHS="${SUDOERS_PATHS:-/etc/sudoers /etc/sudoers.d/}"
 
-ln -s "$INSTALL_DIR/rhcsa_simulator.py" "$BIN_LINK"
+pick_bin_dir() {
+    local secure_path
+    # Later entries win, so take the last secure_path we can find.
+    # shellcheck disable=SC2086
+    secure_path=$(grep -rhs '^[[:space:]]*Defaults.*secure_path' \
+                    $SUDOERS_PATHS 2>/dev/null \
+                  | tail -n1)
+
+    if [ -z "$secure_path" ]; then
+        # No secure_path directive: sudo passes PATH through, so the
+        # conventional location is correct.
+        echo "/usr/local/bin"
+        return
+    fi
+
+    case "$secure_path" in
+        *=*/usr/local/bin*|*:/usr/local/bin*|*/usr/local/bin:*)
+            echo "/usr/local/bin" ;;
+        *)
+            # /usr/local/bin is not searched by sudo on this box. Use /usr/bin
+            # so the documented `sudo rhcsa-simulator` resolves. Editing
+            # secure_path in sudoers would also work but risks breaking sudo
+            # entirely on a box someone is mid-exam on — not worth it.
+            echo "/usr/bin" ;;
+    esac
+}
+
+BIN_DIR="$(pick_bin_dir)"
+BIN_LINK="${BIN_DIR}/${CMD_NAME}"
+
+echo "Installing launcher..."
+echo "  sudo searches ${BIN_DIR} — installing there"
+
+# Drop any launcher from a previous install in either candidate directory, so
+# a stale copy can't win the PATH lookup ahead of this one.
+for dir in $ALL_BIN_DIRS; do
+    old="${dir}/${CMD_NAME}"
+    if [ "$old" != "$BIN_LINK" ] && { [ -L "$old" ] || [ -f "$old" ]; }; then
+        echo "  removing previous launcher at ${old}"
+        rm -f "$old"
+    fi
+done
+rm -f "$BIN_LINK"
+
+# A wrapper rather than a symlink: it names the interpreter and the script
+# explicitly, so it does not depend on the .py file's executable bit, on the
+# shebang resolving, or on how Python treats a symlinked entry point.
+cat > "$BIN_LINK" <<EOF
+#!/bin/bash
+# RHCSA Mock Exam Simulator launcher. Generated by install.sh — edits here are
+# overwritten on reinstall.
+exec ${PYTHON_BIN} ${INSTALL_DIR}/rhcsa_simulator.py "\$@"
+EOF
 chmod 755 "$BIN_LINK"
 
 # Create requirements.txt (empty - stdlib only)
 echo "# No external dependencies required - Python stdlib only" > "$INSTALL_DIR/requirements.txt"
 
 # Verify installation
+#
+# Actually launch the command instead of just checking that a file exists —
+# the previous check confirmed a symlink was present, which it always was,
+# while the command it pointed at could not be run.
 echo "Verifying installation..."
-if [ -f "$INSTALL_DIR/rhcsa_simulator.py" ] && [ -L "$BIN_LINK" ]; then
+INSTALL_OK=1
+
+if [ ! -f "$INSTALL_DIR/rhcsa_simulator.py" ]; then
+    echo -e "${RED}✗ ${INSTALL_DIR}/rhcsa_simulator.py is missing${NC}"
+    INSTALL_OK=0
+fi
+
+if [ ! -x "$BIN_LINK" ]; then
+    echo -e "${RED}✗ launcher ${BIN_LINK} is missing or not executable${NC}"
+    INSTALL_OK=0
+elif ! "$BIN_LINK" --list-categories >/dev/null 2>&1; then
+    echo -e "${RED}✗ ${BIN_LINK} exists but failed to run${NC}"
+    echo "  Try it directly to see the error:"
+    echo "    ${PYTHON_BIN} ${INSTALL_DIR}/rhcsa_simulator.py --list-categories"
+    INSTALL_OK=0
+fi
+
+# Confirm the bare command resolves under sudo's own PATH, which is the way
+# the README tells people to start it.
+RESOLVED=$(env -i PATH="$(getconf PATH 2>/dev/null || echo /usr/bin:/bin)" \
+           command -v "$CMD_NAME" 2>/dev/null)
+if [ "$INSTALL_OK" -eq 1 ] && [ -z "$RESOLVED" ]; then
+    echo -e "${YELLOW}Warning: '${CMD_NAME}' did not resolve on a minimal PATH.${NC}"
+    echo -e "${YELLOW}If 'sudo ${CMD_NAME}' says command not found, use:${NC}"
+    echo "    sudo ${BIN_LINK}"
+fi
+
+if [ "$INSTALL_OK" -eq 1 ]; then
     echo -e "${GREEN}✓ Installation successful!${NC}"
     echo
     echo "Installation Details:"
-    echo "  Location: $INSTALL_DIR"
-    echo "  Executable: $BIN_LINK"
+    echo "  Location:   $INSTALL_DIR"
+    echo "  Launcher:   $BIN_LINK"
     echo
     echo "Usage:"
-    echo "  sudo rhcsa-simulator"
+    echo "  sudo ${CMD_NAME}              # or: sudo ${BIN_LINK}"
     echo
     echo -e "${YELLOW}Note: You must run as root (sudo) to validate system state${NC}"
 else

--- a/rhcsa_simulator.py
+++ b/rhcsa_simulator.py
@@ -290,6 +290,7 @@ def main():
     # the launch.
     try:
         from core import preflight
+        preflight.report_environment()
         preflight.warn_missing()
     except Exception:
         pass

--- a/tests/unit/test_system_id.py
+++ b/tests/unit/test_system_id.py
@@ -1,0 +1,234 @@
+"""
+Tests for utils.system_id — the distro/system-resource identification that
+decides what belongs to the operating system and is therefore off-limits.
+
+The regression that motivated this module: AlmaLinux names its root volume
+group 'almalinux', which was absent from the hardcoded system-VG list, so the
+simulator treated the box's own root VG as spare practice storage.
+"""
+
+import pytest
+
+from utils import system_id
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    system_id.reset_cache()
+    yield
+    system_id.reset_cache()
+
+
+def _fake_os_release(monkeypatch, content):
+    monkeypatch.setattr(system_id, '_cache', {'os_release': content})
+
+
+# ── os-release parsing ──────────────────────────────────────────────────────
+
+def test_os_release_parses_quoted_values(monkeypatch, tmp_path):
+    release = tmp_path / "os-release"
+    release.write_text(
+        'NAME="AlmaLinux"\n'
+        'VERSION="10.0 (Purple Lion)"\n'
+        'ID="almalinux"\n'
+        'ID_LIKE="rhel centos fedora"\n'
+        'VERSION_ID="10.0"\n'
+        'PRETTY_NAME="AlmaLinux 10.0 (Purple Lion)"\n'
+        '\n'
+        '# a comment\n'
+    )
+    monkeypatch.setattr(system_id, 'OS_RELEASE_PATHS', (str(release),))
+
+    assert system_id.distro_id() == 'almalinux'
+    assert system_id.distro_version() == '10.0'
+    assert system_id.distro_major() == 10
+    assert system_id.distro_name() == 'AlmaLinux 10.0 (Purple Lion)'
+    assert system_id.is_rhel_family() is True
+
+
+def test_os_release_missing_is_not_fatal(monkeypatch):
+    monkeypatch.setattr(system_id, 'OS_RELEASE_PATHS', ('/nonexistent/os-release',))
+    assert system_id.os_release() == {}
+    assert system_id.distro_id() == ''
+    assert system_id.distro_major() is None
+
+
+def test_non_rhel_family_detected(monkeypatch):
+    _fake_os_release(monkeypatch, {'ID': 'ubuntu', 'ID_LIKE': 'debian',
+                                   'VERSION_ID': '24.04',
+                                   'PRETTY_NAME': 'Ubuntu 24.04 LTS'})
+    assert system_id.is_rhel_family() is False
+
+
+# ── system VG detection ─────────────────────────────────────────────────────
+
+def test_almalinux_root_vg_is_protected(monkeypatch):
+    """The exact bug: 'almalinux' is not in the legacy name list, so it has to
+    be caught by probing the mounts."""
+    monkeypatch.setattr(system_id, 'detected_system_vgs',
+                        lambda: {'almalinux'})
+    monkeypatch.setattr(system_id, '_distro_vg_guesses', lambda: set())
+
+    assert system_id.is_system_vg('almalinux') is True
+    assert system_id.is_system_vg('vg_practice') is False
+
+
+def test_detected_vgs_come_from_mounts_and_swap(monkeypatch):
+    sources = {'/': '/dev/mapper/almalinux-root',
+               '/home': '/dev/mapper/almalinux-home'}
+    monkeypatch.setattr(system_id, '_source_of_mountpoint',
+                        lambda mp: sources.get(mp))
+    monkeypatch.setattr(system_id, '_active_swap_devices',
+                        lambda: ['/dev/dm-1'])
+
+    def fake_vg_of_device(dev):
+        return {'/dev/mapper/almalinux-root': 'almalinux',
+                '/dev/mapper/almalinux-home': 'almalinux',
+                '/dev/dm-1': 'almalinux'}.get(dev)
+
+    monkeypatch.setattr(system_id, 'vg_of_device', fake_vg_of_device)
+    monkeypatch.setattr(system_id.os.path, 'exists', lambda p: True)
+
+    assert system_id.detected_system_vgs() == {'almalinux'}
+
+
+def test_known_names_still_protected_when_probe_fails(monkeypatch):
+    """An unprobeable box keeps the old (partial) protection rather than none."""
+    monkeypatch.setattr(system_id, 'detected_system_vgs', lambda: set())
+    monkeypatch.setattr(system_id, '_distro_vg_guesses', lambda: set())
+
+    for name in ('rl', 'rhel', 'centos', 'almalinux', 'rocky'):
+        assert system_id.is_system_vg(name) is True, name
+    assert system_id.is_system_vg('vg_exam1') is False
+
+
+def test_unknown_distro_root_vg_guessed_from_os_release(monkeypatch):
+    """A distro nobody thought of still gets its likely root VG protected."""
+    _fake_os_release(monkeypatch, {'ID': 'navylinux', 'VERSION_ID': '10.1'})
+    monkeypatch.setattr(system_id, 'detected_system_vgs', lambda: set())
+
+    assert system_id.is_system_vg('navylinux') is True
+    assert system_id.is_system_vg('navylinux10') is True
+    assert system_id.is_system_vg('vg_exam1') is False
+
+
+def test_blank_vg_name_treated_as_system(monkeypatch):
+    """Refusing to touch what we can't identify is the safe default when the
+    alternative is lvremove."""
+    monkeypatch.setattr(system_id, 'detected_system_vgs', lambda: set())
+    assert system_id.is_system_vg('') is True
+    assert system_id.is_system_vg(None) is True
+    assert system_id.is_system_vg('   ') is True
+
+
+def test_vg_of_device_returns_none_for_non_lv(monkeypatch):
+    monkeypatch.setattr(system_id, '_run', lambda cmd, timeout=10: None)
+    assert system_id.vg_of_device('/dev/sdb') is None
+    assert system_id.vg_of_device('') is None
+    assert system_id.vg_of_device('not-a-device') is None
+
+
+# ── system disk detection ───────────────────────────────────────────────────
+
+def test_system_disk_detected_from_pvs_not_from_name(monkeypatch):
+    monkeypatch.setattr(system_id, 'system_pvs', lambda: frozenset({'/dev/vdb2'}))
+    monkeypatch.setattr(system_id, '_source_of_mountpoint',
+                        lambda mp: '/dev/mapper/almalinux-root' if mp == '/' else None)
+    monkeypatch.setattr(system_id, '_parent_disk',
+                        lambda dev: '/dev/vdb' if dev == '/dev/vdb2' else None)
+
+    assert system_id.system_disks() == frozenset({'/dev/vdb'})
+    # The OS is on the *second* disk here; the first is fair game.
+    assert system_id.is_system_disk('/dev/vdb') is True
+    assert system_id.is_system_disk('/dev/vda') is False
+
+
+def test_system_disk_falls_back_to_name_when_unprobeable(monkeypatch):
+    monkeypatch.setattr(system_id, 'system_disks', lambda: frozenset())
+    assert system_id.is_system_disk('/dev/sda') is True
+    assert system_id.is_system_disk('/dev/nvme0n1') is True
+    assert system_id.is_system_disk('/dev/sdd') is False
+
+
+def test_empty_device_is_treated_as_system(monkeypatch):
+    assert system_id.is_system_disk('') is True
+    assert system_id.is_system_disk(None) is True
+
+
+# ── boot layout ─────────────────────────────────────────────────────────────
+
+def test_efi_grub_config_globs_any_vendor_dir(monkeypatch):
+    monkeypatch.setattr(system_id.glob, 'glob',
+                        lambda pat: ['/boot/efi/EFI/almalinux/grub.cfg'])
+    monkeypatch.setattr(system_id.os.path, 'isfile', lambda p: False)
+
+    assert system_id.efi_grub_configs() == ['/boot/efi/EFI/almalinux/grub.cfg']
+    assert system_id.grub_config_present() is True
+
+
+def test_grub_absent_reported(monkeypatch):
+    monkeypatch.setattr(system_id.glob, 'glob', lambda pat: [])
+    monkeypatch.setattr(system_id.os.path, 'isfile', lambda p: False)
+    assert system_id.grub_config_present() is False
+
+
+# ── environment report ──────────────────────────────────────────────────────
+
+def test_check_environment_flags_non_rhel(monkeypatch):
+    _fake_os_release(monkeypatch, {'ID': 'ubuntu', 'ID_LIKE': 'debian',
+                                   'VERSION_ID': '24.04',
+                                   'PRETTY_NAME': 'Ubuntu 24.04 LTS'})
+    monkeypatch.setattr(system_id, 'detected_system_vgs', lambda: set())
+    monkeypatch.setattr(system_id, '_run', lambda cmd, timeout=10: None)
+    monkeypatch.setattr(system_id, 'grub_config_present', lambda: True)
+
+    levels = [level for level, _ in system_id.check_environment()]
+    assert 'error' in levels
+
+
+def test_check_environment_accepts_almalinux_10(monkeypatch):
+    _fake_os_release(monkeypatch, {'ID': 'almalinux', 'ID_LIKE': 'rhel centos fedora',
+                                   'VERSION_ID': '10.0',
+                                   'PRETTY_NAME': 'AlmaLinux 10.0'})
+    monkeypatch.setattr(system_id, 'detected_system_vgs', lambda: {'almalinux'})
+    monkeypatch.setattr(system_id, 'grub_config_present', lambda: True)
+
+    findings = system_id.check_environment()
+    assert all(level == 'ok' for level, _ in findings), findings
+    assert any('AlmaLinux' in msg for _, msg in findings)
+
+
+def test_check_environment_warns_on_unsupported_major(monkeypatch):
+    _fake_os_release(monkeypatch, {'ID': 'rocky', 'ID_LIKE': 'rhel centos fedora',
+                                   'VERSION_ID': '8.10',
+                                   'PRETTY_NAME': 'Rocky Linux 8.10'})
+    monkeypatch.setattr(system_id, 'detected_system_vgs', lambda: {'rl'})
+    monkeypatch.setattr(system_id, 'grub_config_present', lambda: True)
+
+    levels = [level for level, _ in system_id.check_environment()]
+    assert 'warn' in levels
+
+
+def test_probes_never_raise(monkeypatch):
+    """Every probe goes through _run, which must swallow a missing binary,
+    a timeout and a non-zero exit rather than raise into a validator."""
+    import subprocess
+
+    def missing(*a, **kw):
+        raise FileNotFoundError("lvs")
+
+    monkeypatch.setattr(system_id.subprocess, 'run', missing)
+    assert system_id._run(['lvs']) is None
+
+    def timeout(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd='lvs', timeout=5)
+
+    monkeypatch.setattr(system_id.subprocess, 'run', timeout)
+    assert system_id._run(['lvs']) is None
+
+    class Failed:
+        returncode = 5
+        stdout = 'partial'
+
+    monkeypatch.setattr(system_id.subprocess, 'run', lambda *a, **kw: Failed())
+    assert system_id._run(['lvs']) is None

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -772,7 +772,12 @@ def cleanup_practice_devices():
         return False
 
 
-_SYSTEM_VGS = {'rl', 'rl00', 'rhel', 'centos', 'fedora', 'almalinux', 'rocky'}
+# Static fallback names only. The authoritative answer to "is this the box's
+# own VG?" is utils.system_id.is_system_vg(), which probes the live mounts —
+# a name list silently mis-classified AlmaLinux's 'almalinux' VG as practice
+# storage for as long as nobody had added that name to it.
+from utils.system_id import KNOWN_SYSTEM_VG_NAMES as _SYSTEM_VGS
+from utils.system_id import is_system_vg
 
 # Bypass the LVM devices file so we can see/remove VGs on loop devices even when
 # their devices-file entries are missing or stale (the usual state after an
@@ -816,7 +821,7 @@ def _remove_stray_practice_vgs():
         vgs = set()
 
     for vg in vgs:
-        if vg in _SYSTEM_VGS:
+        if is_system_vg(vg):
             continue
         run(['vgchange', '-an', vg] + _LVM_NODEVFILE)
         run(['vgremove', '-ff', '-y', vg] + _LVM_NODEVFILE)
@@ -871,7 +876,7 @@ def _purge_loop_device(device):
         vg_res = subprocess.run(['pvs', '--noheadings', '-o', 'vg_name'] + members + _LVM_NODEVFILE,
                                 capture_output=True, text=True, timeout=10)
         for vg in {v.strip() for v in vg_res.stdout.splitlines() if v.strip()}:
-            if vg in _SYSTEM_VGS:
+            if is_system_vg(vg):
                 continue
             run(['vgchange', '-an', vg] + _LVM_NODEVFILE)
             run(['vgremove', '-ff', '-y', vg] + _LVM_NODEVFILE)
@@ -1119,17 +1124,16 @@ def get_practice_lv():
         
         if result.returncode != 0:
             return None, None
-        
-        # System VGs to skip
-        system_vgs = ['rl', 'rl00', 'rhel', 'centos', 'fedora']
-        
+
+        from utils.system_id import is_system_vg
+
         for line in result.stdout.strip().splitlines():
             parts = line.split()
             if len(parts) >= 2:
                 vg_name = parts[0]
                 lv_name = parts[1]
-                # Skip system VGs
-                if vg_name not in system_vgs:
+                # Never hand back an LV that belongs to the OS itself.
+                if not is_system_vg(vg_name):
                     return vg_name, lv_name
         
         return None, None
@@ -1152,15 +1156,15 @@ def get_practice_vg():
         
         if result.returncode != 0:
             return None
-        
-        # System VGs to skip
-        system_vgs = ['rl', 'rl00', 'rhel', 'centos', 'fedora']
-        
+
+        from utils.system_id import is_system_vg
+
         for line in result.stdout.strip().splitlines():
             parts = line.split()
             if len(parts) >= 1:
                 vg_name = parts[0]
-                if vg_name not in system_vgs:
+                # Never hand back the VG that backs the OS itself.
+                if not is_system_vg(vg_name):
                     return vg_name
 
         return None

--- a/utils/system_id.py
+++ b/utils/system_id.py
@@ -1,0 +1,428 @@
+"""
+Distro and system-resource identification.
+
+Everything in the simulator that decides "is this thing the candidate's
+practice storage, or is it the box's own operating system?" must go through
+here.
+
+WHY THIS EXISTS
+---------------
+The simulator used to answer that question with a hardcoded list of volume
+group names::
+
+    system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+
+Anaconda names the root VG after the product: RHEL -> ``rhel``, Rocky ->
+``rl``, CentOS -> ``centos`` ... and AlmaLinux -> ``almalinux``, which was
+NOT in that list. On an AlmaLinux install the box's own root VG therefore
+looked like a spare practice VG, so ``get_practice_vg()`` handed LVM tasks
+the system VG and the cleanup pass considered the system LVs fair game.
+
+A name list can only ever describe the distros someone remembered. So the
+system VGs are *detected* here — by asking which VGs actually back the
+mounted filesystems and active swap — and the name list survives only as a
+fallback for when LVM tooling can't be queried.
+
+Everything is cached; call reset_cache() in tests.
+"""
+
+import glob
+import logging
+import os
+import re
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+OS_RELEASE_PATHS = ('/etc/os-release', '/usr/lib/os-release')
+
+# RHEL-family distros this simulator is written for: os-release ID -> label.
+SUPPORTED_IDS = {
+    'rhel': 'Red Hat Enterprise Linux',
+    'almalinux': 'AlmaLinux',
+    'rocky': 'Rocky Linux',
+    'centos': 'CentOS Stream',
+    'ol': 'Oracle Linux',
+    'fedora': 'Fedora',
+}
+
+# EX200 v10 targets RHEL 10; 9 is close enough to practise on.
+SUPPORTED_MAJORS = (9, 10)
+
+# Fallback only — used when LVM can't be queried (no lvm2, non-root, CI
+# container). Detection via mounted filesystems is authoritative.
+KNOWN_SYSTEM_VG_NAMES = frozenset({
+    'rl', 'rl00', 'rl_root', 'rhel', 'rhel00', 'centos', 'fedora',
+    'almalinux', 'alma', 'rocky', 'ol', 'oracle', 'vg_root', 'vg00',
+    'vg_system', 'system',
+})
+
+# Mountpoints that belong to the OS. If one of these lives on an LV, that
+# LV's VG is a system VG. /srv, /mnt, /media, /export deliberately absent —
+# those are where practice filesystems get mounted.
+SYSTEM_MOUNTPOINTS = (
+    '/', '/boot', '/boot/efi', '/home', '/usr', '/var', '/var/log',
+    '/var/tmp', '/opt', '/tmp', '/etc',
+)
+
+_cache = {}
+
+
+def reset_cache():
+    """Drop every cached probe result. Call from tests, or after the
+    candidate has changed storage layout in a way we need to re-read."""
+    _cache.clear()
+
+
+# ── os-release ──────────────────────────────────────────────────────────────
+
+def os_release():
+    """Parsed /etc/os-release as a dict (empty if unreadable)."""
+    if 'os_release' in _cache:
+        return _cache['os_release']
+
+    data = {}
+    for path in OS_RELEASE_PATHS:
+        try:
+            with open(path) as f:
+                content = f.read()
+        except (IOError, OSError):
+            continue
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            data[key.strip()] = value.strip().strip('"').strip("'")
+        if data:
+            break
+
+    _cache['os_release'] = data
+    return data
+
+
+def distro_id():
+    """os-release ID, lowercased ('almalinux', 'rocky', 'rhel'...). '' if unknown."""
+    return os_release().get('ID', '').lower()
+
+
+def distro_like():
+    """os-release ID_LIKE as a list ('rhel', 'centos', 'fedora')."""
+    return os_release().get('ID_LIKE', '').lower().split()
+
+
+def distro_version():
+    """os-release VERSION_ID ('10.0', '9.5'). '' if unknown."""
+    return os_release().get('VERSION_ID', '')
+
+
+def distro_major():
+    """Major version as an int, or None if it can't be parsed."""
+    match = re.match(r'(\d+)', distro_version())
+    return int(match.group(1)) if match else None
+
+
+def is_rhel_family():
+    """True if this is RHEL or a rebuild of it."""
+    ids = set(distro_like())
+    ids.add(distro_id())
+    return bool(ids & {'rhel', 'centos', 'fedora'}) or distro_id() in SUPPORTED_IDS
+
+
+def distro_name():
+    """Human-readable distro name for display."""
+    rel = os_release()
+    return rel.get('PRETTY_NAME') or rel.get('NAME') or 'unknown Linux'
+
+
+# ── LVM / block-device probing ──────────────────────────────────────────────
+
+def _run(cmd, timeout=10):
+    """Run a read-only probe. Returns stdout on success, None on any failure —
+    probes must never raise into a task or a validator."""
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+        logger.debug("probe failed (%s): %s", ' '.join(cmd), e)
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def vg_of_device(device):
+    """VG name backing a block device, or None if it isn't an LV.
+
+    Handles /dev/mapper/vg-lv, /dev/vg/lv and /dev/dm-N alike — lvs resolves
+    all three, which is why we ask lvs instead of parsing the mapper name
+    (device-mapper doubles literal dashes, so parsing gets it wrong for any
+    VG whose name contains one).
+    """
+    if not device or not device.startswith('/dev/'):
+        return None
+    out = _run(['lvs', '--noheadings', '-o', 'vg_name', device], timeout=5)
+    if out is None:
+        return None
+    name = out.strip()
+    return name or None
+
+
+def _source_of_mountpoint(mountpoint):
+    """Backing device for a mountpoint, or None if it isn't a mountpoint."""
+    out = _run(['findmnt', '-no', 'SOURCE', '--target', mountpoint], timeout=5)
+    if out is None:
+        return None
+    return out.strip().splitlines()[0].strip() if out.strip() else None
+
+
+def _active_swap_devices():
+    """Devices listed in /proc/swaps."""
+    devices = []
+    try:
+        with open('/proc/swaps') as f:
+            for line in f.readlines()[1:]:
+                parts = line.split()
+                if parts and parts[0].startswith('/dev/'):
+                    devices.append(parts[0])
+    except (IOError, OSError):
+        pass
+    return devices
+
+
+def detected_system_vgs():
+    """VGs proven to back the running OS: every VG holding a system
+    mountpoint or active swap. Empty set if nothing could be probed."""
+    found = set()
+
+    for mountpoint in SYSTEM_MOUNTPOINTS:
+        if not os.path.exists(mountpoint):
+            continue
+        source = _source_of_mountpoint(mountpoint)
+        vg = vg_of_device(source) if source else None
+        if vg:
+            found.add(vg)
+
+    for device in _active_swap_devices():
+        vg = vg_of_device(device)
+        if vg:
+            found.add(vg)
+
+    return found
+
+
+def system_vgs():
+    """Volume groups that belong to the operating system and must NEVER be
+    handed to a task or touched by cleanup.
+
+    Union of what was detected from live mounts/swap and the known-names
+    fallback, so an unprobeable box still gets the old (partial) protection
+    rather than none at all.
+    """
+    if 'system_vgs' in _cache:
+        return _cache['system_vgs']
+
+    detected = detected_system_vgs()
+    if not detected:
+        logger.debug("no system VGs detected from mounts; using name fallback only")
+
+    vgs = frozenset(detected | set(KNOWN_SYSTEM_VG_NAMES) | _distro_vg_guesses())
+    _cache['system_vgs'] = vgs
+    return vgs
+
+
+def _distro_vg_guesses():
+    """VG names anaconda would plausibly have picked on THIS distro, so a
+    distro we've never seen still gets its most likely root VG protected."""
+    guesses = set()
+    did = distro_id()
+    if did:
+        guesses.add(did)
+        guesses.add(did.replace('linux', ''))
+        major = distro_major()
+        if major is not None:
+            guesses.add('%s%d' % (did, major))
+    return {g for g in guesses if g}
+
+
+def is_system_vg(vg_name):
+    """True if this VG backs the OS. Unknown/empty names are treated as
+    system — refusing to touch something we can't identify is the safe
+    default when the alternative is lvremove."""
+    if not vg_name or not vg_name.strip():
+        return True
+    return vg_name.strip() in system_vgs()
+
+
+def system_pvs():
+    """PV device paths belonging to system VGs."""
+    if 'system_pvs' in _cache:
+        return _cache['system_pvs']
+
+    pvs = set()
+    out = _run(['pvs', '--noheadings', '-o', 'pv_name,vg_name'], timeout=10)
+    if out:
+        protected = system_vgs()
+        for line in out.strip().splitlines():
+            parts = line.split()
+            if len(parts) >= 2 and parts[1].strip() in protected:
+                pvs.add(parts[0].strip())
+
+    _cache['system_pvs'] = frozenset(pvs)
+    return _cache['system_pvs']
+
+
+def _parent_disk(device):
+    """Whole disk ultimately backing a device.
+
+    '/dev/nvme0n1p3' -> '/dev/nvme0n1', and crucially
+    '/dev/mapper/almalinux-root' -> '/dev/nvme0n1', walking LV -> partition
+    -> disk in one step.
+
+    Uses `lsblk -rnso NAME`, which prints the device's ancestry inverted
+    (device first, whole disk last). PKNAME is not usable here: for a
+    partition that has LVM children it reports the parent of each *child*
+    row, so the first line is the partition itself rather than its disk.
+    """
+    if not device:
+        return None
+    out = _run(['lsblk', '-rnso', 'NAME', device], timeout=5)
+    if not out or not out.strip():
+        return None
+    lines = [l.strip() for l in out.strip().splitlines() if l.strip()]
+    if not lines:
+        return None
+    top = lines[-1]
+    disk = '/dev/' + top
+    # The device is already a whole disk — it has no parent.
+    return None if disk == device else disk
+
+
+def system_disks():
+    """Whole disks the OS lives on — the disks holding system PVs, plus the
+    disk backing / and /boot for non-LVM installs.
+
+    Replaces guessing by device name (vda/sda/nvme0n1/xvda), which is wrong
+    on any box whose OS isn't on the first disk.
+    """
+    if 'system_disks' in _cache:
+        return _cache['system_disks']
+
+    disks = set()
+
+    sources = set(system_pvs())
+    for mountpoint in ('/', '/boot', '/boot/efi'):
+        source = _source_of_mountpoint(mountpoint)
+        if source and source.startswith('/dev/'):
+            sources.add(source)
+
+    for source in sources:
+        parent = _parent_disk(source)
+        if parent:
+            disks.add(parent)
+        elif re.match(r'^/dev/[a-z0-9]+$', source) and not source.startswith('/dev/dm-'):
+            # No parent: the source is itself a whole disk.
+            disks.add(source)
+
+    _cache['system_disks'] = frozenset(disks)
+    return _cache['system_disks']
+
+
+# Names anaconda's first/primary disk usually takes. Only consulted when the
+# OS disk could not be determined from live mounts.
+_LIKELY_FIRST_DISKS = ('vda', 'sda', 'nvme0n1', 'xvda', 'hda')
+
+
+def is_system_disk(device):
+    """True if this disk (or a partition of it) holds the OS."""
+    if not device:
+        return True
+    device = device.strip()
+    disks = system_disks()
+
+    if not disks:
+        # Nothing could be probed (no lsblk, not root, odd container). Fall
+        # back to the old name heuristic rather than declaring every disk
+        # fair game — over-protecting costs a practice disk, under-
+        # protecting costs the candidate's VM.
+        return any(name in device for name in _LIKELY_FIRST_DISKS)
+
+    if device in disks:
+        return True
+    parent = _parent_disk(device)
+    return bool(parent and parent in disks)
+
+
+# ── boot layout ─────────────────────────────────────────────────────────────
+
+def efi_grub_configs():
+    """Every /boot/efi/EFI/<vendor>/grub.cfg present.
+
+    The vendor directory is distro-specific (redhat, rocky, almalinux,
+    centos), so it's globbed rather than guessed one name at a time.
+    """
+    return sorted(glob.glob('/boot/efi/EFI/*/grub.cfg'))
+
+
+def grub_config_present():
+    """True if a usable GRUB config exists (BIOS or UEFI layout)."""
+    return os.path.isfile('/boot/grub2/grub.cfg') or bool(efi_grub_configs())
+
+
+# ── environment report ──────────────────────────────────────────────────────
+
+def check_environment():
+    """Report on how well this box suits the simulator.
+
+    Returns a list of (level, message) where level is 'ok', 'warn' or
+    'error'. Purely informational — nothing here blocks a session.
+    """
+    findings = []
+
+    name = distro_name()
+    did = distro_id()
+    major = distro_major()
+
+    if not did:
+        findings.append(('warn',
+                         "Could not read /etc/os-release — unable to confirm this "
+                         "is a RHEL-family system. Tasks may not behave as expected."))
+    elif did not in SUPPORTED_IDS and not is_rhel_family():
+        findings.append(('error',
+                         "%s is not a RHEL-family distribution. Package names, "
+                         "SELinux, firewalld and boot layout will all differ; "
+                         "most tasks will not grade correctly." % name))
+    elif major is not None and major not in SUPPORTED_MAJORS:
+        findings.append(('warn',
+                         "%s — EX200 v10 targets major version 10 (9 is usable). "
+                         "Some tasks may assume a different layout." % name))
+    else:
+        findings.append(('ok', "Detected %s" % name))
+
+    detected = detected_system_vgs()
+    if detected:
+        findings.append(('ok', "Protected system volume group(s): %s"
+                         % ', '.join(sorted(detected))))
+    elif _run(['vgs', '--noheadings', '-o', 'vg_name'], timeout=5) is not None:
+        findings.append(('ok', "No LVM-backed system mounts — nothing to protect"))
+    else:
+        findings.append(('warn',
+                         "Could not probe LVM to identify this system's own volume "
+                         "groups (lvm2 missing, or not running as root). Falling "
+                         "back to a list of known names; storage tasks will be "
+                         "conservative about which volumes they use."))
+
+    if not grub_config_present():
+        findings.append(('warn',
+                         "No GRUB config found at /boot/grub2/grub.cfg or "
+                         "/boot/efi/EFI/*/grub.cfg — boot tasks may not grade."))
+
+    return findings
+
+
+def describe():
+    """One-line summary of the detected environment."""
+    parts = [distro_name()]
+    vgs = sorted(detected_system_vgs())
+    if vgs:
+        parts.append("system VG: %s" % ', '.join(vgs))
+    return ' | '.join(parts)


### PR DESCRIPTION
Two independent bugs, both reproduced on a real AlmaLinux 10.2 VM before and after the fix.

## 1. `sudo rhcsa-simulator` never worked

The installer symlinked the launcher into `/usr/local/bin`. `sudo` ignores your `PATH` and uses `secure_path` from `/etc/sudoers`, which on RHEL, AlmaLinux and Rocky is:

```
Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin
```

`/usr/local/bin` is not on it, so the one command the README documented failed:

```
$ sudo rhcsa-simulator
sudo: rhcsa-simulator: command not found
```

This is not Alma-specific — it is the same on RHEL and Rocky. It went unnoticed because a plain root login shell *does* have `/usr/local/bin` on its PATH. Notably `sudo -i` does **not**, so only one of the three ways people start this actually worked.

**Fix:** `install.sh` reads `secure_path` and installs to a directory sudo actually searches (`/usr/bin` when `/usr/local/bin` isn't listed, `/usr/local/bin` when it is), prints which it chose, removes a stale launcher from a previous install, and writes a wrapper script instead of a symlink so it no longer depends on the `.py` executable bit or shebang resolution.

The verify step also fixed: it checked `[ -L "$BIN_LINK" ]`, which was always true regardless of whether the command could run. It now executes the command and fails the install if it doesn't.

## 2. AlmaLinux's root VG was treated as practice storage

"Is this the box's own storage, or the candidate's practice storage?" was answered by a hardcoded list copied into eight places:

```python
system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
```

Anaconda names the root VG after the product — Rocky is `rl`, RHEL is `rhel`, both covered; AlmaLinux is `almalinux`, which was not. On the test VM the released code returned:

```
get_practice_vg() -> almalinux
get_practice_lv() -> ('almalinux', 'root')
```

LVM tasks were being handed the running root filesystem, and `device_manager`'s cleanup pass treated the system LVs as removable (`lvremove -f` / `vgremove -f` / `pvremove` / `wipefs -a`).

**Fix:** new `utils/system_id.py` probes instead of matching names — system VGs come from what actually backs the mounted filesystems and active swap, the OS disk from what holds `/` and `/boot`, the UEFI `grub.cfg` from a glob of `/boot/efi/EFI/*/`. Name lists remain only as a fallback for boxes where LVM can't be queried, and an unidentifiable VG is treated as system, since refusing to touch what we can't identify is the right default when the alternative is `lvremove`.

Same change fixes:
- `reboot_engine` tested `/boot/efi/EFI/{redhat,rocky}/grub.cfg` but never `almalinux`, so UEFI Alma boxes failed the GRUB check and boot tasks reported boot failure
- `full_reset._system_swap()` matched `'rhel' in device`, so an Alma swap partition on `/dev/sda3` read as practice swap and was pulled from fstab
- practice-disk detection skipped disks by name (`vda|sda|nvme0n1|xvda`) instead of asking which disk holds the OS
- an independent system-disk check now guards the unrecoverable `pvremove`/`wipefs` steps

## Exam-content notes

From a candidate's real EX200 sitting:
- a directory a scripting task reads from may legitimately be **empty** — that's not a sign you set something up wrong
- not every partition/LVM task states a size. The LVM tips asserted the opposite ("Exam specifies exact size"), which is now corrected

## Verification

On AlmaLinux 10.2 (`ID=almalinux`, VG `almalinux`, `secure_path` without `/usr/local/bin`):

| | before | after |
|---|---|---|
| root login shell | works | works |
| `sudo -i` then command | **not found** | works |
| `sudo rhcsa-simulator` | **not found** | works (rc=0) |
| `get_practice_vg()` | `almalinux` | `None` (falls back to loop devices) |
| `is_system_vg('almalinux')` | `False` | `True` |

Also exercised the upgrade path: recreated the old `/usr/local/bin` symlink, re-ran the installer, confirmed it relocated the launcher and removed the stale copy.

Tests: **332 passed, 1 failed** — `test_exam_mode.py::test_generates_correct_count`, which also fails on unmodified `master`.

## Known gap, not addressed here

The README documents `install.sh --yes` and `--no-populate` and claims the installer "auto-detects a non-interactive shell and runs unattended". `install.sh` has no argument parsing at all, and a non-interactive re-install currently hits the "Remove existing installation?" prompt, reads empty, and exits 1. Same class of bug, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cp8gGc1CQ3UjdopTWsUmSd