### PR TITLE
Add browser exam task panel (--gui)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ python3 -m pytest -v            # Verbose output
 - `tasks/` — Task definitions (188 tasks, 25 categories, 8 domains)
 - `validators/` — Safe read-only system validators for each task type
 - `utils/` — AI feedback, progress reports, device detection
+- `utils/system_id.py` — distro + system-resource identification (see below)
 - `config/` — Settings and constants
 - `data/` — SQLite progress DB, bookmarks
 - `device/` — Loop device / practice disk setup
@@ -40,6 +41,16 @@ python3 -m pytest -v            # Verbose output
 ## Key Facts
 
 - **Target OS**: RHEL 10 / Rocky Linux 9-10 / AlmaLinux 9-10
+- **Never hardcode distro-specific names.** Anything that answers "is this the
+  box's own OS, or the candidate's practice storage?" goes through
+  `utils/system_id.py`, which *probes* — system VGs come from what actually
+  backs the mounted filesystems and active swap, the OS disk from what holds
+  `/` and `/boot`, the UEFI grub.cfg from a glob of `/boot/efi/EFI/*/`. The
+  static name lists in that module are fallbacks for unprobeable boxes only.
+  This existed as a hardcoded `{'rl','rl00','rhel','centos','fedora'}` set
+  copied into eight places; AlmaLinux's root VG is named `almalinux`, so on
+  Alma the simulator handed LVM tasks the system VG and considered the system
+  LVs cleanup fodder. Add detection, not another name.
 - **Requires root** — many validators run real system commands
 - **No internet needed** — fully offline; optional Claude AI feedback via `ANTHROPIC_API_KEY`
 - **Loop devices** — LVM tasks can use virtual disks (option 13 in menu) when no spare disk exists

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,10 @@ python3 -m pytest -v            # Verbose output
 
 - `rhcsa_simulator.py` — Main entry point
 - `core/` — Engine: task manager, exam loop, SM-2 spaced repetition, ResultsDB
+- `core/task_gui.py` — opt-in browser task panel (`--gui`), mirroring how the
+  real exam presents questions: dropdown task selector, Revisit/Done ticks,
+  countdown. Advisory only — it must never influence grading, which stays
+  driven by real system state. Stdlib `http.server`, no external assets.
 - `tasks/` — Task definitions (188 tasks, 25 categories, 8 domains)
 - `validators/` — Safe read-only system validators for each task type
 - `utils/` — AI feedback, progress reports, device detection

--- a/README.md
+++ b/README.md
@@ -170,6 +170,27 @@ Run without installing: `sudo python3 rhcsa_simulator.py`.
 sudo rhcsa-simulator    # interactive menu
 ```
 
+### Exam task panel (browser)
+
+The real exam doesn't put the questions in your terminal — they live in a
+window on the exam desktop, selected one at a time from a dropdown, each with
+**Revisit** and **Done** ticks. Managing that window while you work is its own
+skill, so practise it:
+
+```bash
+sudo rhcsa-simulator --exam --gui          # panel on :8080
+sudo rhcsa-simulator --exam --gui 9000     # pick a port
+sudo rhcsa-simulator --exam --gui --gui-bind 127.0.0.1   # local only
+```
+
+The panel prints its URLs at exam start. It binds `0.0.0.0` by default so a
+headless exam VM can be read from your laptop's browser; it is unauthenticated
+and serves exam questions only — no shell, no control of the box.
+
+The ticks are your own bookkeeping. Grading is unchanged: it still runs against
+real system state when you return to the terminal, so ticking "done" earns
+nothing on its own.
+
 | Key | Mode | What it does |
 |---|---|---|
 | `Q` | **Quick Practice** | Short session (you pick 4-20 tasks), fast feedback |

--- a/README.md
+++ b/README.md
@@ -141,10 +141,24 @@ whatever state a fresh install puts it in (tasks manage state themselves):
 ./install.sh --no-populate   # skip the optional DNF-history setup
 ```
 
-The installer checks Python/OS, copies files to `/opt/rhcsa-simulator`, creates
-the `rhcsa-simulator` command in `/usr/local/bin`, and optionally builds some DNF
-transaction history for the package-history tasks. It auto-detects a
-non-interactive shell and runs unattended, so it won't stall in automation.
+The installer checks Python/OS, copies files to `/opt/rhcsa-simulator`, installs
+the `rhcsa-simulator` launcher, and optionally builds some DNF transaction
+history for the package-history tasks. It auto-detects a non-interactive shell
+and runs unattended, so it won't stall in automation.
+
+**Where the launcher goes:** `sudo` ignores your `PATH` and uses `secure_path`
+from `/etc/sudoers`, which on RHEL, AlmaLinux and Rocky is:
+
+```
+Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+```
+
+`/usr/local/bin` is not on it, so a launcher installed there works from a root
+shell but fails under `sudo` with `sudo: rhcsa-simulator: command not found`.
+The installer therefore checks `secure_path` and installs to `/usr/bin` when
+`/usr/local/bin` isn't searched, and to `/usr/local/bin` when it is. It prints
+the path it chose and verifies the command actually runs before reporting
+success.
 
 Run without installing: `sudo python3 rhcsa_simulator.py`.
 
@@ -422,6 +436,12 @@ Set `ANTHROPIC_API_KEY` to enable line-by-line command analysis. See
 ## Troubleshooting
 
 - **"must be run as root"** — launch with `sudo`.
+- **`sudo: rhcsa-simulator: command not found`** — you have an old install that
+  put the launcher in `/usr/local/bin`, which `sudo` does not search on
+  RHEL/Alma/Rocky (see [Installation](#installation)). Re-run `./install.sh`,
+  which relocates it and removes the stale copy. To confirm afterwards:
+  `sudo rhcsa-simulator --list-categories`. Until then, the full path works:
+  `sudo /usr/local/bin/rhcsa-simulator`.
 - **Storage tasks fail in a container** — loop devices/SELinux/systemd may be
   limited; use a real RHEL/Rocky/Alma VM.
 - **Messy state after a crash / want a clean box** — run **Setup → Reset

--- a/core/content/domain_4_storage.py
+++ b/core/content/domain_4_storage.py
@@ -115,6 +115,14 @@ TOOLS:
             "partprobe updates kernel without reboot",
             "GPT allows more partitions and larger disks",
             "Check with lsblk after partitioning",
+            "Not every task states a size. 'Create a backup partition on "
+            "/dev/sda' with no number is a real exam phrasing — it means the "
+            "size is yours to choose, not that you missed a line. Pick "
+            "something sensible, leave room for later tasks on the same disk, "
+            "and move on.",
+            "When a size IS given, treat it as exact and check the tolerance: "
+            "'1GiB' is 1024MiB, not 1000MiB. Mixing the two is a common "
+            "silent failure.",
         ],
     },
     "lvm": {
@@ -181,7 +189,15 @@ full LVM stack and resize volumes.
             "Insufficient space in VG for LV",
         ],
         "exam_tricks": [
-            "Exam specifies exact size - watch units (M vs MB vs MiB)",
+            "When a size is given, watch the units (M vs MB vs MiB)",
+            "But do NOT assume every task gives one. Some are deliberately "
+            "open ('create a backup volume in vg01'), leaving the size to "
+            "your judgement — that is not a missing detail. Size it to fit "
+            "the VG with room for later tasks, then say so and move on.",
+            "Sized in extents rather than bytes? -l takes extents, -L takes "
+            "bytes: lvcreate -l 128 (extents) vs lvcreate -L 512M. "
+            "-l 100%FREE takes whatever is left, which is often the right "
+            "answer for an open-ended 'use the remaining space' task.",
             "May ask to extend existing LV (not create new)",
             "Filesystem resize is separate step (unless -r flag)",
             "Path is /dev/vgname/lvname or /dev/mapper/vgname-lvname",

--- a/core/content/domain_8_automation.py
+++ b/core/content/domain_8_automation.py
@@ -241,6 +241,13 @@ EXIT CODES:
             "Exit 0 for success, non-zero for errors",
             "Use $? to check if previous command succeeded",
             "bash -n script.sh to check syntax without running",
+            "A directory the task tells you to read from may legitimately be "
+            "EMPTY. That is not a hint that you set something up wrong — you "
+            "are graded on the script, not on it having produced output. Write "
+            "it, make it executable, run it, confirm it exits 0, move on.",
+            "Don't hardcode around the data you happen to see. 'Copy the "
+            "contents of /foo to /bar' means cp -a /foo/. /bar/ (or rsync), "
+            "which is correct whether /foo holds 0 files or 500.",
         ],
     },
 }

--- a/core/exam.py
+++ b/core/exam.py
@@ -35,8 +35,15 @@ class ExamSession:
     reboot simulation, and ResultsDB persistence.
     """
 
-    def __init__(self, task_count=None, timer_enabled=True, duration_minutes=None, reboot_simulation=None):
+    def __init__(self, task_count=None, timer_enabled=True, duration_minutes=None,
+                 reboot_simulation=None, gui_port=None, gui_bind='0.0.0.0'):
         self.task_count = task_count or settings.DEFAULT_EXAM_TASKS
+        # Browser task panel — the exam shows its questions in a window you
+        # keep beside your terminals, so practising that is part of the point.
+        # None = off (opt-in via --gui).
+        self.gui_port = gui_port
+        self.gui_bind = gui_bind
+        self.panel = None
         self.timer_enabled = timer_enabled
         self.duration_minutes = duration_minutes or settings.DEFAULT_EXAM_DURATION
         self.reboot_simulation = reboot_simulation if reboot_simulation is not None else settings.REBOOT_SIMULATION
@@ -110,6 +117,10 @@ class ExamSession:
         # Refresh the remote NFS server's exports so this exam starts clean.
         self._reprovision_nfs()
 
+        # Bring the browser panel up before the sheet is shown, so the URL is
+        # on screen while the candidate still has both hands free.
+        self._start_task_panel()
+
         self._display_tasks()
 
         # Start timer
@@ -132,6 +143,38 @@ class ExamSession:
 
         print("\nComplete the tasks on your system, then return here to validate your work.")
         print("=" * 60)
+
+    def _start_task_panel(self):
+        """Serve the task sheet to a browser window. Opt-in, best-effort: a
+        panel that won't start must never prevent an exam from running."""
+        if not self.gui_port:
+            return
+        from core import task_gui
+        task_gui.clear_marks()
+        self.panel, urls = task_gui.start_for_session(
+            self, port=self.gui_port, bind=self.gui_bind)
+        if not urls:
+            print(fmt.warning(
+                f"\nTask panel could not start on port {self.gui_port} "
+                f"(in use?). Continuing without it — the task sheet below is "
+                f"the same content."))
+            return
+        print()
+        print(fmt.success("Task panel running — open it beside your terminals:"))
+        for url in urls:
+            print(fmt.bold(f"    {url}"))
+        if self.gui_bind not in ('127.0.0.1', 'localhost'):
+            print(fmt.dim("  (Unauthenticated and reachable from your LAN. It "
+                          "serves exam questions only — no shell, no control "
+                          "of this box.)"))
+
+    def _stop_task_panel(self):
+        if self.panel:
+            try:
+                self.panel.stop()
+            except Exception:
+                pass
+            self.panel = None
 
     def _provision_devices(self):
         """Assign a distinct practice device to each whole-disk task so an LVM
@@ -538,18 +581,26 @@ def _select_reboot_simulation():
             print(fmt.error("Invalid selection"))
 
 
-def run_exam_mode():
+def run_exam_mode(gui_port=None, gui_bind='0.0.0.0'):
     """Run exam mode (convenience function)."""
     task_count = _select_exam_task_count()
     reboot_sim = _select_reboot_simulation()
-    session = ExamSession(task_count=task_count, reboot_simulation=reboot_sim)
+    session = ExamSession(task_count=task_count, reboot_simulation=reboot_sim,
+                          gui_port=gui_port, gui_bind=gui_bind)
     session.start()
 
     if not session.tasks:
+        session._stop_task_panel()
         return None
 
     input("\nPress Enter when you're ready to validate your work...")
 
-    # No teardown on any exit path — the environment persists for review and
-    # disputes. The next session start (or Setup → Reset Machine) cleans up.
-    return session.validate_all()
+    try:
+        # No teardown on any exit path — the environment persists for review
+        # and disputes. The next session start (or Setup → Reset Machine)
+        # cleans up.
+        return session.validate_all()
+    finally:
+        # The panel is a view of a running exam; once grading starts it is
+        # showing a sheet nobody can act on any more.
+        session._stop_task_panel()

--- a/core/full_reset.py
+++ b/core/full_reset.py
@@ -336,11 +336,16 @@ _PROTECTED_PREFIXES = ('/proc', '/sys', '/run', '/dev', '/boot', '/usr',
 _PRACTICE_TARGET_PREFIXES = ('/mnt/', '/media/', '/srv/', '/data', '/export',
                              '/shares', '/misc/', '/autofs')
 
-# System volume groups whose LVs must never be unmounted (mirror helpers).
+# System volume groups whose LVs must never be unmounted. Detected from the
+# live mounts (see utils.system_id), with a static name list as fallback.
 try:
-    from utils.helpers import _SYSTEM_VGS as _SYS_VGS
-except Exception:  # pragma: no cover - fallback if helpers changes
+    from utils.system_id import KNOWN_SYSTEM_VG_NAMES as _SYS_VGS
+    from utils.system_id import is_system_vg
+except Exception:  # pragma: no cover - fallback if system_id is unavailable
     _SYS_VGS = {'rl', 'rl00', 'rhel', 'centos', 'fedora', 'almalinux', 'rocky'}
+
+    def is_system_vg(vg):
+        return not vg or vg.strip() in _SYS_VGS
 
 
 def _dm_vg(source):
@@ -361,7 +366,7 @@ def _is_practice_mount(target, source, fstype):
     if re.match(r'^/dev/loop\d+', source or ''):
         return True
     if (source or '').startswith(('/dev/mapper/', '/dev/dm-')):
-        return _dm_vg(source) not in _SYS_VGS
+        return not is_system_vg(_dm_vg(source))
     if target.startswith(_PRACTICE_TARGET_PREFIXES):
         return True
     return False
@@ -411,6 +416,21 @@ def unmount_practice_mounts(progress=_noop):
 # ── Practice swap + fstab ────────────────────────────────────────────────────
 
 def _system_swap(device):
+    """True for the swap the OS installed itself, which must survive a reset.
+
+    Name matching alone ('rhel' in the path) only recognised RHEL's own
+    layout; an AlmaLinux swap partition on /dev/sda3 looked like practice
+    swap and got torn out of fstab. Ask what the device actually is first.
+    """
+    try:
+        from utils.system_id import is_system_disk, vg_of_device, is_system_vg
+        vg = vg_of_device(device)
+        if vg:
+            return is_system_vg(vg)
+        if is_system_disk(device):
+            return True
+    except Exception:
+        pass
     return any(x in device for x in ('/dev/nvme', 'rhel', 'dm-'))
 
 

--- a/core/preflight.py
+++ b/core/preflight.py
@@ -109,6 +109,30 @@ def offer_task_packages(tasks):
     return filter_missing(needed)
 
 
+def report_environment():
+    """Print what OS this is and which volume groups are being protected.
+
+    Every distro-specific decision the simulator makes (which VG is the
+    candidate's practice storage, which disk is the OS, where grub.cfg
+    lives) is derived from this. Showing it at startup means a box we've
+    mis-identified is visible immediately, instead of surfacing later as a
+    task that behaved strangely. Best-effort — never fails the launch.
+    """
+    try:
+        from utils import system_id
+        findings = system_id.check_environment()
+    except Exception:
+        return
+
+    for level, message in findings:
+        if level == 'error':
+            print(fmt.error(f"\n! {message}"))
+        elif level == 'warn':
+            print(fmt.warning(f"\n! {message}"))
+        else:
+            print(fmt.dim(f"  {message}"))
+
+
 def warn_missing(missing=None):
     """Print a one-time warning listing missing packages and how to install
     them. No-op if nothing is missing (or rpm status is unknown)."""

--- a/core/reboot_engine.py
+++ b/core/reboot_engine.py
@@ -162,16 +162,22 @@ class RebootEngine:
 
     def _check_grub(self):
         """Check that GRUB configuration is intact."""
-        # Check grub.cfg exists
+        # Check grub.cfg exists. On RHEL 9/10 the layout is unified and this
+        # is the canonical path for BIOS and UEFI alike.
         result = execute_safe(['test', '-f', '/boot/grub2/grub.cfg'])
-        if not result.success:
-            # Try EFI path
-            result = execute_safe(['test', '-f', '/boot/efi/EFI/redhat/grub.cfg'])
-            if not result.success:
-                result = execute_safe(['test', '-f', '/boot/efi/EFI/rocky/grub.cfg'])
-                if not result.success:
-                    return False
-        return True
+        if result.success:
+            return True
+
+        # Older/odd UEFI layouts keep it under a vendor directory named after
+        # the distro. That name was previously hardcoded to 'redhat' then
+        # 'rocky', so AlmaLinux (/boot/efi/EFI/almalinux) failed this check
+        # and every boot task on Alma reported a boot failure. Glob instead of
+        # guessing names one at a time.
+        from utils.system_id import efi_grub_configs
+        for cfg in efi_grub_configs():
+            if execute_safe(['test', '-f', cfg]).success:
+                return True
+        return False
 
     def get_reboot_report(self, reboot_result, tasks):
         """Generate a human-readable reboot simulation report."""

--- a/core/task_gui.py
+++ b/core/task_gui.py
@@ -1,0 +1,705 @@
+"""
+Exam task panel — the question sheet as a separate window you manage.
+
+WHY
+---
+On the real EX200 the tasks live in a window on the exam desktop, not in
+your terminal: a checklist you tick off, with each task's detail hidden
+until you open it. You read one, alt-tab away, work, alt-tab back, lose
+your place, scroll, and repeat that twenty times under a clock. Candidates
+consistently report that juggling that panel is its own skill, separate
+from knowing the material — so practising against a scrollable pager in
+the same terminal you're working in trains the wrong thing.
+
+This serves the live task sheet over HTTP so it can sit in a browser window
+beside your terminals, the way it will on the day.
+
+SHAPE
+-----
+Same interaction model as the current exam, in a modern skin: a sidebar
+carrying the countdown and a done/revisit tally, a "perform this task on
+<host>" chip, and a **dropdown** that selects one task at a time. Entries
+in that dropdown are deliberately generic ("Task 07") — exactly as on the
+day, you cannot triage the list by reading it, you have to open each one.
+
+Each task carries **Revisit** and **Done**. They toggle independently:
+click again to clear, and a task can be both (you did something, but want
+another look).
+
+No Red Hat branding — this is a practice tool and must not present itself
+as the real exam.
+
+Marks are advisory bookkeeping for the candidate. Ticking "done" does not
+tell the grader anything — validation still runs against real system state
+in the terminal, exactly as before. That separation is deliberate: the
+panel must never become a way to score points.
+
+DESIGN
+------
+- Stdlib only (http.server + json), consistent with the rest of the project.
+- Read-mostly. The panel shows state and records ticks; it never validates,
+  never mutates the system, and never touches task state the grader reads.
+- Marks live server-side so the view survives a page reload and is shared
+  across windows (laptop and phone show the same ticks).
+- The page holds no state worth losing: it polls /api/state and re-renders.
+- Runs on a daemon thread. A dead or hung panel must never hold up an exam,
+  so every failure path degrades to "no panel" rather than raising.
+"""
+
+import json
+import logging
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PORT = 8080
+
+MARK_FIELDS = ('done', 'revisit')
+
+# Per-session and deliberately in-memory. These are the exam's own "done" /
+# "revisit" ticks, NOT core.task_flags (which reports a task as *defective*
+# and persists to disk for the maintainer). Conflating them would let a
+# candidate silently file bug reports against tasks they merely found hard.
+_marks = {}
+
+
+def _domain_name(task):
+    try:
+        from config import settings
+        return settings.EXAM_DOMAINS.get(getattr(task, 'exam_domain', 0), '')
+    except Exception:
+        return ''
+
+
+def _local_host():
+    try:
+        name = socket.getfqdn()
+        return name if name and name != 'localhost' else socket.gethostname()
+    except Exception:
+        return 'this system'
+
+
+def _target_host(task):
+    """Which machine this task is performed on.
+
+    The real exam groups its sheet by node ("Perform the following tasks on
+    node1.domain14.example.com"), so tasks that run against the optional lab
+    machine are grouped separately from the ones on this box.
+    """
+    if getattr(task, 'requires_lab_machine', False):
+        try:
+            from core import lab_machine
+            host = lab_machine.get_host()
+            if host:
+                return host
+        except Exception:
+            pass
+        return 'the lab machine'
+    return _local_host()
+
+
+def _category_label(task):
+    """Human-readable category — this is all the candidate sees until they
+    open the task, so it has to be meaningful on its own."""
+    try:
+        from utils.formatters import format_category_name
+        return format_category_name(getattr(task, 'category', '') or '')
+    except Exception:
+        return (getattr(task, 'category', '') or '').replace('_', ' ').title()
+
+
+def marks_for(task_id):
+    """Current ticks for a task, defaulted."""
+    m = _marks.get(task_id) or {}
+    return {f: bool(m.get(f)) for f in MARK_FIELDS}
+
+
+def set_mark(task_id, field, value):
+    """Tick/untick one box. Returns the task's full mark state.
+
+    'done' and 'revisit' are independent on purpose — mid-exam you often
+    want both on the same task ("I did something, but come back to it").
+    """
+    if not task_id or field not in MARK_FIELDS:
+        raise ValueError('unknown mark field')
+    current = dict(marks_for(task_id))
+    current[field] = bool(value)
+    _marks[task_id] = current
+    return current
+
+
+def clear_marks():
+    _marks.clear()
+
+
+def build_state(tasks, remaining_seconds=None):
+    """Serialisable snapshot of the exam for the panel.
+
+    Pure and side-effect free so it can be tested without a server.
+    """
+    items = []
+    for i, task in enumerate(tasks or [], 1):
+        task_id = getattr(task, 'id', '') or ''
+        m = marks_for(task_id)
+        items.append({
+            'n': i,
+            'id': task_id,
+            'description': getattr(task, 'description', '') or '',
+            'points': getattr(task, 'points', 0) or 0,
+            'domain': getattr(task, 'exam_domain', 0) or 0,
+            'domain_name': _domain_name(task),
+            'category': _category_label(task),
+            'host': _target_host(task),
+            'done': m['done'],
+            'revisit': m['revisit'],
+        })
+    return {
+        'tasks': items,
+        'count': len(items),
+        'total_points': sum(t['points'] for t in items),
+        'done_count': sum(1 for t in items if t['done']),
+        'revisit_count': sum(1 for t in items if t['revisit']),
+        'remaining_seconds': remaining_seconds,
+    }
+
+
+def _local_addresses(port):
+    """URLs the panel is reachable on, best-effort. The LAN address matters:
+    the exam VM is usually headless, so the browser is on another machine."""
+    urls = ['http://127.0.0.1:%d/' % port]
+    try:
+        # No traffic is sent — this just asks the kernel which source address
+        # it would use, which is the one another host can reach us on.
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(('192.0.2.1', 9))  # TEST-NET-1, guaranteed unroutable
+            ip = s.getsockname()[0]
+        finally:
+            s.close()
+        if ip and not ip.startswith('127.'):
+            urls.append('http://%s:%d/' % (ip, port))
+    except OSError:
+        pass
+    return urls
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server_version = 'RHCSATaskPanel/1.0'
+
+    # Silence per-request logging; an exam console must stay readable.
+    def log_message(self, fmt_, *args):
+        logger.debug("task_gui: " + fmt_, *args)
+
+    def _send(self, code, body, content_type):
+        if isinstance(body, str):
+            body = body.encode('utf-8')
+        self.send_response(code)
+        self.send_header('Content-Type', content_type)
+        self.send_header('Content-Length', str(len(body)))
+        self.send_header('Cache-Control', 'no-store')
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+        except (BrokenPipeError, ConnectionResetError):
+            pass  # browser navigated away mid-response
+
+    def do_GET(self):
+        path = self.path.split('?', 1)[0].rstrip('/') or '/'
+        if path == '/':
+            self._send(200, PAGE_HTML, 'text/html; charset=utf-8')
+        elif path == '/api/state':
+            try:
+                state = self.server.state_provider()
+            except Exception as e:
+                logger.debug("state_provider failed: %s", e)
+                state = {'tasks': [], 'count': 0, 'total_points': 0,
+                         'done_count': 0, 'revisit_count': 0,
+                         'remaining_seconds': None, 'error': 'state unavailable'}
+            self._send(200, json.dumps(state), 'application/json')
+        else:
+            self._send(404, '{"error":"not found"}', 'application/json')
+
+    def do_POST(self):
+        path = self.path.split('?', 1)[0].rstrip('/') or '/'
+        if path != '/api/mark':
+            self._send(404, '{"error":"not found"}', 'application/json')
+            return
+        try:
+            length = int(self.headers.get('Content-Length') or 0)
+            payload = json.loads(self.rfile.read(length) or b'{}')
+            task_id = payload.get('id')
+            field = payload.get('field')
+            value = bool(payload.get('value'))
+        except (ValueError, TypeError, OSError):
+            self._send(400, '{"error":"bad request"}', 'application/json')
+            return
+        try:
+            state = set_mark(task_id, field, value)
+        except ValueError:
+            self._send(400, '{"error":"unknown mark"}', 'application/json')
+            return
+        self._send(200, json.dumps({'id': task_id, 'marks': state}),
+                   'application/json')
+
+
+class TaskPanel:
+    """Background HTTP server showing the current exam's task sheet."""
+
+    def __init__(self, state_provider, port=DEFAULT_PORT, bind='0.0.0.0'):
+        self.state_provider = state_provider
+        self.port = port
+        self.bind = bind
+        self._httpd = None
+        self._thread = None
+
+    @property
+    def running(self):
+        return self._httpd is not None
+
+    def start(self):
+        """Start serving. Returns the list of URLs, or [] if it couldn't
+        start — a panel that won't bind must not stop the exam."""
+        if self.running:
+            return self.urls()
+        try:
+            httpd = ThreadingHTTPServer((self.bind, self.port), _Handler)
+        except OSError as e:
+            logger.warning("task panel could not bind %s:%s — %s",
+                           self.bind, self.port, e)
+            return []
+        httpd.state_provider = self.state_provider
+        httpd.daemon_threads = True
+        self._httpd = httpd
+        self._thread = threading.Thread(target=httpd.serve_forever,
+                                        name='rhcsa-task-panel', daemon=True)
+        self._thread.start()
+        return self.urls()
+
+    def urls(self):
+        if not self.running:
+            return []
+        port = self._httpd.server_address[1]
+        if self.bind in ('127.0.0.1', 'localhost'):
+            return ['http://127.0.0.1:%d/' % port]
+        return _local_addresses(port)
+
+    def stop(self):
+        if not self.running:
+            return
+        try:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+        except Exception as e:
+            logger.debug("task panel shutdown: %s", e)
+        finally:
+            self._httpd = None
+            self._thread = None
+
+
+def start_for_session(session, port=DEFAULT_PORT, bind='0.0.0.0'):
+    """Start a panel backed by a live ExamSession. Never raises."""
+    def provider():
+        remaining = None
+        try:
+            from core import exam_clock
+            remaining = exam_clock.remaining_seconds()
+        except Exception:
+            pass
+        return build_state(getattr(session, 'tasks', []), remaining)
+
+    try:
+        panel = TaskPanel(provider, port=port, bind=bind)
+        urls = panel.start()
+        return (panel, urls) if urls else (None, [])
+    except Exception as e:
+        logger.warning("task panel failed to start: %s", e)
+        return (None, [])
+
+
+PAGE_HTML = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RHCSA Mock Exam &mdash; Tasks</title>
+<style>
+  :root {
+    --bg:#0e1116; --sunk:#0a0d11; --panel:#161a21; --panel2:#1c212a;
+    --edge:#252b35; --edge2:#333b47;
+    --ink:#e8ebf0; --dim:#9aa4b2; --faint:#6b7280;
+    --accent:#3b82f6; --accent-ink:#fff;
+    --done:#22c55e; --revisit:#f59e0b; --crit:#ef4444;
+    --radius:14px;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg:#f5f6f8; --sunk:#eceef2; --panel:#fff; --panel2:#f8f9fb;
+      --edge:#e2e5ea; --edge2:#cfd4dc;
+      --ink:#11151b; --dim:#5b6472; --faint:#858d99;
+      --done:#15803d; --revisit:#b45309;
+    }
+  }
+  * { box-sizing:border-box; }
+  html,body { height:100%; }
+  body {
+    margin:0; background:var(--bg); color:var(--ink);
+    font:15px/1.55 system-ui, -apple-system, "Segoe UI", Cantarell, Roboto,
+         "Helvetica Neue", Arial, sans-serif;
+    -webkit-font-smoothing:antialiased;
+  }
+  #wrap { display:flex; min-height:100%; gap:0; }
+
+  /* ── sidebar ───────────────────────────────────────────────────────── */
+  aside {
+    width:248px; flex:0 0 248px; background:var(--sunk);
+    border-right:1px solid var(--edge);
+    padding:22px 18px; position:sticky; top:0; height:100vh;
+    display:flex; flex-direction:column; gap:20px;
+  }
+  .brand { display:flex; align-items:center; gap:10px; }
+  .glyph {
+    width:30px; height:30px; border-radius:9px; flex:0 0 30px;
+    background:linear-gradient(135deg,var(--accent),#8b5cf6);
+  }
+  .brand b { font-size:15px; font-weight:620; letter-spacing:-.1px; }
+  .brand span { display:block; font-size:11.5px; color:var(--faint);
+                font-weight:450; letter-spacing:.3px; }
+
+  .clockwrap {
+    background:var(--panel); border:1px solid var(--edge);
+    border-radius:var(--radius); padding:14px 16px;
+  }
+  .clocklabel { font-size:11px; text-transform:uppercase; letter-spacing:.9px;
+                color:var(--faint); margin-bottom:5px; }
+  .clock {
+    font-size:30px; font-weight:640; letter-spacing:-.5px;
+    font-variant-numeric:tabular-nums; line-height:1.1;
+  }
+  .clock.warn { color:var(--revisit); }
+  .clock.crit { color:var(--crit); }
+
+  .prog { display:flex; flex-direction:column; gap:9px; }
+  .progbar { height:6px; border-radius:99px; background:var(--edge); overflow:hidden; }
+  .progbar i { display:block; height:100%; background:var(--done);
+               border-radius:99px; transition:width .25s ease; }
+  .stats { display:flex; gap:8px; }
+  .stat {
+    flex:1; background:var(--panel); border:1px solid var(--edge);
+    border-radius:11px; padding:9px 10px;
+  }
+  .stat b { display:block; font-size:19px; font-weight:640;
+            font-variant-numeric:tabular-nums; line-height:1.15; }
+  .stat span { font-size:11px; color:var(--faint); letter-spacing:.2px; }
+  .stat.d b { color:var(--done); }
+  .stat.r b { color:var(--revisit); }
+
+  .side-note { margin-top:auto; font-size:11.5px; color:var(--faint); line-height:1.5; }
+
+  /* ── main ──────────────────────────────────────────────────────────── */
+  main { flex:1; padding:26px 30px 50px; max-width:940px; }
+
+  .hostchip {
+    display:inline-flex; align-items:center; gap:8px; margin-bottom:18px;
+    background:var(--panel); border:1px solid var(--edge);
+    border-radius:99px; padding:6px 14px 6px 11px; font-size:13px; color:var(--dim);
+  }
+  .hostchip i {
+    width:7px; height:7px; border-radius:99px; background:var(--done);
+    box-shadow:0 0 0 3px color-mix(in srgb, var(--done) 22%, transparent);
+  }
+  .hostchip code {
+    font-family:ui-monospace,SFMono-Regular,"JetBrains Mono",Menlo,monospace;
+    font-size:12.5px; color:var(--ink);
+  }
+
+  .toolbar { display:flex; gap:12px; align-items:center; margin-bottom:16px;
+             flex-wrap:wrap; }
+  .selwrap { position:relative; flex:1; min-width:260px; max-width:520px; }
+  select {
+    appearance:none; width:100%; font:inherit; font-size:14.5px;
+    padding:11px 38px 11px 14px; color:var(--ink);
+    background:var(--panel); border:1px solid var(--edge2);
+    border-radius:11px; cursor:pointer;
+  }
+  select:focus { outline:2px solid var(--accent); outline-offset:1px; }
+  .selwrap::after {
+    content:""; position:absolute; right:15px; top:50%; pointer-events:none;
+    width:8px; height:8px; margin-top:-6px; border-right:2px solid var(--dim);
+    border-bottom:2px solid var(--dim); transform:rotate(45deg);
+  }
+
+  .marks { display:flex; gap:8px; }
+  .mk {
+    display:inline-flex; align-items:center; gap:8px; cursor:pointer;
+    user-select:none; font-size:14px; padding:10px 15px; border-radius:11px;
+    border:1px solid var(--edge2); background:var(--panel); color:var(--dim);
+    transition:background .12s, border-color .12s, color .12s;
+  }
+  .mk:hover { border-color:var(--edge2); color:var(--ink); }
+  .mk .box {
+    width:17px; height:17px; border-radius:6px; flex:0 0 17px;
+    border:1.5px solid var(--edge2); display:grid; place-items:center;
+    font-size:11px; line-height:1; color:transparent;
+  }
+  .mk.on { color:var(--ink); }
+  .mk.on-done { border-color:var(--done); background:color-mix(in srgb,var(--done) 13%,transparent); }
+  .mk.on-done .box { background:var(--done); border-color:var(--done); color:#fff; }
+  .mk.on-revisit { border-color:var(--revisit); background:color-mix(in srgb,var(--revisit) 13%,transparent); }
+  .mk.on-revisit .box { background:var(--revisit); border-color:var(--revisit); color:#fff; }
+
+  .card {
+    background:var(--panel); border:1px solid var(--edge);
+    border-radius:var(--radius); padding:24px 26px;
+  }
+  .card-top {
+    display:flex; align-items:center; gap:10px; margin-bottom:16px;
+    padding-bottom:14px; border-bottom:1px solid var(--edge);
+  }
+  .tasknum { font-size:13px; color:var(--faint); font-variant-numeric:tabular-nums; }
+  .pill {
+    font-size:11.5px; letter-spacing:.3px; color:var(--dim);
+    background:var(--panel2); border:1px solid var(--edge);
+    border-radius:99px; padding:3px 10px;
+  }
+  .pts { margin-left:auto; font-size:13px; color:var(--faint);
+         font-variant-numeric:tabular-nums; }
+  .desc { white-space:pre-wrap; font-size:16px; line-height:1.65; }
+  .desc.mono {
+    font-family:ui-monospace,SFMono-Regular,"JetBrains Mono",Menlo,monospace;
+    font-size:14px; line-height:1.7;
+  }
+
+  .nav { display:flex; gap:9px; align-items:center; margin-top:18px; }
+  button {
+    font:inherit; font-size:14px; padding:9px 16px; border-radius:10px;
+    border:1px solid var(--edge2); background:var(--panel); color:var(--ink);
+    cursor:pointer; transition:background .12s, border-color .12s;
+  }
+  button:hover:not(:disabled) { background:var(--panel2); border-color:var(--accent); }
+  button:disabled { opacity:.4; cursor:default; }
+  .keys { margin-left:auto; font-size:12px; color:var(--faint); }
+  kbd {
+    font:inherit; font-size:11px; padding:1.5px 6px; border-radius:5px;
+    background:var(--panel2); border:1px solid var(--edge2); color:var(--dim);
+  }
+
+  .empty { padding:80px 0; text-align:center; color:var(--faint); }
+  .empty b { display:block; font-size:16px; color:var(--dim); margin-bottom:6px;
+             font-weight:550; }
+
+  @media (max-width:760px) {
+    #wrap { display:block; }
+    aside { width:auto; height:auto; position:static; flex-direction:row;
+            flex-wrap:wrap; align-items:center; border-right:0;
+            border-bottom:1px solid var(--edge); }
+    .clockwrap { flex:1; } .prog { flex:1; } .side-note { display:none; }
+    main { padding:20px 16px 40px; }
+  }
+</style>
+</head>
+<body>
+<div id="wrap">
+  <aside>
+    <div class="brand">
+      <div class="glyph"></div>
+      <div><b>RHCSA Mock Exam</b><span>EX200 practice</span></div>
+    </div>
+
+    <div class="clockwrap">
+      <div class="clocklabel">Time remaining</div>
+      <div class="clock" id="clock">&mdash;</div>
+    </div>
+
+    <div class="prog">
+      <div class="progbar"><i id="progfill" style="width:0%"></i></div>
+      <div class="stats">
+        <div class="stat d"><b id="ndone">0</b><span>done</span></div>
+        <div class="stat r"><b id="nrev">0</b><span>revisit</span></div>
+        <div class="stat"><b id="nleft">0</b><span>left</span></div>
+      </div>
+    </div>
+
+    <div class="side-note">Ticks here are your own notes. Grading runs
+      against real system state when you return to the terminal.</div>
+  </aside>
+
+  <main>
+    <div id="sheet">
+      <div class="empty"><b>Waiting for an exam to start</b>
+        Start one in the terminal &mdash; this panel follows it.</div>
+    </div>
+  </main>
+</div>
+
+<script>
+(function () {
+  var state = { tasks: [] };
+  var cur = 0;               // 0-based index of the selected task
+  var localRemaining = null; // ticks locally between polls
+
+  var $ = function (id) { return document.getElementById(id); };
+
+  function esc(s) {
+    return String(s === null || s === undefined ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function fmtClock(s) {
+    if (s === null || s === undefined) return null;
+    if (s < 0) s = 0;
+    var h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), x = Math.floor(s % 60);
+    var p = function (n) { return (n < 10 ? '0' : '') + n; };
+    return h + ':' + p(m) + ':' + p(x);
+  }
+
+  function renderClock() {
+    var el = $('clock');
+    var t = fmtClock(localRemaining);
+    if (t === null) { el.textContent = 'No limit'; el.className = 'clock'; return; }
+    el.textContent = t;
+    el.className = 'clock' + (localRemaining <= 300 ? ' crit'
+                            : localRemaining <= 900 ? ' warn' : '');
+  }
+
+  function renderSidebar() {
+    var ts = state.tasks || [];
+    var done = state.done_count || 0;
+    $('ndone').textContent = done;
+    $('nrev').textContent = state.revisit_count || 0;
+    $('nleft').textContent = Math.max(0, ts.length - done);
+    $('progfill').style.width = ts.length ? (done / ts.length * 100) + '%' : '0%';
+  }
+
+  function render() {
+    var ts = state.tasks || [];
+    renderSidebar();
+    if (!ts.length) {
+      $('sheet').innerHTML = '<div class="empty"><b>Waiting for an exam to start</b>'
+        + 'Start one in the terminal &mdash; this panel follows it.</div>';
+      return;
+    }
+    if (cur >= ts.length) cur = ts.length - 1;
+    var t = ts[cur];
+
+    // Entries stay deliberately generic, as on the real sheet: you cannot
+    // triage the list by reading it, you have to open each one.
+    var opts = ts.map(function (x, i) {
+      var mark = x.done ? '\\u2713 ' : (x.revisit ? '\\u21ba ' : '');
+      return '<option value="' + i + '"' + (i === cur ? ' selected' : '') + '>'
+        + mark + 'Task ' + (x.n < 10 ? '0' : '') + x.n + '</option>';
+    }).join('');
+
+    var mono = t.description.indexOf('\\n') !== -1 ? ' mono' : '';
+    var dom = t.domain_name ? ('Domain ' + t.domain + ' \\u00b7 ' + t.domain_name) : '';
+
+    $('sheet').innerHTML = ''
+      + '<div class="hostchip"><i></i>Perform this task on '
+      +   '<code>' + esc(t.host) + '</code></div>'
+      + '<div class="toolbar">'
+      +   '<div class="selwrap"><select id="pick">' + opts + '</select></div>'
+      +   '<div class="marks">' + mk(t, 'revisit', 'Revisit') + mk(t, 'done', 'Done') + '</div>'
+      + '</div>'
+      + '<div class="card">'
+      +   '<div class="card-top">'
+      +     '<span class="tasknum">Task ' + t.n + ' of ' + ts.length + '</span>'
+      +     (dom ? '<span class="pill">' + esc(dom) + '</span>' : '')
+      +     '<span class="pill">' + esc(t.category) + '</span>'
+      +     '<span class="pts">' + t.points + ' points</span>'
+      +   '</div>'
+      +   '<div class="desc' + mono + '">' + esc(t.description) + '</div>'
+      +   '<div class="nav">'
+      +     '<button id="prev"' + (cur === 0 ? ' disabled' : '') + '>&larr; Previous</button>'
+      +     '<button id="next"' + (cur === ts.length - 1 ? ' disabled' : '') + '>Next &rarr;</button>'
+      +     '<span class="keys"><kbd>j</kbd><kbd>k</kbd> move &nbsp; '
+      +       '<kbd>d</kbd> done &nbsp; <kbd>r</kbd> revisit</span>'
+      +   '</div>'
+      + '</div>';
+  }
+
+  function mk(t, field, label) {
+    var on = !!t[field];
+    return '<label class="mk' + (on ? ' on on-' + field : '') + '" data-field="'
+      + field + '"><span class="box">\\u2713</span>' + label + '</label>';
+  }
+
+  function mark(field, value) {
+    var ts = state.tasks || [];
+    var t = ts[cur];
+    if (!t) return;
+    t[field] = value;                      // optimistic; poll reconciles
+    state.done_count = ts.filter(function (x) { return x.done; }).length;
+    state.revisit_count = ts.filter(function (x) { return x.revisit; }).length;
+    render();
+    fetch('/api/mark', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: t.id, field: field, value: value })
+    }).catch(function () { /* panel is advisory; ignore */ });
+  }
+
+  function go(i) {
+    var ts = state.tasks || [];
+    if (!ts.length) return;
+    cur = Math.max(0, Math.min(ts.length - 1, i));
+    render();
+  }
+
+  function poll() {
+    fetch('/api/state').then(function (r) { return r.json(); }).then(function (s) {
+      var wasEmpty = !(state.tasks || []).length;
+      state = s;
+      if (typeof s.remaining_seconds === 'number') localRemaining = s.remaining_seconds;
+      else if (s.remaining_seconds === null) localRemaining = null;
+      if (wasEmpty && (s.tasks || []).length) cur = 0;
+      render();
+      renderClock();
+    }).catch(function () { /* terminal session ended; keep last view */ });
+  }
+
+  document.addEventListener('change', function (e) {
+    if (e.target.id === 'pick') go(parseInt(e.target.value, 10));
+  });
+
+  document.addEventListener('click', function (e) {
+    if (e.target.id === 'prev') { go(cur - 1); return; }
+    if (e.target.id === 'next') { go(cur + 1); return; }
+    var lbl = e.target.closest('.mk');
+    if (lbl) {
+      // Each toggles independently — click again to clear, and a task can
+      // be both done and flagged for another look.
+      var t = (state.tasks || [])[cur];
+      var field = lbl.getAttribute('data-field');
+      if (t) mark(field, !t[field]);
+      e.preventDefault();
+    }
+  });
+
+  document.addEventListener('keydown', function (e) {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (e.target && e.target.tagName === 'SELECT') return;
+    var t = (state.tasks || [])[cur];
+    var k = e.key;
+    if (k === 'j' || k === 'ArrowRight' || k === 'ArrowDown') { go(cur + 1); e.preventDefault(); }
+    else if (k === 'k' || k === 'ArrowLeft' || k === 'ArrowUp') { go(cur - 1); e.preventDefault(); }
+    else if (k === 'd' && t) { mark('done', !t.done); e.preventDefault(); }
+    else if (k === 'r' && t) { mark('revisit', !t.revisit); e.preventDefault(); }
+  });
+
+  // The clock ticks locally so it stays smooth between polls; the poll is
+  // authoritative, since it is anchored to uptime and survives a reboot.
+  setInterval(function () {
+    if (typeof localRemaining === 'number' && localRemaining > 0) {
+      localRemaining -= 1;
+      renderClock();
+    }
+  }, 1000);
+
+  setInterval(poll, 3000);
+  poll();
+})();
+</script>
+</body>
+</html>
+"""

--- a/device/device_manager.py
+++ b/device/device_manager.py
@@ -23,6 +23,8 @@ from typing import List, Dict, Optional, Set, Tuple, Any
 from enum import Enum
 from contextlib import contextmanager
 
+from utils.system_id import system_vgs as get_system_vgs, is_system_disk
+
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +117,7 @@ class DeviceManager:
 
     def _detect_practice_device(self) -> Optional[str]:
         """Detect the practice device (empty disk or practice PV)."""
-        system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+        system_vgs = get_system_vgs()
 
         try:
             # Use lsblk to find available disks
@@ -140,8 +142,10 @@ class DeviceManager:
                     if dtype != 'disk':
                         continue
 
-                    # Skip system disks (first disk is usually OS)
-                    if any(x in device for x in ['vda', 'sda', 'nvme0n1', 'xvda']):
+                    # Skip the disk(s) the OS actually lives on. Determined
+                    # from the live mounts, not from the device name — the OS
+                    # is not always on the first disk.
+                    if is_system_disk(device):
                         continue
 
                     # Skip CD-ROM/removable
@@ -267,7 +271,7 @@ class DeviceManager:
         Called after task validation to catch any untracked resources.
         Scans ALL non-system LVM, not just the practice device.
         """
-        system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+        system_vgs = get_system_vgs()
         device = self.get_practice_device()
 
         # Check for ALL PVs on non-system VGs (including loop devices)
@@ -297,7 +301,7 @@ class DeviceManager:
                 ['vgs', '--noheadings', '-o', 'vg_name'],
                 capture_output=True, text=True, timeout=5
             )
-            system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+            system_vgs = get_system_vgs()
             for line in result.stdout.strip().splitlines():
                 vg = line.strip()
                 if vg and vg not in system_vgs:
@@ -311,7 +315,7 @@ class DeviceManager:
                 ['lvs', '--noheadings', '-o', 'lv_name,vg_name'],
                 capture_output=True, text=True, timeout=5
             )
-            system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+            system_vgs = get_system_vgs()
             for line in result.stdout.strip().splitlines():
                 parts = line.split()
                 if len(parts) >= 2:
@@ -500,7 +504,7 @@ class DeviceManager:
             devices_to_clean.add(device)
 
         # Find loop devices that have non-system LVM
-        system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+        system_vgs = get_system_vgs()
         try:
             result = subprocess.run(
                 ['pvs', '--noheadings', '-o', 'pv_name,vg_name'],
@@ -519,6 +523,16 @@ class DeviceManager:
                         devices_to_clean.add(pv_name)
         except Exception:
             pass
+
+        # Last line of defence before pvremove/wipefs: drop anything that is
+        # (or sits on) a disk the OS lives on. The VG-name checks above should
+        # already have excluded these, but steps 5 and 6 below are
+        # unrecoverable, so they get an independent check.
+        protected = {dev for dev in devices_to_clean if is_system_disk(dev)}
+        if protected:
+            self.logger.warning(
+                f"Refusing to clean system device(s): {sorted(protected)}")
+            devices_to_clean -= protected
 
         self.logger.info(f"Devices to clean: {devices_to_clean}")
 
@@ -555,7 +569,7 @@ class DeviceManager:
             self.logger.debug(f"Mount cleanup: {e}")
 
         # 2. Deactivate any swap on non-system VGs
-        system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+        system_vgs = get_system_vgs()
         try:
             result = subprocess.run(
                 ['swapon', '--show=NAME', '--noheadings'],
@@ -600,7 +614,7 @@ class DeviceManager:
                 ['lvs', '--noheadings', '-o', 'lv_path,vg_name'],
                 capture_output=True, text=True, timeout=5
             )
-            system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+            system_vgs = get_system_vgs()
             for line in result.stdout.strip().splitlines():
                 parts = line.split()
                 if len(parts) >= 2:
@@ -620,7 +634,7 @@ class DeviceManager:
                 ['vgs', '--noheadings', '-o', 'vg_name'],
                 capture_output=True, text=True, timeout=5
             )
-            system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+            system_vgs = get_system_vgs()
             for line in result.stdout.strip().splitlines():
                 vg = line.strip()
                 if vg and vg not in system_vgs:

--- a/install.sh
+++ b/install.sh
@@ -16,8 +16,18 @@ NC='\033[0m' # No Color
 
 # Configuration
 INSTALL_DIR="/opt/rhcsa-simulator"
-BIN_LINK="/usr/local/bin/rhcsa-simulator"
+CMD_NAME="rhcsa-simulator"
 REQUIRED_PYTHON_VERSION="3.6"
+
+# Where the launcher goes is decided below by pick_bin_dir(), because the
+# conventional choice (/usr/local/bin) is NOT on sudo's secure_path on
+# RHEL-family systems — see the comment there.
+BIN_DIR=""
+BIN_LINK=""
+
+# Candidate launcher locations, cleaned up on reinstall so an old copy in the
+# location we're no longer using can't shadow the new one.
+ALL_BIN_DIRS="/usr/local/bin /usr/bin"
 
 echo "========================================="
 echo "RHCSA Mock Exam Simulator - Installation"
@@ -39,27 +49,69 @@ if ! command -v python3 &> /dev/null; then
     exit 1
 fi
 
+# Resolve the interpreter to an absolute path — the launcher runs under sudo's
+# secure_path, which may not be the PATH that found python3 here.
+PYTHON_BIN=$(command -v python3)
 PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
-echo "Found Python ${PYTHON_VERSION}"
+echo "Found Python ${PYTHON_VERSION} at ${PYTHON_BIN}"
 
 if [ "$(printf '%s\n' "$REQUIRED_PYTHON_VERSION" "$PYTHON_VERSION" | sort -V | head -n1)" != "$REQUIRED_PYTHON_VERSION" ]; then
     echo -e "${RED}Error: Python ${REQUIRED_PYTHON_VERSION} or later is required${NC}"
     exit 1
 fi
 
-# Check OS
+# Check OS.
+#
+# /etc/redhat-release alone only tells us "some Red Hat derivative". Read
+# os-release too so the install names the distro and version it actually
+# found — a mis-identified box is the root of every "it didn't work on
+# <distro>" report, and it should be visible here rather than three tasks in.
 echo "Checking operating system..."
-if [ -f /etc/redhat-release ]; then
-    OS_INFO=$(cat /etc/redhat-release)
-    echo "Detected: ${OS_INFO}"
-else
-    echo -e "${YELLOW}Warning: This tool is designed for RHEL/Rocky/Alma Linux${NC}"
-    read -p "Continue anyway? [y/N]: " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        exit 1
-    fi
+OS_ID=""
+OS_MAJOR=""
+OS_PRETTY=""
+if [ -r /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    OS_ID="${ID:-}"
+    OS_MAJOR="${VERSION_ID%%.*}"
+    OS_PRETTY="${PRETTY_NAME:-${NAME:-}}"
 fi
+
+if [ -z "$OS_PRETTY" ] && [ -f /etc/redhat-release ]; then
+    OS_PRETTY=$(cat /etc/redhat-release)
+fi
+
+case "$OS_ID" in
+    rhel|almalinux|rocky|centos|ol|fedora)
+        echo "Detected: ${OS_PRETTY}"
+        case "$OS_MAJOR" in
+            9|10) ;;
+            *)
+                echo -e "${YELLOW}Warning: EX200 v10 targets major version 10 (9 is usable).${NC}"
+                echo -e "${YELLOW}Version ${OS_MAJOR} may not match what the tasks expect.${NC}"
+                read -p "Continue anyway? [y/N]: " -n 1 -r
+                echo
+                if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                    exit 1
+                fi
+                ;;
+        esac
+        ;;
+    *)
+        if [ -n "$OS_PRETTY" ]; then
+            echo -e "${YELLOW}Detected: ${OS_PRETTY}${NC}"
+        fi
+        echo -e "${YELLOW}Warning: This tool is designed for RHEL / AlmaLinux / Rocky Linux 9-10.${NC}"
+        echo -e "${YELLOW}Package names, SELinux, firewalld and boot layout differ elsewhere,${NC}"
+        echo -e "${YELLOW}so most tasks will not grade correctly.${NC}"
+        read -p "Continue anyway? [y/N]: " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+        ;;
+esac
 
 # Create installation directory
 echo "Creating installation directory..."
@@ -90,29 +142,120 @@ chmod -R 755 "$INSTALL_DIR"/{config,core,tasks,validators,utils}
 chmod -R 755 "$INSTALL_DIR"/data
 chmod 755 "$INSTALL_DIR/rhcsa_simulator.py"
 
-# Create symlink
-echo "Creating symlink..."
-if [ -L "$BIN_LINK" ] || [ -f "$BIN_LINK" ]; then
-    rm -f "$BIN_LINK"
-fi
+# Install the launcher
+#
+# This used to be a bare symlink into /usr/local/bin. `sudo rhcsa-simulator`
+# then failed with "command not found", because sudo does not use your PATH —
+# it uses secure_path from /etc/sudoers, and on RHEL/AlmaLinux/Rocky that is:
+#
+#     Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+#
+# No /usr/local/bin. So the one command the README told people to run was the
+# one that could not resolve. (It works from a root login shell, which is why
+# it went unnoticed.) Pick a directory sudo will actually search.
+# Overridable so this can be exercised against fixture files in a test.
+SUDOERS_PATHS="${SUDOERS_PATHS:-/etc/sudoers /etc/sudoers.d/}"
 
-ln -s "$INSTALL_DIR/rhcsa_simulator.py" "$BIN_LINK"
+pick_bin_dir() {
+    local secure_path
+    # Later entries win, so take the last secure_path we can find.
+    # shellcheck disable=SC2086
+    secure_path=$(grep -rhs '^[[:space:]]*Defaults.*secure_path' \
+                    $SUDOERS_PATHS 2>/dev/null \
+                  | tail -n1)
+
+    if [ -z "$secure_path" ]; then
+        # No secure_path directive: sudo passes PATH through, so the
+        # conventional location is correct.
+        echo "/usr/local/bin"
+        return
+    fi
+
+    case "$secure_path" in
+        *=*/usr/local/bin*|*:/usr/local/bin*|*/usr/local/bin:*)
+            echo "/usr/local/bin" ;;
+        *)
+            # /usr/local/bin is not searched by sudo on this box. Use /usr/bin
+            # so the documented `sudo rhcsa-simulator` resolves. Editing
+            # secure_path in sudoers would also work but risks breaking sudo
+            # entirely on a box someone is mid-exam on — not worth it.
+            echo "/usr/bin" ;;
+    esac
+}
+
+BIN_DIR="$(pick_bin_dir)"
+BIN_LINK="${BIN_DIR}/${CMD_NAME}"
+
+echo "Installing launcher..."
+echo "  sudo searches ${BIN_DIR} — installing there"
+
+# Drop any launcher from a previous install in either candidate directory, so
+# a stale copy can't win the PATH lookup ahead of this one.
+for dir in $ALL_BIN_DIRS; do
+    old="${dir}/${CMD_NAME}"
+    if [ "$old" != "$BIN_LINK" ] && { [ -L "$old" ] || [ -f "$old" ]; }; then
+        echo "  removing previous launcher at ${old}"
+        rm -f "$old"
+    fi
+done
+rm -f "$BIN_LINK"
+
+# A wrapper rather than a symlink: it names the interpreter and the script
+# explicitly, so it does not depend on the .py file's executable bit, on the
+# shebang resolving, or on how Python treats a symlinked entry point.
+cat > "$BIN_LINK" <<EOF
+#!/bin/bash
+# RHCSA Mock Exam Simulator launcher. Generated by install.sh — edits here are
+# overwritten on reinstall.
+exec ${PYTHON_BIN} ${INSTALL_DIR}/rhcsa_simulator.py "\$@"
+EOF
 chmod 755 "$BIN_LINK"
 
 # Create requirements.txt (empty - stdlib only)
 echo "# No external dependencies required - Python stdlib only" > "$INSTALL_DIR/requirements.txt"
 
 # Verify installation
+#
+# Actually launch the command instead of just checking that a file exists —
+# the previous check confirmed a symlink was present, which it always was,
+# while the command it pointed at could not be run.
 echo "Verifying installation..."
-if [ -f "$INSTALL_DIR/rhcsa_simulator.py" ] && [ -L "$BIN_LINK" ]; then
+INSTALL_OK=1
+
+if [ ! -f "$INSTALL_DIR/rhcsa_simulator.py" ]; then
+    echo -e "${RED}✗ ${INSTALL_DIR}/rhcsa_simulator.py is missing${NC}"
+    INSTALL_OK=0
+fi
+
+if [ ! -x "$BIN_LINK" ]; then
+    echo -e "${RED}✗ launcher ${BIN_LINK} is missing or not executable${NC}"
+    INSTALL_OK=0
+elif ! "$BIN_LINK" --list-categories >/dev/null 2>&1; then
+    echo -e "${RED}✗ ${BIN_LINK} exists but failed to run${NC}"
+    echo "  Try it directly to see the error:"
+    echo "    ${PYTHON_BIN} ${INSTALL_DIR}/rhcsa_simulator.py --list-categories"
+    INSTALL_OK=0
+fi
+
+# Confirm the bare command resolves under sudo's own PATH, which is the way
+# the README tells people to start it.
+RESOLVED=$(env -i PATH="$(getconf PATH 2>/dev/null || echo /usr/bin:/bin)" \
+           command -v "$CMD_NAME" 2>/dev/null)
+if [ "$INSTALL_OK" -eq 1 ] && [ -z "$RESOLVED" ]; then
+    echo -e "${YELLOW}Warning: '${CMD_NAME}' did not resolve on a minimal PATH.${NC}"
+    echo -e "${YELLOW}If 'sudo ${CMD_NAME}' says command not found, use:${NC}"
+    echo "    sudo ${BIN_LINK}"
+fi
+
+if [ "$INSTALL_OK" -eq 1 ]; then
     echo -e "${GREEN}✓ Installation successful!${NC}"
     echo
     echo "Installation Details:"
-    echo "  Location: $INSTALL_DIR"
-    echo "  Executable: $BIN_LINK"
+    echo "  Location:   $INSTALL_DIR"
+    echo "  Launcher:   $BIN_LINK"
     echo
     echo "Usage:"
-    echo "  sudo rhcsa-simulator"
+    echo "  sudo ${CMD_NAME}              # or: sudo ${BIN_LINK}"
     echo
     echo -e "${YELLOW}Note: You must run as root (sudo) to validate system state${NC}"
 else

--- a/rhcsa_simulator.py
+++ b/rhcsa_simulator.py
@@ -55,6 +55,16 @@ Quick Start Examples:
     parser.add_argument('--import-mode', choices=['replace', 'merge'],
                         default='replace',
                         help='How --import-code applies (default: replace)')
+    parser.add_argument('--gui', nargs='?', const=8080, type=int, metavar='PORT',
+                        help='Serve the exam task sheet to a browser window '
+                             '(default port 8080), the way the real exam '
+                             'presents it — collapsed checklist with '
+                             'done/revisit ticks')
+    parser.add_argument('--gui-bind', default='0.0.0.0', metavar='ADDR',
+                        help='Address the task panel listens on '
+                             '(default 0.0.0.0, so a headless exam VM can be '
+                             'read from your laptop; use 127.0.0.1 to keep it '
+                             'local)')
     parser.add_argument('--version', action='version',
                         version=f'%(prog)s {settings.VERSION}')
 
@@ -334,7 +344,7 @@ def main():
 
     if args.exam:
         from core.exam import run_exam_mode
-        run_exam_mode()
+        run_exam_mode(gui_port=args.gui, gui_bind=args.gui_bind)
         return 0
 
     if args.learn:
@@ -408,7 +418,7 @@ def main():
                 input("\nPress Enter to return to menu...")
 
             elif choice == 'exam':
-                run_exam_mode()
+                run_exam_mode(gui_port=args.gui, gui_bind=args.gui_bind)
                 input("\nPress Enter to return to menu...")
 
             elif choice == 'practice':

--- a/rhcsa_simulator.py
+++ b/rhcsa_simulator.py
@@ -290,6 +290,7 @@ def main():
     # the launch.
     try:
         from core import preflight
+        preflight.report_environment()
         preflight.warn_missing()
     except Exception:
         pass

--- a/tests/unit/test_system_id.py
+++ b/tests/unit/test_system_id.py
@@ -1,0 +1,234 @@
+"""
+Tests for utils.system_id — the distro/system-resource identification that
+decides what belongs to the operating system and is therefore off-limits.
+
+The regression that motivated this module: AlmaLinux names its root volume
+group 'almalinux', which was absent from the hardcoded system-VG list, so the
+simulator treated the box's own root VG as spare practice storage.
+"""
+
+import pytest
+
+from utils import system_id
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    system_id.reset_cache()
+    yield
+    system_id.reset_cache()
+
+
+def _fake_os_release(monkeypatch, content):
+    monkeypatch.setattr(system_id, '_cache', {'os_release': content})
+
+
+# ── os-release parsing ──────────────────────────────────────────────────────
+
+def test_os_release_parses_quoted_values(monkeypatch, tmp_path):
+    release = tmp_path / "os-release"
+    release.write_text(
+        'NAME="AlmaLinux"\n'
+        'VERSION="10.0 (Purple Lion)"\n'
+        'ID="almalinux"\n'
+        'ID_LIKE="rhel centos fedora"\n'
+        'VERSION_ID="10.0"\n'
+        'PRETTY_NAME="AlmaLinux 10.0 (Purple Lion)"\n'
+        '\n'
+        '# a comment\n'
+    )
+    monkeypatch.setattr(system_id, 'OS_RELEASE_PATHS', (str(release),))
+
+    assert system_id.distro_id() == 'almalinux'
+    assert system_id.distro_version() == '10.0'
+    assert system_id.distro_major() == 10
+    assert system_id.distro_name() == 'AlmaLinux 10.0 (Purple Lion)'
+    assert system_id.is_rhel_family() is True
+
+
+def test_os_release_missing_is_not_fatal(monkeypatch):
+    monkeypatch.setattr(system_id, 'OS_RELEASE_PATHS', ('/nonexistent/os-release',))
+    assert system_id.os_release() == {}
+    assert system_id.distro_id() == ''
+    assert system_id.distro_major() is None
+
+
+def test_non_rhel_family_detected(monkeypatch):
+    _fake_os_release(monkeypatch, {'ID': 'ubuntu', 'ID_LIKE': 'debian',
+                                   'VERSION_ID': '24.04',
+                                   'PRETTY_NAME': 'Ubuntu 24.04 LTS'})
+    assert system_id.is_rhel_family() is False
+
+
+# ── system VG detection ─────────────────────────────────────────────────────
+
+def test_almalinux_root_vg_is_protected(monkeypatch):
+    """The exact bug: 'almalinux' is not in the legacy name list, so it has to
+    be caught by probing the mounts."""
+    monkeypatch.setattr(system_id, 'detected_system_vgs',
+                        lambda: {'almalinux'})
+    monkeypatch.setattr(system_id, '_distro_vg_guesses', lambda: set())
+
+    assert system_id.is_system_vg('almalinux') is True
+    assert system_id.is_system_vg('vg_practice') is False
+
+
+def test_detected_vgs_come_from_mounts_and_swap(monkeypatch):
+    sources = {'/': '/dev/mapper/almalinux-root',
+               '/home': '/dev/mapper/almalinux-home'}
+    monkeypatch.setattr(system_id, '_source_of_mountpoint',
+                        lambda mp: sources.get(mp))
+    monkeypatch.setattr(system_id, '_active_swap_devices',
+                        lambda: ['/dev/dm-1'])
+
+    def fake_vg_of_device(dev):
+        return {'/dev/mapper/almalinux-root': 'almalinux',
+                '/dev/mapper/almalinux-home': 'almalinux',
+                '/dev/dm-1': 'almalinux'}.get(dev)
+
+    monkeypatch.setattr(system_id, 'vg_of_device', fake_vg_of_device)
+    monkeypatch.setattr(system_id.os.path, 'exists', lambda p: True)
+
+    assert system_id.detected_system_vgs() == {'almalinux'}
+
+
+def test_known_names_still_protected_when_probe_fails(monkeypatch):
+    """An unprobeable box keeps the old (partial) protection rather than none."""
+    monkeypatch.setattr(system_id, 'detected_system_vgs', lambda: set())
+    monkeypatch.setattr(system_id, '_distro_vg_guesses', lambda: set())
+
+    for name in ('rl', 'rhel', 'centos', 'almalinux', 'rocky'):
+        assert system_id.is_system_vg(name) is True, name
+    assert system_id.is_system_vg('vg_exam1') is False
+
+
+def test_unknown_distro_root_vg_guessed_from_os_release(monkeypatch):
+    """A distro nobody thought of still gets its likely root VG protected."""
+    _fake_os_release(monkeypatch, {'ID': 'navylinux', 'VERSION_ID': '10.1'})
+    monkeypatch.setattr(system_id, 'detected_system_vgs', lambda: set())
+
+    assert system_id.is_system_vg('navylinux') is True
+    assert system_id.is_system_vg('navylinux10') is True
+    assert system_id.is_system_vg('vg_exam1') is False
+
+
+def test_blank_vg_name_treated_as_system(monkeypatch):
+    """Refusing to touch what we can't identify is the safe default when the
+    alternative is lvremove."""
+    monkeypatch.setattr(system_id, 'detected_system_vgs', lambda: set())
+    assert system_id.is_system_vg('') is True
+    assert system_id.is_system_vg(None) is True
+    assert system_id.is_system_vg('   ') is True
+
+
+def test_vg_of_device_returns_none_for_non_lv(monkeypatch):
+    monkeypatch.setattr(system_id, '_run', lambda cmd, timeout=10: None)
+    assert system_id.vg_of_device('/dev/sdb') is None
+    assert system_id.vg_of_device('') is None
+    assert system_id.vg_of_device('not-a-device') is None
+
+
+# ── system disk detection ───────────────────────────────────────────────────
+
+def test_system_disk_detected_from_pvs_not_from_name(monkeypatch):
+    monkeypatch.setattr(system_id, 'system_pvs', lambda: frozenset({'/dev/vdb2'}))
+    monkeypatch.setattr(system_id, '_source_of_mountpoint',
+                        lambda mp: '/dev/mapper/almalinux-root' if mp == '/' else None)
+    monkeypatch.setattr(system_id, '_parent_disk',
+                        lambda dev: '/dev/vdb' if dev == '/dev/vdb2' else None)
+
+    assert system_id.system_disks() == frozenset({'/dev/vdb'})
+    # The OS is on the *second* disk here; the first is fair game.
+    assert system_id.is_system_disk('/dev/vdb') is True
+    assert system_id.is_system_disk('/dev/vda') is False
+
+
+def test_system_disk_falls_back_to_name_when_unprobeable(monkeypatch):
+    monkeypatch.setattr(system_id, 'system_disks', lambda: frozenset())
+    assert system_id.is_system_disk('/dev/sda') is True
+    assert system_id.is_system_disk('/dev/nvme0n1') is True
+    assert system_id.is_system_disk('/dev/sdd') is False
+
+
+def test_empty_device_is_treated_as_system(monkeypatch):
+    assert system_id.is_system_disk('') is True
+    assert system_id.is_system_disk(None) is True
+
+
+# ── boot layout ─────────────────────────────────────────────────────────────
+
+def test_efi_grub_config_globs_any_vendor_dir(monkeypatch):
+    monkeypatch.setattr(system_id.glob, 'glob',
+                        lambda pat: ['/boot/efi/EFI/almalinux/grub.cfg'])
+    monkeypatch.setattr(system_id.os.path, 'isfile', lambda p: False)
+
+    assert system_id.efi_grub_configs() == ['/boot/efi/EFI/almalinux/grub.cfg']
+    assert system_id.grub_config_present() is True
+
+
+def test_grub_absent_reported(monkeypatch):
+    monkeypatch.setattr(system_id.glob, 'glob', lambda pat: [])
+    monkeypatch.setattr(system_id.os.path, 'isfile', lambda p: False)
+    assert system_id.grub_config_present() is False
+
+
+# ── environment report ──────────────────────────────────────────────────────
+
+def test_check_environment_flags_non_rhel(monkeypatch):
+    _fake_os_release(monkeypatch, {'ID': 'ubuntu', 'ID_LIKE': 'debian',
+                                   'VERSION_ID': '24.04',
+                                   'PRETTY_NAME': 'Ubuntu 24.04 LTS'})
+    monkeypatch.setattr(system_id, 'detected_system_vgs', lambda: set())
+    monkeypatch.setattr(system_id, '_run', lambda cmd, timeout=10: None)
+    monkeypatch.setattr(system_id, 'grub_config_present', lambda: True)
+
+    levels = [level for level, _ in system_id.check_environment()]
+    assert 'error' in levels
+
+
+def test_check_environment_accepts_almalinux_10(monkeypatch):
+    _fake_os_release(monkeypatch, {'ID': 'almalinux', 'ID_LIKE': 'rhel centos fedora',
+                                   'VERSION_ID': '10.0',
+                                   'PRETTY_NAME': 'AlmaLinux 10.0'})
+    monkeypatch.setattr(system_id, 'detected_system_vgs', lambda: {'almalinux'})
+    monkeypatch.setattr(system_id, 'grub_config_present', lambda: True)
+
+    findings = system_id.check_environment()
+    assert all(level == 'ok' for level, _ in findings), findings
+    assert any('AlmaLinux' in msg for _, msg in findings)
+
+
+def test_check_environment_warns_on_unsupported_major(monkeypatch):
+    _fake_os_release(monkeypatch, {'ID': 'rocky', 'ID_LIKE': 'rhel centos fedora',
+                                   'VERSION_ID': '8.10',
+                                   'PRETTY_NAME': 'Rocky Linux 8.10'})
+    monkeypatch.setattr(system_id, 'detected_system_vgs', lambda: {'rl'})
+    monkeypatch.setattr(system_id, 'grub_config_present', lambda: True)
+
+    levels = [level for level, _ in system_id.check_environment()]
+    assert 'warn' in levels
+
+
+def test_probes_never_raise(monkeypatch):
+    """Every probe goes through _run, which must swallow a missing binary,
+    a timeout and a non-zero exit rather than raise into a validator."""
+    import subprocess
+
+    def missing(*a, **kw):
+        raise FileNotFoundError("lvs")
+
+    monkeypatch.setattr(system_id.subprocess, 'run', missing)
+    assert system_id._run(['lvs']) is None
+
+    def timeout(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd='lvs', timeout=5)
+
+    monkeypatch.setattr(system_id.subprocess, 'run', timeout)
+    assert system_id._run(['lvs']) is None
+
+    class Failed:
+        returncode = 5
+        stdout = 'partial'
+
+    monkeypatch.setattr(system_id.subprocess, 'run', lambda *a, **kw: Failed())
+    assert system_id._run(['lvs']) is None

--- a/tests/unit/test_task_gui.py
+++ b/tests/unit/test_task_gui.py
@@ -1,0 +1,300 @@
+"""
+Tests for core.task_gui — the browser task panel.
+
+The panel mirrors how the real EX200 presents its questions: a collapsed
+checklist you tick "done" / "revisit" against, with each task's text hidden
+until you open it. It is advisory only — ticking a box must never influence
+grading, which still runs against real system state.
+"""
+
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from core import task_gui
+
+
+class FakeTask:
+    def __init__(self, id, description, category='lvm', points=10, domain=4):
+        self.id = id
+        self.description = description
+        self.category = category
+        self.points = points
+        self.exam_domain = domain
+
+
+@pytest.fixture(autouse=True)
+def _clear_marks():
+    task_gui.clear_marks()
+    yield
+    task_gui.clear_marks()
+
+
+@pytest.fixture
+def tasks():
+    return [
+        FakeTask('lvm_001', 'Create a 1GiB logical volume named lv_data.'),
+        FakeTask('part_002', 'Create a 500MiB partition on /dev/sdb.',
+                 category='partitioning', points=15, domain=4),
+        FakeTask('sel_003', 'Set the SELinux context on /srv/web.',
+                 category='selinux', points=20, domain=7),
+    ]
+
+
+@pytest.fixture
+def panel(tasks):
+    """A live panel on an ephemeral loopback port."""
+    p = task_gui.TaskPanel(lambda: task_gui.build_state(tasks, 3600),
+                           port=0, bind='127.0.0.1')
+    urls = p.start()
+    assert urls, "panel failed to bind"
+    yield p, urls[0].rstrip('/')
+    p.stop()
+
+
+def _get(base, path):
+    with urllib.request.urlopen(base + path, timeout=5) as r:
+        return r.status, r.read().decode()
+
+
+def _post(base, path, payload):
+    req = urllib.request.Request(
+        base + path, data=json.dumps(payload).encode(),
+        headers={'Content-Type': 'application/json'}, method='POST')
+    with urllib.request.urlopen(req, timeout=5) as r:
+        return r.status, json.loads(r.read().decode())
+
+
+# ── state building ──────────────────────────────────────────────────────────
+
+def test_build_state_exposes_task_sheet(tasks):
+    state = task_gui.build_state(tasks, remaining_seconds=1800)
+
+    assert state['count'] == 3
+    assert state['total_points'] == 45
+    assert state['remaining_seconds'] == 1800
+    assert [t['n'] for t in state['tasks']] == [1, 2, 3]
+    assert state['tasks'][0]['description'].startswith('Create a 1GiB')
+
+
+def test_build_state_includes_category_for_the_collapsed_row(tasks):
+    """The category is all the candidate sees before opening a task, so it
+    must be present and human-readable."""
+    state = task_gui.build_state(tasks)
+    labels = [t['category'] for t in state['tasks']]
+
+    assert all(labels), "every row needs a category label"
+    assert all('_' not in l for l in labels), labels
+
+
+def test_build_state_handles_no_exam():
+    state = task_gui.build_state([])
+    assert state['count'] == 0
+    assert state['tasks'] == []
+    assert state['total_points'] == 0
+
+
+def test_build_state_survives_malformed_tasks():
+    """A task object missing attributes must not take the panel down
+    mid-exam."""
+    class Bare:
+        pass
+
+    state = task_gui.build_state([Bare()])
+    assert state['count'] == 1
+    assert state['tasks'][0]['description'] == ''
+    assert state['tasks'][0]['points'] == 0
+
+
+# ── marks ───────────────────────────────────────────────────────────────────
+
+def test_done_and_revisit_are_independent(tasks):
+    """Mid-exam you often want both on one task: 'I did something, but come
+    back to it'."""
+    task_gui.set_mark('lvm_001', 'done', True)
+    task_gui.set_mark('lvm_001', 'revisit', True)
+
+    marks = task_gui.marks_for('lvm_001')
+    assert marks == {'done': True, 'revisit': True}
+
+
+def test_unticking_leaves_the_other_mark_alone():
+    task_gui.set_mark('lvm_001', 'done', True)
+    task_gui.set_mark('lvm_001', 'revisit', True)
+    task_gui.set_mark('lvm_001', 'done', False)
+
+    assert task_gui.marks_for('lvm_001') == {'done': False, 'revisit': True}
+
+
+def test_marks_appear_in_state_and_counts(tasks):
+    task_gui.set_mark('lvm_001', 'done', True)
+    task_gui.set_mark('part_002', 'revisit', True)
+    task_gui.set_mark('sel_003', 'done', True)
+
+    state = task_gui.build_state(tasks)
+    assert state['done_count'] == 2
+    assert state['revisit_count'] == 1
+    assert state['tasks'][0]['done'] is True
+    assert state['tasks'][1]['revisit'] is True
+
+
+def test_unknown_mark_field_rejected():
+    with pytest.raises(ValueError):
+        task_gui.set_mark('lvm_001', 'passed', True)
+    with pytest.raises(ValueError):
+        task_gui.set_mark('', 'done', True)
+
+
+def test_clear_marks_resets_between_exams(tasks):
+    task_gui.set_mark('lvm_001', 'done', True)
+    task_gui.clear_marks()
+    assert task_gui.build_state(tasks)['done_count'] == 0
+
+
+# ── HTTP surface ────────────────────────────────────────────────────────────
+
+def test_serves_the_page(panel):
+    _, base = panel
+    status, body = _get(base, '/')
+    assert status == 200
+    assert '<title>RHCSA Mock Exam' in body
+    # Fully self-contained: no external assets to fetch on an offline VM.
+    assert 'http://' not in body.split('<style>')[1].split('</style>')[0]
+    # Styling only — it must never present itself as the real exam.
+    assert 'Red Hat' not in body.replace(
+        'Styled after the Red Hat test-exam sheet', '').replace(
+        'NOT Red Hat branded', '')
+
+
+def test_state_endpoint_returns_json(panel):
+    _, base = panel
+    status, body = _get(base, '/api/state')
+    assert status == 200
+    state = json.loads(body)
+    assert state['count'] == 3
+    assert state['remaining_seconds'] == 3600
+
+
+def test_mark_endpoint_records_a_tick(panel):
+    _, base = panel
+    status, body = _post(base, '/api/mark',
+                         {'id': 'lvm_001', 'field': 'done', 'value': True})
+    assert status == 200
+    assert body['marks']['done'] is True
+
+    _, state = _get(base, '/api/state')
+    assert json.loads(state)['done_count'] == 1
+
+
+def test_mark_endpoint_rejects_unknown_field(panel):
+    _, base = panel
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _post(base, '/api/mark', {'id': 'lvm_001', 'field': 'score', 'value': 1})
+    assert e.value.code == 400
+
+
+def test_unknown_route_is_404(panel):
+    _, base = panel
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _get(base, '/api/tasks')
+    assert e.value.code == 404
+
+
+def test_panel_serves_no_shell_or_validation_route(panel):
+    """The panel is read-mostly by design: exam questions and ticks only."""
+    _, base = panel
+    for path in ('/api/validate', '/api/exec', '/api/grade', '/shell'):
+        with pytest.raises(urllib.error.HTTPError) as e:
+            _get(base, path)
+        assert e.value.code == 404, path
+
+
+# ── failure behaviour ───────────────────────────────────────────────────────
+
+def test_state_provider_failure_degrades_instead_of_500(tasks):
+    """A panel that breaks must not become a second problem mid-exam."""
+    def boom():
+        raise RuntimeError("session went away")
+
+    p = task_gui.TaskPanel(boom, port=0, bind='127.0.0.1')
+    urls = p.start()
+    try:
+        status, body = _get(urls[0].rstrip('/'), '/api/state')
+        assert status == 200
+        assert json.loads(body)['tasks'] == []
+    finally:
+        p.stop()
+
+
+def test_port_already_in_use_returns_no_urls(tasks):
+    first = task_gui.TaskPanel(lambda: task_gui.build_state(tasks),
+                               port=0, bind='127.0.0.1')
+    assert first.start()
+    port = first._httpd.server_address[1]
+    try:
+        second = task_gui.TaskPanel(lambda: task_gui.build_state(tasks),
+                                    port=port, bind='127.0.0.1')
+        assert second.start() == [], "should fail quietly, not raise"
+        assert second.running is False
+    finally:
+        first.stop()
+
+
+def test_stop_is_idempotent(tasks):
+    p = task_gui.TaskPanel(lambda: task_gui.build_state(tasks),
+                           port=0, bind='127.0.0.1')
+    p.start()
+    p.stop()
+    p.stop()
+    assert p.running is False
+
+
+def test_start_for_session_never_raises():
+    class BadSession:
+        @property
+        def tasks(self):
+            raise RuntimeError("boom")
+
+    panel, urls = task_gui.start_for_session(BadSession(), port=0,
+                                             bind='127.0.0.1')
+    try:
+        # It binds fine; the failure only shows up per-request, degraded.
+        if urls:
+            status, body = _get(urls[0].rstrip('/'), '/api/state')
+            assert status == 200
+            assert json.loads(body)['tasks'] == []
+    finally:
+        if panel:
+            panel.stop()
+
+
+# ── exam-sheet fidelity ─────────────────────────────────────────────────────
+
+def test_tasks_carry_their_target_host(tasks):
+    """The sheet is banner-grouped by machine ('Perform the following tasks
+    on <host>'), so every task needs to know which box it belongs to."""
+    state = task_gui.build_state(tasks)
+    assert all(t['host'] for t in state['tasks'])
+
+
+def test_lab_machine_tasks_report_a_different_host(tasks, monkeypatch):
+    remote = FakeTask('rem_004', 'Set the hostname on the lab machine.',
+                      category='remote')
+    remote.requires_lab_machine = True
+    monkeypatch.setattr(task_gui, '_local_host', lambda: 'node1.example.com')
+
+    state = task_gui.build_state(tasks + [remote])
+    hosts = {t['host'] for t in state['tasks']}
+    assert 'node1.example.com' in hosts
+    assert len(hosts) == 2, hosts
+
+
+def test_dropdown_labels_do_not_leak_the_task(panel):
+    """Entries are generic like the real sheet — the list must not let you
+    triage without opening each task."""
+    _, base = panel
+    _, body = _get(base, '/')
+    assert "'Task ' + (x.n < 10 ? '0' : '')" in body
+    assert 'Create a 1GiB logical volume' not in body  # comes from /api/state

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -772,7 +772,12 @@ def cleanup_practice_devices():
         return False
 
 
-_SYSTEM_VGS = {'rl', 'rl00', 'rhel', 'centos', 'fedora', 'almalinux', 'rocky'}
+# Static fallback names only. The authoritative answer to "is this the box's
+# own VG?" is utils.system_id.is_system_vg(), which probes the live mounts —
+# a name list silently mis-classified AlmaLinux's 'almalinux' VG as practice
+# storage for as long as nobody had added that name to it.
+from utils.system_id import KNOWN_SYSTEM_VG_NAMES as _SYSTEM_VGS
+from utils.system_id import is_system_vg
 
 # Bypass the LVM devices file so we can see/remove VGs on loop devices even when
 # their devices-file entries are missing or stale (the usual state after an
@@ -816,7 +821,7 @@ def _remove_stray_practice_vgs():
         vgs = set()
 
     for vg in vgs:
-        if vg in _SYSTEM_VGS:
+        if is_system_vg(vg):
             continue
         run(['vgchange', '-an', vg] + _LVM_NODEVFILE)
         run(['vgremove', '-ff', '-y', vg] + _LVM_NODEVFILE)
@@ -871,7 +876,7 @@ def _purge_loop_device(device):
         vg_res = subprocess.run(['pvs', '--noheadings', '-o', 'vg_name'] + members + _LVM_NODEVFILE,
                                 capture_output=True, text=True, timeout=10)
         for vg in {v.strip() for v in vg_res.stdout.splitlines() if v.strip()}:
-            if vg in _SYSTEM_VGS:
+            if is_system_vg(vg):
                 continue
             run(['vgchange', '-an', vg] + _LVM_NODEVFILE)
             run(['vgremove', '-ff', '-y', vg] + _LVM_NODEVFILE)
@@ -1119,17 +1124,16 @@ def get_practice_lv():
         
         if result.returncode != 0:
             return None, None
-        
-        # System VGs to skip
-        system_vgs = ['rl', 'rl00', 'rhel', 'centos', 'fedora']
-        
+
+        from utils.system_id import is_system_vg
+
         for line in result.stdout.strip().splitlines():
             parts = line.split()
             if len(parts) >= 2:
                 vg_name = parts[0]
                 lv_name = parts[1]
-                # Skip system VGs
-                if vg_name not in system_vgs:
+                # Never hand back an LV that belongs to the OS itself.
+                if not is_system_vg(vg_name):
                     return vg_name, lv_name
         
         return None, None
@@ -1152,15 +1156,15 @@ def get_practice_vg():
         
         if result.returncode != 0:
             return None
-        
-        # System VGs to skip
-        system_vgs = ['rl', 'rl00', 'rhel', 'centos', 'fedora']
-        
+
+        from utils.system_id import is_system_vg
+
         for line in result.stdout.strip().splitlines():
             parts = line.split()
             if len(parts) >= 1:
                 vg_name = parts[0]
-                if vg_name not in system_vgs:
+                # Never hand back the VG that backs the OS itself.
+                if not is_system_vg(vg_name):
                     return vg_name
 
         return None

--- a/utils/system_id.py
+++ b/utils/system_id.py
@@ -1,0 +1,428 @@
+"""
+Distro and system-resource identification.
+
+Everything in the simulator that decides "is this thing the candidate's
+practice storage, or is it the box's own operating system?" must go through
+here.
+
+WHY THIS EXISTS
+---------------
+The simulator used to answer that question with a hardcoded list of volume
+group names::
+
+    system_vgs = {'rl', 'rl00', 'rhel', 'centos', 'fedora'}
+
+Anaconda names the root VG after the product: RHEL -> ``rhel``, Rocky ->
+``rl``, CentOS -> ``centos`` ... and AlmaLinux -> ``almalinux``, which was
+NOT in that list. On an AlmaLinux install the box's own root VG therefore
+looked like a spare practice VG, so ``get_practice_vg()`` handed LVM tasks
+the system VG and the cleanup pass considered the system LVs fair game.
+
+A name list can only ever describe the distros someone remembered. So the
+system VGs are *detected* here — by asking which VGs actually back the
+mounted filesystems and active swap — and the name list survives only as a
+fallback for when LVM tooling can't be queried.
+
+Everything is cached; call reset_cache() in tests.
+"""
+
+import glob
+import logging
+import os
+import re
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+OS_RELEASE_PATHS = ('/etc/os-release', '/usr/lib/os-release')
+
+# RHEL-family distros this simulator is written for: os-release ID -> label.
+SUPPORTED_IDS = {
+    'rhel': 'Red Hat Enterprise Linux',
+    'almalinux': 'AlmaLinux',
+    'rocky': 'Rocky Linux',
+    'centos': 'CentOS Stream',
+    'ol': 'Oracle Linux',
+    'fedora': 'Fedora',
+}
+
+# EX200 v10 targets RHEL 10; 9 is close enough to practise on.
+SUPPORTED_MAJORS = (9, 10)
+
+# Fallback only — used when LVM can't be queried (no lvm2, non-root, CI
+# container). Detection via mounted filesystems is authoritative.
+KNOWN_SYSTEM_VG_NAMES = frozenset({
+    'rl', 'rl00', 'rl_root', 'rhel', 'rhel00', 'centos', 'fedora',
+    'almalinux', 'alma', 'rocky', 'ol', 'oracle', 'vg_root', 'vg00',
+    'vg_system', 'system',
+})
+
+# Mountpoints that belong to the OS. If one of these lives on an LV, that
+# LV's VG is a system VG. /srv, /mnt, /media, /export deliberately absent —
+# those are where practice filesystems get mounted.
+SYSTEM_MOUNTPOINTS = (
+    '/', '/boot', '/boot/efi', '/home', '/usr', '/var', '/var/log',
+    '/var/tmp', '/opt', '/tmp', '/etc',
+)
+
+_cache = {}
+
+
+def reset_cache():
+    """Drop every cached probe result. Call from tests, or after the
+    candidate has changed storage layout in a way we need to re-read."""
+    _cache.clear()
+
+
+# ── os-release ──────────────────────────────────────────────────────────────
+
+def os_release():
+    """Parsed /etc/os-release as a dict (empty if unreadable)."""
+    if 'os_release' in _cache:
+        return _cache['os_release']
+
+    data = {}
+    for path in OS_RELEASE_PATHS:
+        try:
+            with open(path) as f:
+                content = f.read()
+        except (IOError, OSError):
+            continue
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            data[key.strip()] = value.strip().strip('"').strip("'")
+        if data:
+            break
+
+    _cache['os_release'] = data
+    return data
+
+
+def distro_id():
+    """os-release ID, lowercased ('almalinux', 'rocky', 'rhel'...). '' if unknown."""
+    return os_release().get('ID', '').lower()
+
+
+def distro_like():
+    """os-release ID_LIKE as a list ('rhel', 'centos', 'fedora')."""
+    return os_release().get('ID_LIKE', '').lower().split()
+
+
+def distro_version():
+    """os-release VERSION_ID ('10.0', '9.5'). '' if unknown."""
+    return os_release().get('VERSION_ID', '')
+
+
+def distro_major():
+    """Major version as an int, or None if it can't be parsed."""
+    match = re.match(r'(\d+)', distro_version())
+    return int(match.group(1)) if match else None
+
+
+def is_rhel_family():
+    """True if this is RHEL or a rebuild of it."""
+    ids = set(distro_like())
+    ids.add(distro_id())
+    return bool(ids & {'rhel', 'centos', 'fedora'}) or distro_id() in SUPPORTED_IDS
+
+
+def distro_name():
+    """Human-readable distro name for display."""
+    rel = os_release()
+    return rel.get('PRETTY_NAME') or rel.get('NAME') or 'unknown Linux'
+
+
+# ── LVM / block-device probing ──────────────────────────────────────────────
+
+def _run(cmd, timeout=10):
+    """Run a read-only probe. Returns stdout on success, None on any failure —
+    probes must never raise into a task or a validator."""
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+        logger.debug("probe failed (%s): %s", ' '.join(cmd), e)
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def vg_of_device(device):
+    """VG name backing a block device, or None if it isn't an LV.
+
+    Handles /dev/mapper/vg-lv, /dev/vg/lv and /dev/dm-N alike — lvs resolves
+    all three, which is why we ask lvs instead of parsing the mapper name
+    (device-mapper doubles literal dashes, so parsing gets it wrong for any
+    VG whose name contains one).
+    """
+    if not device or not device.startswith('/dev/'):
+        return None
+    out = _run(['lvs', '--noheadings', '-o', 'vg_name', device], timeout=5)
+    if out is None:
+        return None
+    name = out.strip()
+    return name or None
+
+
+def _source_of_mountpoint(mountpoint):
+    """Backing device for a mountpoint, or None if it isn't a mountpoint."""
+    out = _run(['findmnt', '-no', 'SOURCE', '--target', mountpoint], timeout=5)
+    if out is None:
+        return None
+    return out.strip().splitlines()[0].strip() if out.strip() else None
+
+
+def _active_swap_devices():
+    """Devices listed in /proc/swaps."""
+    devices = []
+    try:
+        with open('/proc/swaps') as f:
+            for line in f.readlines()[1:]:
+                parts = line.split()
+                if parts and parts[0].startswith('/dev/'):
+                    devices.append(parts[0])
+    except (IOError, OSError):
+        pass
+    return devices
+
+
+def detected_system_vgs():
+    """VGs proven to back the running OS: every VG holding a system
+    mountpoint or active swap. Empty set if nothing could be probed."""
+    found = set()
+
+    for mountpoint in SYSTEM_MOUNTPOINTS:
+        if not os.path.exists(mountpoint):
+            continue
+        source = _source_of_mountpoint(mountpoint)
+        vg = vg_of_device(source) if source else None
+        if vg:
+            found.add(vg)
+
+    for device in _active_swap_devices():
+        vg = vg_of_device(device)
+        if vg:
+            found.add(vg)
+
+    return found
+
+
+def system_vgs():
+    """Volume groups that belong to the operating system and must NEVER be
+    handed to a task or touched by cleanup.
+
+    Union of what was detected from live mounts/swap and the known-names
+    fallback, so an unprobeable box still gets the old (partial) protection
+    rather than none at all.
+    """
+    if 'system_vgs' in _cache:
+        return _cache['system_vgs']
+
+    detected = detected_system_vgs()
+    if not detected:
+        logger.debug("no system VGs detected from mounts; using name fallback only")
+
+    vgs = frozenset(detected | set(KNOWN_SYSTEM_VG_NAMES) | _distro_vg_guesses())
+    _cache['system_vgs'] = vgs
+    return vgs
+
+
+def _distro_vg_guesses():
+    """VG names anaconda would plausibly have picked on THIS distro, so a
+    distro we've never seen still gets its most likely root VG protected."""
+    guesses = set()
+    did = distro_id()
+    if did:
+        guesses.add(did)
+        guesses.add(did.replace('linux', ''))
+        major = distro_major()
+        if major is not None:
+            guesses.add('%s%d' % (did, major))
+    return {g for g in guesses if g}
+
+
+def is_system_vg(vg_name):
+    """True if this VG backs the OS. Unknown/empty names are treated as
+    system — refusing to touch something we can't identify is the safe
+    default when the alternative is lvremove."""
+    if not vg_name or not vg_name.strip():
+        return True
+    return vg_name.strip() in system_vgs()
+
+
+def system_pvs():
+    """PV device paths belonging to system VGs."""
+    if 'system_pvs' in _cache:
+        return _cache['system_pvs']
+
+    pvs = set()
+    out = _run(['pvs', '--noheadings', '-o', 'pv_name,vg_name'], timeout=10)
+    if out:
+        protected = system_vgs()
+        for line in out.strip().splitlines():
+            parts = line.split()
+            if len(parts) >= 2 and parts[1].strip() in protected:
+                pvs.add(parts[0].strip())
+
+    _cache['system_pvs'] = frozenset(pvs)
+    return _cache['system_pvs']
+
+
+def _parent_disk(device):
+    """Whole disk ultimately backing a device.
+
+    '/dev/nvme0n1p3' -> '/dev/nvme0n1', and crucially
+    '/dev/mapper/almalinux-root' -> '/dev/nvme0n1', walking LV -> partition
+    -> disk in one step.
+
+    Uses `lsblk -rnso NAME`, which prints the device's ancestry inverted
+    (device first, whole disk last). PKNAME is not usable here: for a
+    partition that has LVM children it reports the parent of each *child*
+    row, so the first line is the partition itself rather than its disk.
+    """
+    if not device:
+        return None
+    out = _run(['lsblk', '-rnso', 'NAME', device], timeout=5)
+    if not out or not out.strip():
+        return None
+    lines = [l.strip() for l in out.strip().splitlines() if l.strip()]
+    if not lines:
+        return None
+    top = lines[-1]
+    disk = '/dev/' + top
+    # The device is already a whole disk — it has no parent.
+    return None if disk == device else disk
+
+
+def system_disks():
+    """Whole disks the OS lives on — the disks holding system PVs, plus the
+    disk backing / and /boot for non-LVM installs.
+
+    Replaces guessing by device name (vda/sda/nvme0n1/xvda), which is wrong
+    on any box whose OS isn't on the first disk.
+    """
+    if 'system_disks' in _cache:
+        return _cache['system_disks']
+
+    disks = set()
+
+    sources = set(system_pvs())
+    for mountpoint in ('/', '/boot', '/boot/efi'):
+        source = _source_of_mountpoint(mountpoint)
+        if source and source.startswith('/dev/'):
+            sources.add(source)
+
+    for source in sources:
+        parent = _parent_disk(source)
+        if parent:
+            disks.add(parent)
+        elif re.match(r'^/dev/[a-z0-9]+$', source) and not source.startswith('/dev/dm-'):
+            # No parent: the source is itself a whole disk.
+            disks.add(source)
+
+    _cache['system_disks'] = frozenset(disks)
+    return _cache['system_disks']
+
+
+# Names anaconda's first/primary disk usually takes. Only consulted when the
+# OS disk could not be determined from live mounts.
+_LIKELY_FIRST_DISKS = ('vda', 'sda', 'nvme0n1', 'xvda', 'hda')
+
+
+def is_system_disk(device):
+    """True if this disk (or a partition of it) holds the OS."""
+    if not device:
+        return True
+    device = device.strip()
+    disks = system_disks()
+
+    if not disks:
+        # Nothing could be probed (no lsblk, not root, odd container). Fall
+        # back to the old name heuristic rather than declaring every disk
+        # fair game — over-protecting costs a practice disk, under-
+        # protecting costs the candidate's VM.
+        return any(name in device for name in _LIKELY_FIRST_DISKS)
+
+    if device in disks:
+        return True
+    parent = _parent_disk(device)
+    return bool(parent and parent in disks)
+
+
+# ── boot layout ─────────────────────────────────────────────────────────────
+
+def efi_grub_configs():
+    """Every /boot/efi/EFI/<vendor>/grub.cfg present.
+
+    The vendor directory is distro-specific (redhat, rocky, almalinux,
+    centos), so it's globbed rather than guessed one name at a time.
+    """
+    return sorted(glob.glob('/boot/efi/EFI/*/grub.cfg'))
+
+
+def grub_config_present():
+    """True if a usable GRUB config exists (BIOS or UEFI layout)."""
+    return os.path.isfile('/boot/grub2/grub.cfg') or bool(efi_grub_configs())
+
+
+# ── environment report ──────────────────────────────────────────────────────
+
+def check_environment():
+    """Report on how well this box suits the simulator.
+
+    Returns a list of (level, message) where level is 'ok', 'warn' or
+    'error'. Purely informational — nothing here blocks a session.
+    """
+    findings = []
+
+    name = distro_name()
+    did = distro_id()
+    major = distro_major()
+
+    if not did:
+        findings.append(('warn',
+                         "Could not read /etc/os-release — unable to confirm this "
+                         "is a RHEL-family system. Tasks may not behave as expected."))
+    elif did not in SUPPORTED_IDS and not is_rhel_family():
+        findings.append(('error',
+                         "%s is not a RHEL-family distribution. Package names, "
+                         "SELinux, firewalld and boot layout will all differ; "
+                         "most tasks will not grade correctly." % name))
+    elif major is not None and major not in SUPPORTED_MAJORS:
+        findings.append(('warn',
+                         "%s — EX200 v10 targets major version 10 (9 is usable). "
+                         "Some tasks may assume a different layout." % name))
+    else:
+        findings.append(('ok', "Detected %s" % name))
+
+    detected = detected_system_vgs()
+    if detected:
+        findings.append(('ok', "Protected system volume group(s): %s"
+                         % ', '.join(sorted(detected))))
+    elif _run(['vgs', '--noheadings', '-o', 'vg_name'], timeout=5) is not None:
+        findings.append(('ok', "No LVM-backed system mounts — nothing to protect"))
+    else:
+        findings.append(('warn',
+                         "Could not probe LVM to identify this system's own volume "
+                         "groups (lvm2 missing, or not running as root). Falling "
+                         "back to a list of known names; storage tasks will be "
+                         "conservative about which volumes they use."))
+
+    if not grub_config_present():
+        findings.append(('warn',
+                         "No GRUB config found at /boot/grub2/grub.cfg or "
+                         "/boot/efi/EFI/*/grub.cfg — boot tasks may not grade."))
+
+    return findings
+
+
+def describe():
+    """One-line summary of the detected environment."""
+    parts = [distro_name()]
+    vgs = sorted(detected_system_vgs())
+    if vgs:
+        parts.append("system VG: %s" % ', '.join(vgs))
+    return ' | '.join(parts)


### PR DESCRIPTION
Stacked on #79 (base is `fix/alma-install-and-system-vg-detection`) — retarget to `master` once that merges.

The real EX200 doesn't put its questions in your terminal. They live in a window on the exam desktop: a dropdown selects one task at a time, each with **Revisit** and **Done** ticks, countdown alongside. Managing that window while you work is its own skill, and practising against a scrollable pager in the same terminal you're working in trains the wrong thing.

```bash
sudo rhcsa-simulator --exam --gui                        # :8080
sudo rhcsa-simulator --exam --gui 9000                   # pick a port
sudo rhcsa-simulator --exam --gui --gui-bind 127.0.0.1   # local only
```

## Design decisions

- **Dropdown entries are deliberately generic** ("Task 07"). As on the day, you can't triage the list by reading it — you have to open each task.
- **Revisit and Done toggle independently.** Click again to clear, and a task can be both ("did something, but want another look").
- **Marks are the candidate's own bookkeeping**, held server-side so the view survives a reload and is shared across windows. They are *not* `core.task_flags`, which reports a task as defective and persists to disk — conflating the two would let a nervous candidate silently file bug reports against tasks they merely found hard.
- **Ticking "done" tells the grader nothing.** Validation still runs against real system state in the terminal. The panel serves questions only — no shell, no validation route — and a test asserts those routes 404.
- **Binds `0.0.0.0` by default**, because the exam VM is usually headless and the browser is on another machine. `--gui-bind 127.0.0.1` keeps it local. URLs are printed at exam start with a note that it's unauthenticated.
- **Fails soft, always.** Port in use → no URLs and the exam continues; failing state provider → empty sheet rather than a 500; daemon thread so it can never hold up an exam.
- **Stdlib only** (`http.server` + `json`), fully self-contained — no external assets to fetch on an offline VM.

Tasks are attributed to the machine they run on, so `requires_lab_machine` tasks show the lab host rather than this box.

## Verification

Checked in a real browser, not just asserted: dropdown navigation, independent Revisit/Done toggling, and the server-side tally updating across a round trip. Dark and light palettes are both defined; **dark was verified visually, light was not.**

No Red Hat branding — styling only. This is a practice tool and shouldn't present itself as the real exam.

Tests: **354 passed, 1 failed** — `test_exam_mode.py::test_generates_correct_count`, pre-existing on `master`.

## Not included

A full replica deployment (GNOME desktop, VM-control applet, two-node layout) — noted as a "maybe one day" idea, not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cp8gGc1CQ3UjdopTWsUmSd