### PR TITLE
Fix stale --gui help text

### DIFF
--- a/rhcsa_simulator.py
+++ b/rhcsa_simulator.py
@@ -58,8 +58,8 @@ Quick Start Examples:
     parser.add_argument('--gui', nargs='?', const=8080, type=int, metavar='PORT',
                         help='Serve the exam task sheet to a browser window '
                              '(default port 8080), the way the real exam '
-                             'presents it — collapsed checklist with '
-                             'done/revisit ticks')
+                             'presents it — dropdown task selector with '
+                             'done/revisit ticks and the countdown')
     parser.add_argument('--gui-bind', default='0.0.0.0', metavar='ADDR',
                         help='Address the task panel listens on '
                              '(default 0.0.0.0, so a headless exam VM can be '


### PR DESCRIPTION
`--gui`'s help string still described the collapsed-checklist layout from an earlier draft of the panel. The shipped panel uses a dropdown task selector, so the text was wrong the moment it landed in #80.

One line, docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cp8gGc1CQ3UjdopTWsUmSd