### PR TITLE
Task panel: accordion layout, and stop advertising unreachable URLs

### DIFF
--- a/core/exam.py
+++ b/core/exam.py
@@ -167,6 +167,27 @@ class ExamSession:
             print(fmt.dim("  (Unauthenticated and reachable from your LAN. It "
                           "serves exam questions only — no shell, no control "
                           "of this box.)"))
+            # A stock RHEL/Alma box has firewalld up with nothing open, so
+            # the LAN URL above simply won't connect from a laptop. Say so
+            # rather than letting the candidate debug it mid-exam. We never
+            # open the port ourselves — this simulator grades firewall tasks,
+            # and editing firewalld here would corrupt what they check.
+            try:
+                from core import task_gui
+                if task_gui.firewall_blocks(self.gui_port):
+                    print(fmt.warning(
+                        f"  firewalld is blocking port {self.gui_port}, so only "
+                        f"the 127.0.0.1 URL will work from this box."))
+                    print(fmt.dim(
+                        f"    Reach it from another machine either by "
+                        f"forwarding it over SSH (leaves the firewall alone):\n"
+                        f"      ssh -L {self.gui_port}:127.0.0.1:"
+                        f"{self.gui_port} root@<this-box>\n"
+                        f"    or by opening the port yourself. Note that this "
+                        f"exam may contain firewall tasks, so the simulator "
+                        f"will not change firewalld for you."))
+            except Exception:
+                pass
 
     def _stop_task_panel(self):
         if self.panel:

--- a/core/task_gui.py
+++ b/core/task_gui.py
@@ -16,11 +16,13 @@ beside your terminals, the way it will on the day.
 
 SHAPE
 -----
-Same interaction model as the current exam, in a modern skin: a sidebar
-carrying the countdown and a done/revisit tally, a "perform this task on
-<host>" chip, and a **dropdown** that selects one task at a time. Entries
-in that dropdown are deliberately generic ("Task 07") — exactly as on the
-day, you cannot triage the list by reading it, you have to open each one.
+An accordion, in a modern skin: a sidebar carrying the countdown and a
+done/revisit tally, a "perform these tasks on <host>" chip, then one
+collapsed row per task. Click a row and its drawer expands in place to
+reveal the task text.
+
+Row labels are deliberately generic ("Task 07") — exactly as on the day,
+you cannot triage the list by reading it, you have to open each one.
 
 Each task carries **Revisit** and **Done**. They toggle independently:
 click again to clear, and a task can be both (you did something, but want
@@ -165,23 +167,77 @@ def build_state(tasks, remaining_seconds=None):
     }
 
 
+def _probe(cmd, timeout=5):
+    """Run a read-only command, returning stdout or None. Never raises."""
+    import subprocess
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except (FileNotFoundError, OSError, Exception):
+        return None
+    return r.stdout if r.returncode == 0 else None
+
+
+# Addresses that are never a useful URL for the candidate's browser.
+# 192.0.2.0/24 and friends matter here specifically because the simulator's
+# own networking tasks configure documentation-range addresses on dummy
+# interfaces — this used to advertise http://192.0.2.10:8080/ on a box that
+# had run one.
+_USELESS_ADDR_PREFIXES = (
+    '127.',          # loopback, already listed
+    '169.254.',      # link-local
+    '192.0.2.',      # TEST-NET-1
+    '198.51.100.',   # TEST-NET-2
+    '203.0.113.',    # TEST-NET-3
+)
+
+
+def _host_addresses():
+    """Global-scope IPv4 addresses another machine could actually reach."""
+    found = []
+    out = _probe(['ip', '-4', '-o', 'addr', 'show', 'scope', 'global'])
+    if out:
+        for line in out.splitlines():
+            parts = line.split()
+            for i, token in enumerate(parts):
+                if token == 'inet' and i + 1 < len(parts):
+                    found.append(parts[i + 1].split('/')[0])
+    if not found:
+        # No iproute2: ask the kernel which source address it would use for
+        # an off-box destination. No packets are sent by connecting a UDP
+        # socket — it only sets the local endpoint.
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            try:
+                s.connect(('8.8.8.8', 9))
+                found.append(s.getsockname()[0])
+            finally:
+                s.close()
+        except OSError:
+            pass
+    return [a for a in found if a and not a.startswith(_USELESS_ADDR_PREFIXES)]
+
+
+def firewall_blocks(port):
+    """True if firewalld is running and would drop connections to `port`.
+
+    Deliberately advisory. The panel must NEVER open the port itself: this
+    simulator has firewall tasks, and silently editing firewalld would
+    corrupt the very state their validators grade.
+    """
+    active = _probe(['systemctl', 'is-active', 'firewalld'])
+    if not active or active.strip() != 'active':
+        return False
+    ports = _probe(['firewall-cmd', '--list-ports'])
+    if ports is None:
+        return False
+    return ('%d/tcp' % port) not in ports.split()
+
+
 def _local_addresses(port):
     """URLs the panel is reachable on, best-effort. The LAN address matters:
     the exam VM is usually headless, so the browser is on another machine."""
     urls = ['http://127.0.0.1:%d/' % port]
-    try:
-        # No traffic is sent — this just asks the kernel which source address
-        # it would use, which is the one another host can reach us on.
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        try:
-            s.connect(('192.0.2.1', 9))  # TEST-NET-1, guaranteed unroutable
-            ip = s.getsockname()[0]
-        finally:
-            s.close()
-        if ip and not ip.startswith('127.'):
-            urls.append('http://%s:%d/' % (ip, port))
-    except OSError:
-        pass
+    urls.extend('http://%s:%d/' % (a, port) for a in _host_addresses())
     return urls
 
 
@@ -329,8 +385,7 @@ PAGE_HTML = """<!doctype html>
     --bg:#0e1116; --sunk:#0a0d11; --panel:#161a21; --panel2:#1c212a;
     --edge:#252b35; --edge2:#333b47;
     --ink:#e8ebf0; --dim:#9aa4b2; --faint:#6b7280;
-    --accent:#3b82f6; --accent-ink:#fff;
-    --done:#22c55e; --revisit:#f59e0b; --crit:#ef4444;
+    --accent:#3b82f6; --done:#22c55e; --revisit:#f59e0b; --crit:#ef4444;
     --radius:14px;
   }
   @media (prefers-color-scheme: light) {
@@ -349,34 +404,28 @@ PAGE_HTML = """<!doctype html>
          "Helvetica Neue", Arial, sans-serif;
     -webkit-font-smoothing:antialiased;
   }
-  #wrap { display:flex; min-height:100%; gap:0; }
+  #wrap { display:flex; min-height:100%; }
 
   /* ── sidebar ───────────────────────────────────────────────────────── */
   aside {
     width:248px; flex:0 0 248px; background:var(--sunk);
-    border-right:1px solid var(--edge);
-    padding:22px 18px; position:sticky; top:0; height:100vh;
+    border-right:1px solid var(--edge); padding:22px 18px;
+    position:sticky; top:0; height:100vh;
     display:flex; flex-direction:column; gap:20px;
   }
   .brand { display:flex; align-items:center; gap:10px; }
-  .glyph {
-    width:30px; height:30px; border-radius:9px; flex:0 0 30px;
-    background:linear-gradient(135deg,var(--accent),#8b5cf6);
-  }
+  .glyph { width:30px; height:30px; border-radius:9px; flex:0 0 30px;
+           background:linear-gradient(135deg,var(--accent),#8b5cf6); }
   .brand b { font-size:15px; font-weight:620; letter-spacing:-.1px; }
   .brand span { display:block; font-size:11.5px; color:var(--faint);
                 font-weight:450; letter-spacing:.3px; }
 
-  .clockwrap {
-    background:var(--panel); border:1px solid var(--edge);
-    border-radius:var(--radius); padding:14px 16px;
-  }
+  .clockwrap { background:var(--panel); border:1px solid var(--edge);
+               border-radius:var(--radius); padding:14px 16px; }
   .clocklabel { font-size:11px; text-transform:uppercase; letter-spacing:.9px;
                 color:var(--faint); margin-bottom:5px; }
-  .clock {
-    font-size:30px; font-weight:640; letter-spacing:-.5px;
-    font-variant-numeric:tabular-nums; line-height:1.1;
-  }
+  .clock { font-size:30px; font-weight:640; letter-spacing:-.5px;
+           font-variant-numeric:tabular-nums; line-height:1.1; }
   .clock.warn { color:var(--revisit); }
   .clock.crit { color:var(--crit); }
 
@@ -385,105 +434,100 @@ PAGE_HTML = """<!doctype html>
   .progbar i { display:block; height:100%; background:var(--done);
                border-radius:99px; transition:width .25s ease; }
   .stats { display:flex; gap:8px; }
-  .stat {
-    flex:1; background:var(--panel); border:1px solid var(--edge);
-    border-radius:11px; padding:9px 10px;
-  }
+  .stat { flex:1; background:var(--panel); border:1px solid var(--edge);
+          border-radius:11px; padding:9px 10px; }
   .stat b { display:block; font-size:19px; font-weight:640;
             font-variant-numeric:tabular-nums; line-height:1.15; }
-  .stat span { font-size:11px; color:var(--faint); letter-spacing:.2px; }
+  .stat span { font-size:11px; color:var(--faint); }
   .stat.d b { color:var(--done); }
   .stat.r b { color:var(--revisit); }
-
   .side-note { margin-top:auto; font-size:11.5px; color:var(--faint); line-height:1.5; }
 
   /* ── main ──────────────────────────────────────────────────────────── */
-  main { flex:1; padding:26px 30px 50px; max-width:940px; }
-
+  main { flex:1; padding:26px 30px 60px; max-width:960px; }
+  .topbar { display:flex; align-items:center; gap:12px; margin-bottom:16px;
+            flex-wrap:wrap; }
   .hostchip {
-    display:inline-flex; align-items:center; gap:8px; margin-bottom:18px;
+    display:inline-flex; align-items:center; gap:8px;
     background:var(--panel); border:1px solid var(--edge);
     border-radius:99px; padding:6px 14px 6px 11px; font-size:13px; color:var(--dim);
   }
-  .hostchip i {
-    width:7px; height:7px; border-radius:99px; background:var(--done);
-    box-shadow:0 0 0 3px color-mix(in srgb, var(--done) 22%, transparent);
-  }
+  .hostchip i { width:7px; height:7px; border-radius:99px; background:var(--done); }
   .hostchip code {
     font-family:ui-monospace,SFMono-Regular,"JetBrains Mono",Menlo,monospace;
     font-size:12.5px; color:var(--ink);
   }
-
-  .toolbar { display:flex; gap:12px; align-items:center; margin-bottom:16px;
-             flex-wrap:wrap; }
-  .selwrap { position:relative; flex:1; min-width:260px; max-width:520px; }
-  select {
-    appearance:none; width:100%; font:inherit; font-size:14.5px;
-    padding:11px 38px 11px 14px; color:var(--ink);
-    background:var(--panel); border:1px solid var(--edge2);
-    border-radius:11px; cursor:pointer;
+  .spacer { margin-left:auto; }
+  .ghost {
+    font:inherit; font-size:13px; padding:7px 13px; border-radius:9px;
+    border:1px solid var(--edge2); background:transparent; color:var(--dim);
+    cursor:pointer;
   }
-  select:focus { outline:2px solid var(--accent); outline-offset:1px; }
-  .selwrap::after {
-    content:""; position:absolute; right:15px; top:50%; pointer-events:none;
-    width:8px; height:8px; margin-top:-6px; border-right:2px solid var(--dim);
-    border-bottom:2px solid var(--dim); transform:rotate(45deg);
-  }
+  .ghost:hover { color:var(--ink); border-color:var(--accent); }
 
-  .marks { display:flex; gap:8px; }
+  /* ── accordion ─────────────────────────────────────────────────────── */
+  .item {
+    background:var(--panel); border:1px solid var(--edge);
+    border-radius:12px; margin-bottom:8px; overflow:hidden;
+    transition:border-color .12s;
+  }
+  .item.sel { border-color:var(--accent); }
+  .item.is-revisit { box-shadow:inset 3px 0 0 var(--revisit); }
+  .item.is-done .label { color:var(--faint); }
+
+  .row {
+    display:flex; align-items:center; gap:13px; padding:13px 16px;
+    cursor:pointer; user-select:none;
+  }
+  .row:hover { background:var(--panel2); }
+  .chev {
+    width:9px; height:9px; flex:0 0 9px; margin-right:1px;
+    border-right:2px solid var(--faint); border-bottom:2px solid var(--faint);
+    transform:rotate(-45deg); transition:transform .16s ease;
+  }
+  .item.open .chev { transform:rotate(45deg); }
+  .label { font-size:15px; font-weight:540; font-variant-numeric:tabular-nums; }
+  .cat {
+    font-size:11.5px; color:var(--faint); background:var(--panel2);
+    border:1px solid var(--edge); border-radius:99px; padding:2px 9px;
+  }
+  .rowpts { margin-left:auto; font-size:12.5px; color:var(--faint);
+            font-variant-numeric:tabular-nums; }
+
+  .marks { display:flex; gap:7px; }
   .mk {
-    display:inline-flex; align-items:center; gap:8px; cursor:pointer;
-    user-select:none; font-size:14px; padding:10px 15px; border-radius:11px;
+    display:inline-flex; align-items:center; gap:7px; cursor:pointer;
+    font-size:12.5px; padding:6px 11px; border-radius:9px;
     border:1px solid var(--edge2); background:var(--panel); color:var(--dim);
     transition:background .12s, border-color .12s, color .12s;
   }
-  .mk:hover { border-color:var(--edge2); color:var(--ink); }
+  .mk:hover { color:var(--ink); }
   .mk .box {
-    width:17px; height:17px; border-radius:6px; flex:0 0 17px;
+    width:15px; height:15px; border-radius:5px; flex:0 0 15px;
     border:1.5px solid var(--edge2); display:grid; place-items:center;
-    font-size:11px; line-height:1; color:transparent;
+    font-size:10px; line-height:1; color:transparent;
   }
   .mk.on { color:var(--ink); }
-  .mk.on-done { border-color:var(--done); background:color-mix(in srgb,var(--done) 13%,transparent); }
+  .mk.on-done { border-color:var(--done); background:color-mix(in srgb,var(--done) 14%,transparent); }
   .mk.on-done .box { background:var(--done); border-color:var(--done); color:#fff; }
-  .mk.on-revisit { border-color:var(--revisit); background:color-mix(in srgb,var(--revisit) 13%,transparent); }
+  .mk.on-revisit { border-color:var(--revisit); background:color-mix(in srgb,var(--revisit) 14%,transparent); }
   .mk.on-revisit .box { background:var(--revisit); border-color:var(--revisit); color:#fff; }
 
-  .card {
-    background:var(--panel); border:1px solid var(--edge);
-    border-radius:var(--radius); padding:24px 26px;
+  .drawer {
+    display:none; padding:4px 18px 18px 39px;
+    border-top:1px solid var(--edge);
   }
-  .card-top {
-    display:flex; align-items:center; gap:10px; margin-bottom:16px;
-    padding-bottom:14px; border-bottom:1px solid var(--edge);
-  }
-  .tasknum { font-size:13px; color:var(--faint); font-variant-numeric:tabular-nums; }
-  .pill {
-    font-size:11.5px; letter-spacing:.3px; color:var(--dim);
-    background:var(--panel2); border:1px solid var(--edge);
-    border-radius:99px; padding:3px 10px;
-  }
-  .pts { margin-left:auto; font-size:13px; color:var(--faint);
-         font-variant-numeric:tabular-nums; }
-  .desc { white-space:pre-wrap; font-size:16px; line-height:1.65; }
+  .item.open .drawer { display:block; }
+  .desc { white-space:pre-wrap; font-size:15.5px; line-height:1.65; padding-top:14px; }
   .desc.mono {
     font-family:ui-monospace,SFMono-Regular,"JetBrains Mono",Menlo,monospace;
-    font-size:14px; line-height:1.7;
+    font-size:13.8px; line-height:1.7;
   }
+  .meta { margin-top:13px; font-size:12px; color:var(--faint); }
 
-  .nav { display:flex; gap:9px; align-items:center; margin-top:18px; }
-  button {
-    font:inherit; font-size:14px; padding:9px 16px; border-radius:10px;
-    border:1px solid var(--edge2); background:var(--panel); color:var(--ink);
-    cursor:pointer; transition:background .12s, border-color .12s;
-  }
-  button:hover:not(:disabled) { background:var(--panel2); border-color:var(--accent); }
-  button:disabled { opacity:.4; cursor:default; }
-  .keys { margin-left:auto; font-size:12px; color:var(--faint); }
-  kbd {
-    font:inherit; font-size:11px; padding:1.5px 6px; border-radius:5px;
-    background:var(--panel2); border:1px solid var(--edge2); color:var(--dim);
-  }
+  .keys { margin-top:20px; font-size:12px; color:var(--faint); }
+  kbd { font:inherit; font-size:11px; padding:1.5px 6px; border-radius:5px;
+        background:var(--panel2); border:1px solid var(--edge2); color:var(--dim); }
 
   .empty { padding:80px 0; text-align:center; color:var(--faint); }
   .empty b { display:block; font-size:16px; color:var(--dim); margin-bottom:6px;
@@ -494,8 +538,9 @@ PAGE_HTML = """<!doctype html>
     aside { width:auto; height:auto; position:static; flex-direction:row;
             flex-wrap:wrap; align-items:center; border-right:0;
             border-bottom:1px solid var(--edge); }
-    .clockwrap { flex:1; } .prog { flex:1; } .side-note { display:none; }
-    main { padding:20px 16px 40px; }
+    .clockwrap, .prog { flex:1; } .side-note { display:none; }
+    main { padding:18px 14px 40px; }
+    .rowpts, .cat { display:none; }
   }
 </style>
 </head>
@@ -506,12 +551,10 @@ PAGE_HTML = """<!doctype html>
       <div class="glyph"></div>
       <div><b>RHCSA Mock Exam</b><span>EX200 practice</span></div>
     </div>
-
     <div class="clockwrap">
       <div class="clocklabel">Time remaining</div>
       <div class="clock" id="clock">&mdash;</div>
     </div>
-
     <div class="prog">
       <div class="progbar"><i id="progfill" style="width:0%"></i></div>
       <div class="stats">
@@ -520,23 +563,25 @@ PAGE_HTML = """<!doctype html>
         <div class="stat"><b id="nleft">0</b><span>left</span></div>
       </div>
     </div>
-
     <div class="side-note">Ticks here are your own notes. Grading runs
       against real system state when you return to the terminal.</div>
   </aside>
 
   <main>
-    <div id="sheet">
+    <div class="topbar" id="topbar"></div>
+    <div id="list">
       <div class="empty"><b>Waiting for an exam to start</b>
         Start one in the terminal &mdash; this panel follows it.</div>
     </div>
+    <div class="keys" id="keys"></div>
   </main>
 </div>
 
 <script>
 (function () {
   var state = { tasks: [] };
-  var cur = 0;               // 0-based index of the selected task
+  var open = {};             // task id -> drawer expanded
+  var sel = 0;               // keyboard cursor, 0-based
   var localRemaining = null; // ticks locally between polls
 
   var $ = function (id) { return document.getElementById(id); };
@@ -563,70 +608,71 @@ PAGE_HTML = """<!doctype html>
                             : localRemaining <= 900 ? ' warn' : '');
   }
 
-  function renderSidebar() {
+  function render() {
     var ts = state.tasks || [];
     var done = state.done_count || 0;
     $('ndone').textContent = done;
     $('nrev').textContent = state.revisit_count || 0;
     $('nleft').textContent = Math.max(0, ts.length - done);
     $('progfill').style.width = ts.length ? (done / ts.length * 100) + '%' : '0%';
-  }
 
-  function render() {
-    var ts = state.tasks || [];
-    renderSidebar();
     if (!ts.length) {
-      $('sheet').innerHTML = '<div class="empty"><b>Waiting for an exam to start</b>'
+      $('topbar').innerHTML = '';
+      $('keys').innerHTML = '';
+      $('list').innerHTML = '<div class="empty"><b>Waiting for an exam to start</b>'
         + 'Start one in the terminal &mdash; this panel follows it.</div>';
       return;
     }
-    if (cur >= ts.length) cur = ts.length - 1;
-    var t = ts[cur];
+    if (sel >= ts.length) sel = ts.length - 1;
 
-    // Entries stay deliberately generic, as on the real sheet: you cannot
+    var anyOpen = ts.some(function (t) { return open[t.id]; });
+    $('topbar').innerHTML =
+      '<div class="hostchip"><i></i>Perform these tasks on <code>'
+      + esc(ts[0].host) + '</code></div>'
+      + '<span class="spacer"></span>'
+      + '<button class="ghost" id="toggleall">'
+      + (anyOpen ? 'Collapse all' : 'Expand all') + '</button>';
+
+    $('keys').innerHTML = '<kbd>j</kbd><kbd>k</kbd> move &nbsp; '
+      + '<kbd>enter</kbd> open &nbsp; <kbd>d</kbd> done &nbsp; <kbd>r</kbd> revisit';
+
+    // Labels stay deliberately generic, as on the real sheet: you cannot
     // triage the list by reading it, you have to open each one.
-    var opts = ts.map(function (x, i) {
-      var mark = x.done ? '\\u2713 ' : (x.revisit ? '\\u21ba ' : '');
-      return '<option value="' + i + '"' + (i === cur ? ' selected' : '') + '>'
-        + mark + 'Task ' + (x.n < 10 ? '0' : '') + x.n + '</option>';
+    $('list').innerHTML = ts.map(function (t, i) {
+      var isOpen = !!open[t.id];
+      var cls = 'item' + (isOpen ? ' open' : '') + (i === sel ? ' sel' : '')
+        + (t.done ? ' is-done' : '') + (t.revisit ? ' is-revisit' : '');
+      var mono = t.description.indexOf('\\n') !== -1 ? ' mono' : '';
+      var dom = t.domain_name ? ('Domain ' + t.domain + ' \\u00b7 ' + t.domain_name) : '';
+      return ''
+        + '<div class="' + cls + '" data-i="' + i + '">'
+        +   '<div class="row" data-act="toggle">'
+        +     '<span class="chev"></span>'
+        +     '<span class="label">Task ' + (t.n < 10 ? '0' : '') + t.n + '</span>'
+        +     (isOpen ? '<span class="cat">' + esc(t.category) + '</span>' : '')
+        +     '<span class="rowpts">' + t.points + ' pts</span>'
+        +     '<span class="marks">'
+        +       mk(t, 'revisit', 'Revisit') + mk(t, 'done', 'Done')
+        +     '</span>'
+        +   '</div>'
+        +   '<div class="drawer">'
+        +     '<div class="desc' + mono + '">' + esc(t.description) + '</div>'
+        +     (dom ? '<div class="meta">' + esc(dom) + '</div>' : '')
+        +   '</div>'
+        + '</div>';
     }).join('');
-
-    var mono = t.description.indexOf('\\n') !== -1 ? ' mono' : '';
-    var dom = t.domain_name ? ('Domain ' + t.domain + ' \\u00b7 ' + t.domain_name) : '';
-
-    $('sheet').innerHTML = ''
-      + '<div class="hostchip"><i></i>Perform this task on '
-      +   '<code>' + esc(t.host) + '</code></div>'
-      + '<div class="toolbar">'
-      +   '<div class="selwrap"><select id="pick">' + opts + '</select></div>'
-      +   '<div class="marks">' + mk(t, 'revisit', 'Revisit') + mk(t, 'done', 'Done') + '</div>'
-      + '</div>'
-      + '<div class="card">'
-      +   '<div class="card-top">'
-      +     '<span class="tasknum">Task ' + t.n + ' of ' + ts.length + '</span>'
-      +     (dom ? '<span class="pill">' + esc(dom) + '</span>' : '')
-      +     '<span class="pill">' + esc(t.category) + '</span>'
-      +     '<span class="pts">' + t.points + ' points</span>'
-      +   '</div>'
-      +   '<div class="desc' + mono + '">' + esc(t.description) + '</div>'
-      +   '<div class="nav">'
-      +     '<button id="prev"' + (cur === 0 ? ' disabled' : '') + '>&larr; Previous</button>'
-      +     '<button id="next"' + (cur === ts.length - 1 ? ' disabled' : '') + '>Next &rarr;</button>'
-      +     '<span class="keys"><kbd>j</kbd><kbd>k</kbd> move &nbsp; '
-      +       '<kbd>d</kbd> done &nbsp; <kbd>r</kbd> revisit</span>'
-      +   '</div>'
-      + '</div>';
   }
 
   function mk(t, field, label) {
     var on = !!t[field];
-    return '<label class="mk' + (on ? ' on on-' + field : '') + '" data-field="'
-      + field + '"><span class="box">\\u2713</span>' + label + '</label>';
+    return '<label class="mk' + (on ? ' on on-' + field : '') + '" data-act="mark"'
+      + ' data-field="' + field + '"><span class="box">\\u2713</span>'
+      + label + '</label>';
   }
 
-  function mark(field, value) {
+  function mark(i, field, value) {
     var ts = state.tasks || [];
-    var t = ts[cur];
+    var t = ts[i];
     if (!t) return;
     t[field] = value;                      // optimistic; poll reconciles
     state.done_count = ts.filter(function (x) { return x.done; }).length;
@@ -639,52 +685,65 @@ PAGE_HTML = """<!doctype html>
     }).catch(function () { /* panel is advisory; ignore */ });
   }
 
-  function go(i) {
+  function toggle(i) {
+    var t = (state.tasks || [])[i];
+    if (!t) return;
+    open[t.id] = !open[t.id];
+    render();
+  }
+
+  function move(delta) {
     var ts = state.tasks || [];
     if (!ts.length) return;
-    cur = Math.max(0, Math.min(ts.length - 1, i));
+    sel = Math.max(0, Math.min(ts.length - 1, sel + delta));
     render();
+    var el = document.querySelector('.item.sel');
+    if (el) el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
   }
 
   function poll() {
     fetch('/api/state').then(function (r) { return r.json(); }).then(function (s) {
-      var wasEmpty = !(state.tasks || []).length;
       state = s;
       if (typeof s.remaining_seconds === 'number') localRemaining = s.remaining_seconds;
       else if (s.remaining_seconds === null) localRemaining = null;
-      if (wasEmpty && (s.tasks || []).length) cur = 0;
       render();
       renderClock();
     }).catch(function () { /* terminal session ended; keep last view */ });
   }
 
-  document.addEventListener('change', function (e) {
-    if (e.target.id === 'pick') go(parseInt(e.target.value, 10));
-  });
-
   document.addEventListener('click', function (e) {
-    if (e.target.id === 'prev') { go(cur - 1); return; }
-    if (e.target.id === 'next') { go(cur + 1); return; }
-    var lbl = e.target.closest('.mk');
+    if (e.target.id === 'toggleall') {
+      var ts = state.tasks || [];
+      var anyOpen = ts.some(function (t) { return open[t.id]; });
+      ts.forEach(function (t) { open[t.id] = !anyOpen; });
+      render();
+      return;
+    }
+    var host = e.target.closest('[data-i]');
+    if (!host) return;
+    var i = parseInt(host.getAttribute('data-i'), 10);
+    sel = i;
+    var lbl = e.target.closest('[data-act="mark"]');
     if (lbl) {
       // Each toggles independently — click again to clear, and a task can
       // be both done and flagged for another look.
-      var t = (state.tasks || [])[cur];
-      var field = lbl.getAttribute('data-field');
-      if (t) mark(field, !t[field]);
+      var t = (state.tasks || [])[i];
+      if (t) mark(i, lbl.getAttribute('data-field'), !t[lbl.getAttribute('data-field')]);
       e.preventDefault();
+      return;
     }
+    if (e.target.closest('[data-act="toggle"]')) toggle(i);
   });
 
   document.addEventListener('keydown', function (e) {
     if (e.metaKey || e.ctrlKey || e.altKey) return;
-    if (e.target && e.target.tagName === 'SELECT') return;
-    var t = (state.tasks || [])[cur];
+    var t = (state.tasks || [])[sel];
     var k = e.key;
-    if (k === 'j' || k === 'ArrowRight' || k === 'ArrowDown') { go(cur + 1); e.preventDefault(); }
-    else if (k === 'k' || k === 'ArrowLeft' || k === 'ArrowUp') { go(cur - 1); e.preventDefault(); }
-    else if (k === 'd' && t) { mark('done', !t.done); e.preventDefault(); }
-    else if (k === 'r' && t) { mark('revisit', !t.revisit); e.preventDefault(); }
+    if (k === 'j' || k === 'ArrowDown') { move(1); e.preventDefault(); }
+    else if (k === 'k' || k === 'ArrowUp') { move(-1); e.preventDefault(); }
+    else if (k === 'Enter' || k === ' ') { toggle(sel); e.preventDefault(); }
+    else if (k === 'd' && t) { mark(sel, 'done', !t.done); e.preventDefault(); }
+    else if (k === 'r' && t) { mark(sel, 'revisit', !t.revisit); e.preventDefault(); }
   });
 
   // The clock ticks locally so it stays smooth between polls; the poll is

--- a/core/task_gui.py
+++ b/core/task_gui.py
@@ -381,7 +381,10 @@ PAGE_HTML = """<!doctype html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>RHCSA Mock Exam &mdash; Tasks</title>
 <style>
-  :root {
+  /* Dark is the default. The OS preference applies only while the viewer
+     has not chosen explicitly; data-theme (set by the toggle, remembered in
+     localStorage) always wins in both directions. */
+  :root, :root[data-theme="dark"] {
     --bg:#0e1116; --sunk:#0a0d11; --panel:#161a21; --panel2:#1c212a;
     --edge:#252b35; --edge2:#333b47;
     --ink:#e8ebf0; --dim:#9aa4b2; --faint:#6b7280;
@@ -389,12 +392,18 @@ PAGE_HTML = """<!doctype html>
     --radius:14px;
   }
   @media (prefers-color-scheme: light) {
-    :root {
+    :root:not([data-theme]) {
       --bg:#f5f6f8; --sunk:#eceef2; --panel:#fff; --panel2:#f8f9fb;
       --edge:#e2e5ea; --edge2:#cfd4dc;
       --ink:#11151b; --dim:#5b6472; --faint:#858d99;
       --done:#15803d; --revisit:#b45309;
     }
+  }
+  :root[data-theme="light"] {
+    --bg:#f5f6f8; --sunk:#eceef2; --panel:#fff; --panel2:#f8f9fb;
+    --edge:#e2e5ea; --edge2:#cfd4dc;
+    --ink:#11151b; --dim:#5b6472; --faint:#858d99;
+    --done:#15803d; --revisit:#b45309;
   }
   * { box-sizing:border-box; }
   html,body { height:100%; }
@@ -441,7 +450,14 @@ PAGE_HTML = """<!doctype html>
   .stat span { font-size:11px; color:var(--faint); }
   .stat.d b { color:var(--done); }
   .stat.r b { color:var(--revisit); }
-  .side-note { margin-top:auto; font-size:11.5px; color:var(--faint); line-height:1.5; }
+  .side-foot { margin-top:auto; display:flex; flex-direction:column; gap:12px; }
+  .side-note { font-size:11.5px; color:var(--faint); line-height:1.5; }
+  #theme {
+    font:inherit; font-size:12.5px; padding:8px 12px; border-radius:9px;
+    border:1px solid var(--edge2); background:var(--panel); color:var(--dim);
+    cursor:pointer; display:flex; align-items:center; gap:8px;
+  }
+  #theme:hover { color:var(--ink); border-color:var(--accent); }
 
   /* ── main ──────────────────────────────────────────────────────────── */
   main { flex:1; padding:26px 30px 60px; max-width:960px; }
@@ -563,8 +579,11 @@ PAGE_HTML = """<!doctype html>
         <div class="stat"><b id="nleft">0</b><span>left</span></div>
       </div>
     </div>
-    <div class="side-note">Ticks here are your own notes. Grading runs
-      against real system state when you return to the terminal.</div>
+    <div class="side-foot">
+      <div class="side-note">Ticks here are your own notes. Grading runs
+        against real system state when you return to the terminal.</div>
+      <button id="theme"><span id="themeicon">&#9789;</span><span id="themetext">Dark</span></button>
+    </div>
   </aside>
 
   <main>
@@ -585,6 +604,39 @@ PAGE_HTML = """<!doctype html>
   var localRemaining = null; // ticks locally between polls
 
   var $ = function (id) { return document.getElementById(id); };
+
+  // ── theme ───────────────────────────────────────────────────────────
+  // Follows the OS until the viewer picks one, then remembers the choice.
+  var THEME_KEY = 'rhcsa-panel-theme';
+
+  function systemTheme() {
+    return (window.matchMedia
+      && window.matchMedia('(prefers-color-scheme: light)').matches)
+      ? 'light' : 'dark';
+  }
+
+  function currentTheme() {
+    return document.documentElement.getAttribute('data-theme') || systemTheme();
+  }
+
+  function applyTheme(name) {
+    if (name) document.documentElement.setAttribute('data-theme', name);
+    var dark = currentTheme() === 'dark';
+    $('themeicon').innerHTML = dark ? '&#9789;' : '&#9788;';   // moon / sun
+    $('themetext').textContent = dark ? 'Dark' : 'Light';
+  }
+
+  try {
+    var saved = localStorage.getItem(THEME_KEY);
+    if (saved === 'light' || saved === 'dark') applyTheme(saved);
+    else applyTheme(null);
+  } catch (err) { applyTheme(null); }
+
+  $('theme').addEventListener('click', function () {
+    var next = currentTheme() === 'dark' ? 'light' : 'dark';
+    applyTheme(next);
+    try { localStorage.setItem(THEME_KEY, next); } catch (err) { /* private mode */ }
+  });
 
   function esc(s) {
     return String(s === null || s === undefined ? '' : s)

--- a/tests/unit/test_task_gui.py
+++ b/tests/unit/test_task_gui.py
@@ -291,10 +291,86 @@ def test_lab_machine_tasks_report_a_different_host(tasks, monkeypatch):
     assert len(hosts) == 2, hosts
 
 
-def test_dropdown_labels_do_not_leak_the_task(panel):
-    """Entries are generic like the real sheet — the list must not let you
-    triage without opening each task."""
+def test_row_labels_do_not_leak_the_task(panel):
+    """Collapsed rows are generic like the real sheet — the list must not
+    let you triage without opening each task."""
     _, base = panel
     _, body = _get(base, '/')
-    assert "'Task ' + (x.n < 10 ? '0' : '')" in body
+    assert 'class="label">Task ' in body
     assert 'Create a 1GiB logical volume' not in body  # comes from /api/state
+
+
+# ── reachable-URL advertising ───────────────────────────────────────────────
+
+def test_documentation_range_addresses_are_not_advertised(monkeypatch):
+    """The simulator's own networking tasks put TEST-NET-1 addresses on dummy
+    interfaces, and this used to advertise http://192.0.2.10:8080/ as the URL
+    to open."""
+    monkeypatch.setattr(task_gui, '_probe', lambda cmd, timeout=5: (
+        '1: lo    inet 127.0.0.1/8 scope host lo\n'
+        '2: ens160    inet 192.168.21.128/24 scope global ens160\n'
+        '3: dummy0    inet 192.0.2.10/24 scope global dummy0\n'
+    ))
+    assert task_gui._host_addresses() == ['192.168.21.128']
+
+    urls = task_gui._local_addresses(8080)
+    assert 'http://192.168.21.128:8080/' in urls
+    assert not any('192.0.2.10' in u for u in urls)
+
+
+def test_link_local_is_not_advertised(monkeypatch):
+    monkeypatch.setattr(task_gui, '_probe', lambda cmd, timeout=5: (
+        '2: ens160    inet 169.254.3.4/16 scope global ens160\n'))
+    assert task_gui._host_addresses() == []
+
+
+def test_loopback_url_always_offered(monkeypatch):
+    monkeypatch.setattr(task_gui, '_probe', lambda cmd, timeout=5: None)
+    monkeypatch.setattr(task_gui, '_host_addresses', lambda: [])
+    assert task_gui._local_addresses(8080) == ['http://127.0.0.1:8080/']
+
+
+# ── firewall awareness ──────────────────────────────────────────────────────
+
+def test_firewall_blocks_when_port_closed(monkeypatch):
+    def fake(cmd, timeout=5):
+        if 'is-active' in cmd:
+            return 'active\n'
+        if cmd[0] == 'firewall-cmd':
+            return '\n'          # nothing open, as on a stock RHEL/Alma box
+        return None
+    monkeypatch.setattr(task_gui, '_probe', fake)
+    assert task_gui.firewall_blocks(8080) is True
+
+
+def test_firewall_does_not_block_when_port_open(monkeypatch):
+    def fake(cmd, timeout=5):
+        if 'is-active' in cmd:
+            return 'active\n'
+        if cmd[0] == 'firewall-cmd':
+            return '8080/tcp 443/tcp\n'
+        return None
+    monkeypatch.setattr(task_gui, '_probe', fake)
+    assert task_gui.firewall_blocks(8080) is False
+
+
+def test_no_firewall_warning_when_firewalld_inactive(monkeypatch):
+    monkeypatch.setattr(task_gui, '_probe',
+                        lambda cmd, timeout=5: 'inactive\n' if 'is-active' in cmd else None)
+    assert task_gui.firewall_blocks(8080) is False
+
+
+def test_firewall_check_never_opens_the_port(monkeypatch):
+    """This simulator grades firewall tasks — the panel must never touch
+    firewalld, only report on it."""
+    seen = []
+
+    def fake(cmd, timeout=5):
+        seen.append(cmd)
+        return 'active\n' if 'is-active' in cmd else '\n'
+
+    monkeypatch.setattr(task_gui, '_probe', fake)
+    task_gui.firewall_blocks(8080)
+    flat = ' '.join(' '.join(c) for c in seen)
+    for mutating in ('--add-port', '--reload', '--permanent', '--remove-port'):
+        assert mutating not in flat, seen

--- a/tests/unit/test_task_gui.py
+++ b/tests/unit/test_task_gui.py
@@ -374,3 +374,20 @@ def test_firewall_check_never_opens_the_port(monkeypatch):
     flat = ' '.join(' '.join(c) for c in seen)
     for mutating in ('--add-port', '--reload', '--permanent', '--remove-port'):
         assert mutating not in flat, seen
+
+
+# ── theme ───────────────────────────────────────────────────────────────────
+
+def test_theme_toggle_present_and_overrides_the_os_preference(panel):
+    """Dark/light must be switchable in the page: the exam VM's browser often
+    has no desktop theme to follow, and the viewer may just want the other
+    one. data-theme has to win over prefers-color-scheme in BOTH directions."""
+    _, base = panel
+    _, body = _get(base, '/')
+
+    assert 'id="theme"' in body
+    assert ':root[data-theme="light"]' in body
+    assert ':root[data-theme="dark"]' in body
+    # The OS preference must not beat an explicit choice.
+    assert ':root:not([data-theme])' in body
+    assert 'localStorage' in body


### PR DESCRIPTION
Three fixes, all found by running the panel on the real AlmaLinux VM rather than only against tests.

## 1. Accordion instead of the dropdown

The dropdown showed one task at a time and hid the shape of the exam. The sheet is a list you scan and open in place: click **Task 04** and its drawer expands to reveal the content, with Revisit/Done on every row so you can see at a glance what you've marked.

Row labels stay deliberately generic (`Task 07`), as on the day — you can't triage the list by reading it, you have to open each one. The category chip only appears once a row is open.

## 2. It advertised a URL that could not work

`_local_addresses()` picked the source address the kernel would use to reach `192.0.2.1`, which I'd chosen as "guaranteed unroutable". That assumption is false on exactly the boxes this runs on — the simulator's *own* networking tasks configure documentation-range addresses on dummy interfaces:

```
$ ip -4 -br addr
ens160    UP    192.168.21.128/24
dummy0    UNKNOWN    192.0.2.10/24

urls: ['http://127.0.0.1:8080/', 'http://192.0.2.10:8080/']   # useless
```

Now enumerates global-scope addresses via `ip -4 -o addr` and filters loopback, link-local and all three documentation ranges, falling back to the kernel-source trick (against a routable address) when iproute2 is missing. Same box now correctly reports `192.168.21.128`.

## 3. firewalld silently ate the LAN URL

A stock RHEL/Alma install has firewalld active with **no ports open**, so the LAN URL the panel prints refuses connections from the candidate's laptop — the exact scenario `--gui` exists to serve. Confirmed on the VM: `curl` from another host got nothing.

The panel now detects this at exam start and says so, suggesting an SSH port-forward.

It deliberately does **not** open the port. This simulator grades firewall tasks, and silently editing firewalld would corrupt the state their validators check. A test asserts no mutating `firewall-cmd` flag is ever passed.

## Verification

Ran on the Alma VM with 16 real generated tasks and clicked through it in a browser: rows expand and collapse in place, Revisit/Done toggle independently per row, expand/collapse-all works, and the advertised URL is now the reachable one.

Tests: **361 passed, 1 failed** — `test_exam_mode.py::test_generates_correct_count`, pre-existing on `master`.

Supersedes #81, which I closed: the panel is a collapsed checklist again, so master's existing help text is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cp8gGc1CQ3UjdopTWsUmSd