### PR TITLE
Add EX200 v9 mode, including the containers objectives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,14 @@ python3 -m pytest -v            # Verbose output
 ## Key Facts
 
 - **Target OS**: RHEL 10 / Rocky Linux 9-10 / AlmaLinux 9-10
+- **Two exam versions.** `--exam-version 9|10` (default 10). v9 adds the
+  `containers` category and MBR partitioning; v10 adds `flatpak` and
+  `systemd_timers`. Gating lives in `config/settings.py`
+  (`VERSION_EXCLUDED_CATEGORIES` for whole categories, `exam_versions` on a
+  task class for one-off cases like MBR) and is enforced in
+  `TaskRegistry.in_scope()`. Objectives/weights per version are in
+  `config/exam_objectives.py` — call `get_objectives()`, never the version
+  dicts directly. A task that is out of scope must never be drawn.
 - **Never hardcode distro-specific names.** Anything that answers "is this the
   box's own OS, or the candidate's practice storage?" goes through
   `utils/system_id.py`, which *probes* — system VGs come from what actually

--- a/README.md
+++ b/README.md
@@ -227,6 +227,42 @@ The ticks are your own bookkeeping. Grading is unchanged: it still runs against
 real system state when you return to the terminal, so ticking "done" earns
 nothing on its own.
 
+### Exam version — v10 (default) or v9
+
+```bash
+sudo rhcsa-simulator --exam                    # EX200 v10 (RHEL 10), default
+sudo rhcsa-simulator --exam --exam-version 9   # EX200 v9  (RHEL 9)
+```
+
+The two exams are not the same syllabus, and the difference is not
+symmetric — v9 has an objective section v10 dropped entirely:
+
+| | v9 (RHEL 9) | v10 (RHEL 10) |
+|---|---|---|
+| **Manage containers** (podman/skopeo, run a service in a container, systemd auto-start, persistent storage) | ✅ own section | ❌ removed |
+| **Flatpak** repositories and packages | ❌ | ✅ |
+| **systemd timer units** as a scheduling mechanism | ❌ (at/cron only) | ✅ |
+| Partition tables | MBR **and** GPT | GPT only |
+| set-GID collaboration directories | ✅ | ❌ |
+| "Diagnose routine SELinux policy violations" | ✅ explicit | ❌ |
+
+Switching versions changes which tasks can be drawn, the domain weighting,
+and what Learn mode shows. Out-of-scope tasks are never generated — being
+graded against objectives your exam doesn't contain is worse than a shorter
+task pool.
+
+**Container tasks need an image.** Everything else here works offline, but
+you can't practise containers without one. Pull one before an exam:
+
+```bash
+dnf install -y podman skopeo
+podman pull registry.access.redhat.com/ubi9/ubi-minimal
+```
+
+If no image is cached, container tasks say so in the task text and the
+checks that need a running container are **skipped rather than failed**, so
+you're never marked down for a limitation of the lab.
+
 ### Terminal menu
 
 Everything works without a browser — pass `--no-gui`:
@@ -253,6 +289,7 @@ sudo rhcsa-simulator    # interactive menu
 ```bash
 rhcsa-simulator --exam               # mock exam + task panel window
 rhcsa-simulator --exam --no-gui      # mock exam, terminal only
+rhcsa-simulator --exam-version 9     # simulate EX200 v9 (adds containers)
 rhcsa-simulator --quick [lvm]        # short practice round (pick 4-20 tasks)
 rhcsa-simulator --practice lvm       # practice a specific category
 rhcsa-simulator --learn              # study mode

--- a/config/exam_objectives.py
+++ b/config/exam_objectives.py
@@ -1,8 +1,19 @@
 """
-EX200 v10 Exam Objectives - Formal domain definitions with weights and mapped categories.
+EX200 Exam Objectives — formal domain definitions with weights and mapped
+categories, per exam version.
+
+Domains 1-8 are this simulator's own grouping of the official study points;
+domain 9 (Containers) exists only in v9, where "Manage containers" is its own
+section on Red Hat's page. Weights are the simulator's estimate — Red Hat does
+not publish per-section weightings.
+
+Call get_objectives() rather than touching the version dicts directly, so a
+session always sees the syllabus it is being graded against.
 """
 
-EXAM_OBJECTIVES = {
+from config import settings
+
+OBJECTIVES_V10 = {
     1: {
         "name": "Software Management",
         "weight": 12,
@@ -120,16 +131,182 @@ EXAM_OBJECTIVES = {
 }
 
 
-def get_domain_weight(domain_number):
+# ---------------------------------------------------------------------------
+# v9 differences, taken from Red Hat's EX200 (RHEL 9) study points:
+#
+#   - No "Manage software" section and no Flatpak at all. Software install
+#     lives under "Deploy, configure, and maintain systems".
+#   - "List, create, delete partitions on MBR and GPT disks" (v10: GPT only).
+#   - "Create and configure set-GID directories for collaboration"
+#     (dropped in v10).
+#   - "Schedule tasks using at and cron" — no systemd timer units.
+#   - "Diagnose and address routine SELinux policy violations"
+#     (dropped in v10).
+#   - "Manage containers" is a section of its own — domain 9 below.
+#
+# Weight is redistributed to give containers ~10%, taken proportionally from
+# the domains that lose objectives in v9 (software, systemd/services).
+# ---------------------------------------------------------------------------
+
+OBJECTIVES_V9 = {
+    1: {
+        "name": "Software Management",
+        "weight": 10,
+        "objectives": [
+            "Install and update software packages using dnf/yum",
+            "Install and update software packages from Red Hat Network, a "
+            "remote repository, or from the local file system",
+            "Configure access to RPM repositories (BaseOS, AppStream, "
+            "third-party)",
+            "Manage RPM packages (query, verify, install)",
+            "Manage package groups and environments",
+        ],
+        "categories": ["packages", "repos"],
+    },
+    2: {
+        "name": "System Setup & Boot",
+        "weight": 11,
+        "objectives": [
+            "Set default boot target (multi-user, graphical)",
+            "Configure GRUB2 boot loader parameters",
+            "Interrupt the boot process to gain access to a system "
+            "(rd.break root password reset)",
+            "Boot into emergency and rescue targets",
+            "Modify the system bootloader",
+            "Locate and interpret system log files and journals",
+            "Preserve system journals",
+        ],
+        "categories": ["boot", "boot_recovery", "journalctl"],
+    },
+    3: {
+        "name": "Users, Groups & Permissions",
+        "weight": 12,
+        "objectives": [
+            "Create, delete, and modify local user accounts",
+            "Change passwords and adjust password aging for local accounts",
+            "Create, delete, and modify local groups and group memberships",
+            "Configure superuser access",
+            "List, set, and change standard ugo/rwx permissions",
+            "Manage default file permissions (umask)",
+            "Create and configure set-GID directories for collaboration",
+            "Diagnose and correct file permission problems",
+        ],
+        "categories": ["users_groups", "permissions", "essential_tools"],
+    },
+    4: {
+        "name": "Storage & Filesystems",
+        "weight": 18,
+        "objectives": [
+            "List, create, delete partitions on MBR and GPT disks",
+            "Create and remove physical volumes",
+            "Assign physical volumes to volume groups",
+            "Create and delete logical volumes",
+            "Extend existing logical volumes",
+            "Create, mount, unmount, and use vfat, ext4, and xfs file systems",
+            "Configure systems to mount file systems at boot by UUID or label",
+            "Add new partitions, logical volumes and swap non-destructively",
+            "Mount and unmount network file systems using NFS",
+            "Configure autofs",
+        ],
+        "categories": ["partitioning", "lvm", "filesystems", "swap",
+                       "network_storage"],
+    },
+    5: {
+        "name": "Network & DNS",
+        "weight": 10,
+        "objectives": [
+            "Configure IPv4 and IPv6 addresses",
+            "Configure hostname resolution",
+            "Configure network services to start automatically at boot",
+            "Access remote systems using SSH",
+            "Configure key-based authentication for SSH",
+            "Securely transfer files between systems",
+        ],
+        "categories": ["networking", "ssh"],
+    },
+    6: {
+        "name": "Systemd, Services & Processes",
+        "weight": 10,
+        "objectives": [
+            "Start and stop services and configure them to start at boot",
+            "Start, stop, and check the status of network services",
+            "Configure systems to boot into a specific target automatically",
+            "Identify CPU/memory intensive processes and kill processes",
+            "Adjust process scheduling",
+            "Manage tuning profiles",
+            "Configure time service clients",
+        ],
+        "categories": ["services", "processes", "time_services",
+                       "troubleshooting"],
+    },
+    7: {
+        "name": "Security - SELinux & Firewall",
+        "weight": 13,
+        "objectives": [
+            "Set enforcing and permissive modes for SELinux",
+            "List and identify SELinux file and process context",
+            "Restore default file contexts",
+            "Manage SELinux port labels",
+            "Use boolean settings to modify system SELinux settings",
+            "Diagnose and address routine SELinux policy violations",
+            "Configure firewall settings using firewall-cmd/firewalld",
+            "Restrict network access using firewall-cmd/firewall",
+        ],
+        "categories": ["selinux", "firewall"],
+    },
+    8: {
+        "name": "Automation & Scripting",
+        "weight": 6,
+        "objectives": [
+            "Schedule tasks using at and cron",
+            "Write correct cron expressions",
+            "Restrict cron access for users",
+            "Conditionally execute code (if, test, [], etc.)",
+            "Use looping constructs (for, etc.) to process input",
+            "Process script inputs ($1, $2, etc.)",
+            "Process output of shell commands within a script",
+        ],
+        "categories": ["scheduling", "scripting"],
+    },
+    9: {
+        "name": "Containers",
+        "weight": 10,
+        "objectives": [
+            "Find and retrieve container images from a remote registry",
+            "Inspect container images",
+            "Perform container management using commands such as podman and "
+            "skopeo",
+            "Perform basic container management such as running, starting, "
+            "stopping, and listing running containers",
+            "Run a service inside a container",
+            "Configure a container to start automatically as a systemd "
+            "service",
+            "Attach persistent storage to a container",
+        ],
+        "categories": ["containers"],
+    },
+}
+
+_BY_VERSION = {9: OBJECTIVES_V9, 10: OBJECTIVES_V10}
+
+
+def get_objectives(version=None):
+    """Objective table for an exam version (defaults to the active one)."""
+    if version is None:
+        version = settings.get_exam_version()
+    return _BY_VERSION.get(version, OBJECTIVES_V10)
+
+
+def get_domain_weight(domain_number, version=None):
     """Get the weight percentage for a domain."""
-    return EXAM_OBJECTIVES.get(domain_number, {}).get("weight", 0)
+    return get_objectives(version).get(domain_number, {}).get("weight", 0)
 
 
-def get_domain_categories(domain_number):
+def get_domain_categories(domain_number, version=None):
     """Get all task categories for a domain."""
-    return EXAM_OBJECTIVES.get(domain_number, {}).get("categories", [])
+    return get_objectives(version).get(domain_number, {}).get("categories", [])
 
 
-def get_domain_name(domain_number):
+def get_domain_name(domain_number, version=None):
     """Get the display name for a domain."""
-    return EXAM_OBJECTIVES.get(domain_number, {}).get("name", "Unknown")
+    return get_objectives(version).get(domain_number, {}).get("name", "Unknown")

--- a/config/settings.py
+++ b/config/settings.py
@@ -64,7 +64,76 @@ TASK_CATEGORIES = [
     "swap",
 ]
 
-# EX200 v10 Exam Domains (1-8)
+# ---------------------------------------------------------------------------
+# Exam version (EX200 v9 vs v10)
+#
+# The two exams differ by more than a rename, and not symmetrically:
+#
+#   v9 only   Manage containers (podman/skopeo) — a whole objective section
+#             MBR partition tables ("MBR and GPT disks")
+#             set-GID collaboration directories
+#             "Diagnose and address routine SELinux policy violations"
+#   v10 only  Flatpak repositories and packages
+#             systemd timer units as a scheduling mechanism
+#             (v10 also drops MBR: "List, create, and delete partitions on
+#             GPT disks")
+#
+# Everything else is identical or a wording change (superuser -> privileged
+# access, Red Hat Network -> Red Hat CDN). Rather than fork the task set, one
+# catalogue carries both and the out-of-scope pieces are filtered per version.
+# ---------------------------------------------------------------------------
+
+SUPPORTED_EXAM_VERSIONS = (9, 10)
+DEFAULT_EXAM_VERSION = 10
+
+_active_exam_version = DEFAULT_EXAM_VERSION
+
+
+def get_exam_version():
+    """The EX200 version currently being simulated (9 or 10)."""
+    return _active_exam_version
+
+
+def set_exam_version(version):
+    """Switch the simulated exam version. Raises ValueError on anything else —
+    silently falling back would mean grading against the wrong syllabus."""
+    version = int(version)
+    if version not in SUPPORTED_EXAM_VERSIONS:
+        raise ValueError(
+            "unsupported exam version %r (expected one of %s)"
+            % (version, ', '.join(str(v) for v in SUPPORTED_EXAM_VERSIONS)))
+    global _active_exam_version
+    _active_exam_version = version
+    return _active_exam_version
+
+
+# Categories that are out of scope for a given exam version. Task classes can
+# additionally opt out individually via `exam_versions` (see tasks/base.py) —
+# used where a whole category is in scope but one task inside it is not, as
+# with MBR partitioning.
+VERSION_EXCLUDED_CATEGORIES = {
+    9: {
+        "flatpak",         # no Flatpak objective exists in EX200 v9
+        "systemd_timers",  # v9 scheduling objective is "at and cron" only
+    },
+    10: {
+        "containers",      # v10 dropped the Manage containers section
+    },
+}
+
+
+def excluded_categories(version=None):
+    """Categories out of scope for this exam version."""
+    version = version if version is not None else get_exam_version()
+    return VERSION_EXCLUDED_CATEGORIES.get(version, set())
+
+
+def category_in_scope(category, version=None):
+    return category not in excluded_categories(version)
+
+
+# Exam Domains. 1-8 apply to both versions; 9 exists only in v9, where
+# "Manage containers" is its own objective section.
 EXAM_DOMAINS = {
     1: "Software Management",
     2: "System Setup & Boot",
@@ -74,9 +143,20 @@ EXAM_DOMAINS = {
     6: "Systemd, Services & Processes",
     7: "Security - SELinux & Firewall",
     8: "Automation & Scripting",
+    9: "Containers",
 }
 
-# Map categories to domains
+
+def exam_domains(version=None):
+    """Domain number -> name for this exam version."""
+    version = version if version is not None else get_exam_version()
+    if version == 9:
+        return dict(EXAM_DOMAINS)
+    return {n: name for n, name in EXAM_DOMAINS.items() if n != 9}
+
+
+# Map categories to domains (the union across versions; filtering is done by
+# VERSION_EXCLUDED_CATEGORIES, so a category keeps its domain either way).
 CATEGORY_TO_DOMAIN = {
     "packages": 1, "repos": 1, "flatpak": 1,
     "boot": 2, "boot_recovery": 2, "journalctl": 2,
@@ -86,6 +166,7 @@ CATEGORY_TO_DOMAIN = {
     "services": 6, "systemd_timers": 6, "processes": 6, "time_services": 6, "troubleshooting": 6,
     "selinux": 7, "firewall": 7,
     "scheduling": 8, "scripting": 8,
+    "containers": 9,
 }
 
 # Practice mode configuration
@@ -146,14 +227,15 @@ SAFE_VALIDATION_COMMANDS = {
     # Scheduling
     'crontab', 'atq', 'at',
 
-    # Containers
-    'podman',
-
     # Package management (read-only)
     'rpm', 'dnf', 'yum',
 
     # Flatpak (read-only)
     'flatpak',
+
+    # Containers — read-only subcommands only, enforced in
+    # validators/safe_executor.py (_validate_specific_commands). v9 only.
+    'podman', 'skopeo',
 
     # Time services (read-only)
     'timedatectl', 'chronyc',

--- a/core/content/__init__.py
+++ b/core/content/__init__.py
@@ -68,7 +68,8 @@ class ContentRegistry:
     def get_categories_for_domain(cls, domain_number):
         """Get category keys belonging to a specific domain."""
         cls.initialize()
-        from config.exam_objectives import EXAM_OBJECTIVES
+        from config.exam_objectives import get_objectives
+        EXAM_OBJECTIVES = get_objectives()
 
         domain = EXAM_OBJECTIVES.get(domain_number, {})
         return [c for c in domain.get("categories", []) if c in cls._content]

--- a/core/exam.py
+++ b/core/exam.py
@@ -335,6 +335,7 @@ class ExamSession:
         fmt.print_header("RHCSA MOCK EXAM", char='=')
 
         print(fmt.bold("Exam Information:"))
+        print(f"  Exam: EX200 v{settings.get_exam_version()}")
         print(f"  Tasks: {self.task_count}")
         print(f"  Duration: {self.duration_minutes} minutes" if self.timer_enabled else "  Duration: No time limit")
         print(f"  Pass threshold: {settings.EXAM_PASS_THRESHOLD * 100:.0f}%")

--- a/core/learn.py
+++ b/core/learn.py
@@ -6,7 +6,7 @@ UI dispatcher that loads content from core.content modules.
 import logging
 from utils import formatters as fmt
 from core.content import ContentRegistry
-from config.exam_objectives import EXAM_OBJECTIVES
+from config.exam_objectives import get_objectives
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,12 @@ class LearnMode:
 
         while True:
             fmt.clear_screen()
-            fmt.print_header("LEARN MODE - EX200 v10 Exam Domains")
+            # Learn mode must show the syllabus the candidate will be graded
+            # against — v9 has a Containers domain that v10 does not.
+            from config import settings
+            EXAM_OBJECTIVES = get_objectives()
+            fmt.print_header(
+                f"LEARN MODE - EX200 v{settings.get_exam_version()} Exam Domains")
             print()
 
             for domain_num in sorted(EXAM_OBJECTIVES.keys()):
@@ -107,7 +112,7 @@ class LearnMode:
 
     def _show_domain_topics(self, domain_num, weak_cats, due_cats):
         """Show topics within a domain."""
-        domain = EXAM_OBJECTIVES[domain_num]
+        domain = get_objectives()[domain_num]
         categories = ContentRegistry.get_categories_for_domain(domain_num)
 
         if not categories:

--- a/core/preflight.py
+++ b/core/preflight.py
@@ -31,6 +31,24 @@ REQUIRED_PACKAGES = {
     'tuned': 'tuning profile (tuned-adm) tasks',
 }
 
+# Packages only some exam versions need. v10 dropped the containers section
+# entirely, so warning a v10 candidate about podman would be noise.
+VERSION_PACKAGES = {
+    9: {
+        'podman': 'container tasks (v9 "Manage containers" objectives)',
+        'skopeo': 'remote container image inspection (v9)',
+    },
+}
+
+
+def required_packages(version=None):
+    """REQUIRED_PACKAGES plus anything this exam version adds."""
+    from config import settings
+    version = version if version is not None else settings.get_exam_version()
+    packages = dict(REQUIRED_PACKAGES)
+    packages.update(VERSION_PACKAGES.get(version, {}))
+    return packages
+
 
 def _rpm_installed(pkg):
     """True/False if rpm can answer, None if rpm itself isn't available
@@ -45,7 +63,7 @@ def _rpm_installed(pkg):
 def check_dependencies(packages=None):
     """Return {pkg: True|False|None} for each of REQUIRED_PACKAGES (or the
     given package list). None means installation status is unknown."""
-    packages = packages if packages is not None else REQUIRED_PACKAGES
+    packages = packages if packages is not None else required_packages()
     return {pkg: _rpm_installed(pkg) for pkg in packages}
 
 
@@ -143,7 +161,7 @@ def warn_missing(missing=None):
         f"\n! {len(missing)} exam-relevant package(s) not installed: {', '.join(missing)}"
     ))
     for pkg in missing:
-        print(fmt.dim(f"    {pkg} — {REQUIRED_PACKAGES.get(pkg, '')}"))
+        print(fmt.dim(f"    {pkg} — {required_packages().get(pkg, '')}"))
     print(fmt.warning(
         "  Tasks that rely on them may fail to set up their scenario "
         "(e.g. an httpd task where httpd never runs).\n"

--- a/rhcsa_simulator.py
+++ b/rhcsa_simulator.py
@@ -31,6 +31,7 @@ Quick Start Examples:
   %(prog)s --quick lvm          5 LVM tasks
   %(prog)s --exam               Full mock exam (task panel in a window)
   %(prog)s --exam --no-gui      Same, terminal only
+  %(prog)s --exam-version 9     Simulate EX200 v9 (RHEL 9): adds containers
   %(prog)s --learn              Domain-based study mode
   %(prog)s --practice lvm       Practice LVM category
   %(prog)s --adaptive           SM-2 driven weak-area practice
@@ -75,6 +76,15 @@ Quick Start Examples:
                              '(default 0.0.0.0, so a headless exam VM can be '
                              'read from your laptop; use 127.0.0.1 to keep it '
                              'local)')
+    # Which EX200 to simulate. v10 is the default because it is the current
+    # exam; v9 candidates get containers and MBR, and lose Flatpak and
+    # systemd timers.
+    parser.add_argument('--exam-version', type=int, metavar='N',
+                        choices=settings.SUPPORTED_EXAM_VERSIONS,
+                        default=settings.DEFAULT_EXAM_VERSION,
+                        help=f'EX200 version to simulate: '
+                             f'{" or ".join(str(v) for v in settings.SUPPORTED_EXAM_VERSIONS)} '
+                             f'(default {settings.DEFAULT_EXAM_VERSION})')
     parser.add_argument('--version', action='version',
                         version=f'%(prog)s {settings.VERSION}')
 
@@ -231,6 +241,11 @@ def main():
     logger = logging.getLogger(__name__)
 
     args = parse_args()
+
+    # Set the exam version before anything reads the task registry or the
+    # objective tables — task filtering, domain weighting and Learn mode all
+    # key off it.
+    settings.set_exam_version(args.exam_version)
 
     # Handle --list-categories without root
     if args.list_categories:

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -40,6 +40,13 @@ class BaseTask(ABC):
     # fabricated log evidence, or descriptive-only.
     required_packages = []
 
+    # Exam versions this task is in scope for. None = both. Set it when a
+    # category is in scope for both versions but one task inside it is not —
+    # MBR partitioning is v9-only, because v10's objective reads "List,
+    # create, and delete partitions on GPT disks". Whole categories are
+    # filtered by settings.VERSION_EXCLUDED_CATEGORIES instead.
+    exam_versions = None
+
     # True for tasks performed ON the linked second lab machine (over SSH).
     # They are only offered when a lab machine is linked (Setup → Link second
     # lab machine); the registry filters them out otherwise.

--- a/tasks/containers.py
+++ b/tasks/containers.py
@@ -1,0 +1,836 @@
+"""
+Container management tasks — EX200 v9 only.
+
+"Manage containers" is its own objective section on the RHEL 9 exam and was
+dropped entirely from RHEL 10, so every task here is filtered out when the
+simulator runs in v10 mode (settings.VERSION_EXCLUDED_CATEGORIES).
+
+Objectives covered:
+  - Find and retrieve container images from a remote registry
+  - Inspect container images
+  - Perform container management using commands such as podman and skopeo
+  - Perform basic container management (run, start, stop, list)
+  - Run a service inside a container
+  - Configure a container to start automatically as a systemd service
+  - Attach persistent storage to a container
+
+TWO THINGS MAKE THIS CATEGORY DIFFERENT
+---------------------------------------
+1. It needs an image. Everything else in this simulator works offline, but
+   you cannot practise containers without one. Rather than fail with a
+   confusing "no such image", tasks check what is present up front:
+   image_available() picks an image the box already has, and when nothing is
+   cached the task says so in its own description and the affected checks are
+   skipped rather than failed. A candidate who did the work correctly must
+   never lose points because the lab had no registry access.
+
+2. Rootless is the exam-realistic default. Containers on the exam are run as
+   an ordinary user, which changes where the systemd unit lives
+   (~/.config/systemd/user), requires lingering for boot start, and needs :Z
+   on bind mounts under SELinux. Tasks say which user to work as, and
+   validation looks in that user's context.
+
+All validation is read-only: podman/skopeo are restricted to inspection
+subcommands by validators/safe_executor.py, so a check can never destroy the
+container it is grading.
+"""
+
+import logging
+import random
+
+from tasks.base import BaseTask
+from tasks.registry import TaskRegistry
+from core.validator import ValidationCheck, ValidationResult
+from validators.safe_executor import execute_safe
+
+logger = logging.getLogger(__name__)
+
+
+# Images small enough to be reasonable on a lab box, most-preferred first.
+# ubi-minimal is ~40MB and ships everything these tasks need.
+CANDIDATE_IMAGES = [
+    'registry.access.redhat.com/ubi9/ubi-minimal',
+    'registry.access.redhat.com/ubi9/ubi',
+    'registry.access.redhat.com/ubi8/ubi-minimal',
+    'quay.io/podman/hello',
+    'docker.io/library/alpine',
+]
+
+# A registry the exam-style "pull an image" task can name. The real exam
+# provides the registry in the question, so we do too.
+DEFAULT_REGISTRY = 'registry.access.redhat.com'
+
+
+def podman_available():
+    """True if podman is installed and usable."""
+    result = execute_safe(['podman', 'version', '--format', '{{.Client.Version}}'])
+    return bool(result.success and result.stdout.strip())
+
+
+def local_images():
+    """Image references already present on the box (no network needed)."""
+    result = execute_safe(['podman', 'images', '--format', '{{.Repository}}:{{.Tag}}'])
+    if not result.success:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def image_available():
+    """An image the candidate can actually use, or None if the box has none.
+
+    Prefers our candidate list, then falls back to whatever is cached — a box
+    that pulled something else is still a box you can practise on.
+    """
+    have = local_images()
+    if not have:
+        return None
+    for wanted in CANDIDATE_IMAGES:
+        for ref in have:
+            if ref.split(':')[0] == wanted:
+                return ref
+    for ref in have:
+        if '<none>' not in ref:
+            return ref
+    return None
+
+
+def _exam_user():
+    """A non-root user to run rootless containers as.
+
+    Container tasks are the one place the exam explicitly expects rootless
+    operation, so the task creates its own user rather than borrowing one the
+    candidate may also be graded on elsewhere.
+    """
+    return 'container'
+
+
+def _user_exists(username):
+    return execute_safe(['id', username]).success
+
+
+class _ContainerTask(BaseTask):
+    """Shared setup for container tasks: podman/image availability, and the
+    skip-vs-fail decision that follows from it."""
+
+    exam_versions = (9,)          # dropped from EX200 v10
+    required_packages = ['podman']
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.image = None
+        self.tags = ['v9-only', 'containers']
+
+    def _probe_environment(self):
+        """Cache what the lab can actually do. Never raises."""
+        try:
+            self.has_podman = podman_available()
+            self.image = image_available() if self.has_podman else None
+        except Exception as e:                      # pragma: no cover
+            logger.debug("container probe failed: %s", e)
+            self.has_podman = False
+            self.image = None
+
+    def _lab_note(self):
+        """Text appended to a description when the lab is short of something,
+        so the candidate knows before spending exam time on it."""
+        if not getattr(self, 'has_podman', False):
+            return ("\n\nNOTE: podman is not installed on this system, so this "
+                    "task cannot be completed here. Install it with "
+                    "'dnf install -y podman' and regenerate the task.")
+        if not self.image:
+            return ("\n\nNOTE: no container image is cached locally and this "
+                    "lab may have no registry access. Checks that need a "
+                    "running container will be SKIPPED rather than failed.")
+        return ""
+
+    def _skip_or_fail(self, checks, name, points, message):
+        """Record a check the lab could not observe.
+
+        Skips are excluded from the score denominator, so a candidate is never
+        penalised for a limitation of the box.
+        """
+        if not self.image or not getattr(self, 'has_podman', False):
+            checks.append(ValidationCheck(
+                name=name, passed=True, points=0, max_points=0,
+                message=f"SKIPPED (no usable container image): {message}"))
+            return True
+        return False
+
+
+@TaskRegistry.register("containers")
+class PullContainerImageTask(_ContainerTask):
+    """Find and retrieve a container image from a remote registry."""
+
+    def __init__(self):
+        super().__init__(id="containers_pull_001", category="containers",
+                         difficulty="easy", points=8)
+        self.requires_persistence = False
+        self.exam_tips = [
+            "podman search registry.access.redhat.com/ubi finds images",
+            "podman pull <registry>/<namespace>/<image>:<tag>",
+            "podman images lists what is already local — check before pulling",
+            "skopeo inspect docker://<image> reads a remote image without pulling it",
+        ]
+
+    def generate(self, **params):
+        self._probe_environment()
+        self.image_name = params.get('image_name', 'ubi9/ubi-minimal')
+        self.description = (
+            f"Retrieve a container image from a remote registry:\n"
+            f"  - Registry: {DEFAULT_REGISTRY}\n"
+            f"  - Image: {self.image_name}\n"
+            f"  - Pull the image so it is available locally\n"
+            f"  - Verify it appears in the local image list"
+        ) + self._lab_note()
+        self.hints = [
+            f"podman pull {DEFAULT_REGISTRY}/{self.image_name}",
+            "podman images  — confirm it is listed",
+            "podman search can find images if you do not know the exact name",
+        ]
+        return self
+
+    def validate(self):
+        checks = []
+        total = 0
+
+        if not podman_available():
+            checks.append(ValidationCheck(
+                name="podman_installed", passed=False, points=0, max_points=8,
+                message="podman is not installed"))
+            return ValidationResult(self.id, False, 0, self.points, checks)
+
+        images = local_images()
+        wanted = self.image_name.split(':')[0]
+        matched = [ref for ref in images if wanted in ref]
+
+        if matched:
+            checks.append(ValidationCheck(
+                name="image_present", passed=True, points=8,
+                message=f"Image present locally: {matched[0]}"))
+            total += 8
+        elif images:
+            # They pulled something, just not the named image. Partial credit
+            # is wrong here — the objective is retrieving a *specific* image.
+            checks.append(ValidationCheck(
+                name="image_present", passed=False, points=0, max_points=8,
+                message=(f"'{self.image_name}' not found locally. Images "
+                         f"present: {', '.join(images[:3])}")))
+        else:
+            checks.append(ValidationCheck(
+                name="image_present", passed=False, points=0, max_points=8,
+                message="No container images are present locally"))
+
+        return ValidationResult(self.id, total >= 8, total, self.points, checks)
+
+
+@TaskRegistry.register("containers")
+class InspectContainerImageTask(_ContainerTask):
+    """Inspect a container image and record a specific field."""
+
+    def __init__(self):
+        super().__init__(id="containers_inspect_002", category="containers",
+                         difficulty="medium", points=10)
+        self.requires_persistence = True
+        self.exam_tips = [
+            "podman inspect <image> returns JSON — use --format to pull one field",
+            "podman image inspect --format '{{.Config.Cmd}}' <image>",
+            "skopeo inspect docker://<image> works without pulling the image",
+        ]
+
+    def generate(self, **params):
+        self._probe_environment()
+        self.report_path = params.get('report_path', '/root/image-report.txt')
+        self.description = (
+            f"Inspect a container image and record what you find:\n"
+            f"  - Inspect a container image available on this system\n"
+            f"  - Write the image's Id (or Digest) to {self.report_path}\n"
+            f"  - The file must contain only that value"
+        ) + self._lab_note()
+        self.hints = [
+            "podman images  — pick an image that exists locally",
+            "podman inspect --format '{{.Id}}' <image>",
+            f"podman inspect --format '{{{{.Id}}}}' <image> > {self.report_path}",
+        ]
+        return self
+
+    def validate(self):
+        checks = []
+        total = 0
+        self._probe_environment()
+
+        result = execute_safe(['test', '-f', self.report_path])
+        if not result.success:
+            checks.append(ValidationCheck(
+                name="report_exists", passed=False, points=0, max_points=4,
+                message=f"{self.report_path} does not exist"))
+        else:
+            checks.append(ValidationCheck(
+                name="report_exists", passed=True, points=4,
+                message=f"{self.report_path} exists"))
+            total += 4
+
+        if self._skip_or_fail(checks, "report_matches_image", 6,
+                              "cannot confirm the recorded id matches an image"):
+            passed = total >= 4
+            return ValidationResult(self.id, passed, total, self.points, checks)
+
+        content = execute_safe(['cat', self.report_path])
+        recorded = (content.stdout or '').strip() if content.success else ''
+        ids = execute_safe(['podman', 'images', '--format', '{{.ID}}'])
+        digests = execute_safe(['podman', 'images', '--format', '{{.Digest}}'])
+        known = set()
+        for r in (ids, digests):
+            if r.success:
+                known.update(x.strip() for x in r.stdout.splitlines() if x.strip())
+
+        # podman abbreviates IDs in some output forms, so match on prefix.
+        hit = recorded and any(
+            k.startswith(recorded) or recorded.startswith(k) or recorded in k
+            for k in known)
+        if hit:
+            checks.append(ValidationCheck(
+                name="report_matches_image", passed=True, points=6,
+                message="Recorded value matches a local image"))
+            total += 6
+        else:
+            checks.append(ValidationCheck(
+                name="report_matches_image", passed=False, points=0, max_points=6,
+                message=("Recorded value does not match any local image id "
+                         "or digest")))
+
+        return ValidationResult(self.id, total >= 7, total, self.points, checks)
+
+
+@TaskRegistry.register("containers")
+class RunNamedContainerTask(_ContainerTask):
+    """Basic container management: run a named container and keep it running."""
+
+    def __init__(self):
+        super().__init__(id="containers_run_003", category="containers",
+                         difficulty="medium", points=12)
+        self.requires_persistence = False
+        self.exam_tips = [
+            "podman run -d --name <name> <image> keeps it in the background",
+            "A container exits immediately unless its command keeps running",
+            "podman ps shows running; podman ps -a shows stopped too",
+        ]
+
+    def generate(self, **params):
+        self._probe_environment()
+        self.container_name = params.get('container_name',
+                                         random.choice(['webapp', 'appsrv',
+                                                        'testsrv', 'mysvc']))
+        self.description = (
+            f"Run a container and leave it running:\n"
+            f"  - Name: {self.container_name}\n"
+            f"  - Use a container image available on this system\n"
+            f"  - The container must be running (not exited) when checked\n"
+            f"  - Run it detached"
+        ) + self._lab_note()
+        self.hints = [
+            f"podman run -d --name {self.container_name} <image> sleep infinity",
+            "podman ps  — confirm STATUS shows Up",
+            "A plain 'podman run <image>' exits as soon as its command finishes",
+        ]
+        return self
+
+    def validate(self):
+        checks = []
+        total = 0
+        self._probe_environment()
+
+        if self._skip_or_fail(checks, "container_running", 12,
+                              f"cannot check for container '{self.container_name}'"):
+            return ValidationResult(self.id, True, 0, 0, checks)
+
+        result = execute_safe(['podman', 'ps', '-a', '--format',
+                               '{{.Names}}|{{.State}}|{{.Image}}'])
+        found = None
+        for line in (result.stdout or '').splitlines():
+            parts = line.split('|')
+            if parts and parts[0].strip() == self.container_name:
+                found = parts
+                break
+
+        if not found:
+            checks.append(ValidationCheck(
+                name="container_exists", passed=False, points=0, max_points=6,
+                message=f"No container named '{self.container_name}'"))
+            checks.append(ValidationCheck(
+                name="container_running", passed=False, points=0, max_points=6,
+                message="Container does not exist, so it is not running"))
+            return ValidationResult(self.id, False, 0, self.points, checks)
+
+        checks.append(ValidationCheck(
+            name="container_exists", passed=True, points=6,
+            message=f"Container '{self.container_name}' exists "
+                    f"(image {found[2].strip() if len(found) > 2 else '?'})"))
+        total += 6
+
+        state = found[1].strip().lower() if len(found) > 1 else ''
+        if state == 'running':
+            checks.append(ValidationCheck(
+                name="container_running", passed=True, points=6,
+                message="Container is running"))
+            total += 6
+        else:
+            checks.append(ValidationCheck(
+                name="container_running", passed=False, points=0, max_points=6,
+                message=(f"Container state is '{state}', not running. A "
+                         f"container exits when its command finishes — give "
+                         f"it a long-running one.")))
+
+        return ValidationResult(self.id, total >= 12, total, self.points, checks)
+
+
+@TaskRegistry.register("containers")
+class ContainerPersistentStorageTask(_ContainerTask):
+    """Attach persistent storage to a container."""
+
+    def __init__(self):
+        super().__init__(id="containers_storage_004", category="containers",
+                         difficulty="exam", points=15)
+        self.requires_persistence = True
+        self.exam_tips = [
+            "podman run -v /host/path:/container/path:Z ...",
+            "The :Z suffix relabels the host directory for SELinux — without "
+            "it the container gets permission denied on an enforcing system",
+            "podman inspect --format '{{.Mounts}}' <container> shows the mount",
+            "A named volume (podman volume create) also satisfies persistence",
+        ]
+
+    def generate(self, **params):
+        self._probe_environment()
+        self.container_name = params.get('container_name', 'datasvc')
+        self.host_dir = params.get('host_dir', '/opt/container-data')
+        self.mount_point = params.get('mount_point', '/data')
+        self.description = (
+            f"Attach persistent storage to a container:\n"
+            f"  - Host directory: {self.host_dir}\n"
+            f"  - Mounted inside the container at: {self.mount_point}\n"
+            f"  - Container name: {self.container_name}\n"
+            f"  - Data written in the container must survive the container "
+            f"being removed and recreated\n"
+            f"  - SELinux must remain enforcing"
+        ) + self._lab_note()
+        self.hints = [
+            f"mkdir -p {self.host_dir}",
+            f"podman run -d --name {self.container_name} "
+            f"-v {self.host_dir}:{self.mount_point}:Z <image> sleep infinity",
+            "The :Z relabels the host dir — check with ls -Zd",
+            "Verify: podman inspect --format '{{.Mounts}}' <container>",
+        ]
+        return self
+
+    def validate(self):
+        checks = []
+        total = 0
+        self._probe_environment()
+
+        # Host directory — checkable regardless of container state.
+        if execute_safe(['test', '-d', self.host_dir]).success:
+            checks.append(ValidationCheck(
+                name="host_dir", passed=True, points=5,
+                message=f"{self.host_dir} exists"))
+            total += 5
+        else:
+            checks.append(ValidationCheck(
+                name="host_dir", passed=False, points=0, max_points=5,
+                message=f"{self.host_dir} does not exist"))
+
+        if self._skip_or_fail(checks, "volume_mounted", 10,
+                              "cannot inspect the container's mounts"):
+            return ValidationResult(self.id, total >= 5, total, 5, checks)
+
+        result = execute_safe(['podman', 'inspect', '--format',
+                               '{{range .Mounts}}{{.Source}}:{{.Destination}} {{end}}',
+                               self.container_name])
+        mounts = (result.stdout or '').strip() if result.success else ''
+        expected = f"{self.host_dir}:{self.mount_point}"
+
+        if expected in mounts:
+            checks.append(ValidationCheck(
+                name="volume_mounted", passed=True, points=7,
+                message=f"{self.host_dir} is mounted at {self.mount_point}"))
+            total += 7
+        elif mounts:
+            checks.append(ValidationCheck(
+                name="volume_mounted", passed=False, points=0, max_points=7,
+                message=f"Expected {expected}, container has: {mounts}"))
+        else:
+            checks.append(ValidationCheck(
+                name="volume_mounted", passed=False, points=0, max_points=7,
+                message=(f"Container '{self.container_name}' has no mounts "
+                         f"(or does not exist)")))
+
+        # SELinux label — the part candidates most often miss.
+        ctx = execute_safe(['ls', '-Zd', self.host_dir])
+        if ctx.success and 'container_file_t' in (ctx.stdout or ''):
+            checks.append(ValidationCheck(
+                name="selinux_label", passed=True, points=3,
+                message="Host directory carries container_file_t (:Z was used)"))
+            total += 3
+        elif execute_safe(['getenforce']).stdout.strip().lower() != 'enforcing':
+            checks.append(ValidationCheck(
+                name="selinux_label", passed=True, points=0, max_points=0,
+                message="SKIPPED (SELinux not enforcing): container_file_t label"))
+        else:
+            checks.append(ValidationCheck(
+                name="selinux_label", passed=False, points=0, max_points=3,
+                message=("Host directory is not labelled container_file_t — "
+                         "mount with :Z so the container can access it")))
+
+        return ValidationResult(self.id, total >= 11, total, self.points, checks)
+
+
+@TaskRegistry.register("containers")
+class ContainerSystemdServiceTask(_ContainerTask):
+    """Configure a container to start automatically as a systemd service."""
+
+    def __init__(self):
+        super().__init__(id="containers_systemd_005", category="containers",
+                         difficulty="exam", points=18)
+        self.requires_persistence = True
+        self.exam_tips = [
+            "Rootless: units live in ~/.config/systemd/user/",
+            "podman generate systemd --name <c> --files --new  (RHEL 9)",
+            "Quadlet (.container files) is the newer way and also acceptable",
+            "systemctl --user enable --now <unit>",
+            "loginctl enable-linger <user> — without it the user's services "
+            "stop at logout and never start at boot",
+            "Reload after writing a unit: systemctl --user daemon-reload",
+        ]
+
+    def generate(self, **params):
+        self._probe_environment()
+        self.username = params.get('username', _exam_user())
+        self.container_name = params.get('container_name', 'websvc')
+        self.unit_name = f"container-{self.container_name}.service"
+        self.description = (
+            f"Configure a container to start automatically at boot:\n"
+            f"  - Run as the user '{self.username}' (rootless), not root\n"
+            f"  - Container name: {self.container_name}\n"
+            f"  - Create a systemd user service that starts it\n"
+            f"  - The service must be enabled so it starts at boot, without "
+            f"that user having to log in\n"
+            f"  - Create the user if it does not exist"
+        ) + self._lab_note()
+        self.hints = [
+            f"useradd {self.username}",
+            f"loginctl enable-linger {self.username}",
+            f"su - {self.username}",
+            f"podman run -d --name {self.container_name} <image> sleep infinity",
+            f"mkdir -p ~/.config/systemd/user && cd ~/.config/systemd/user",
+            f"podman generate systemd --name {self.container_name} --files --new",
+            f"systemctl --user daemon-reload && systemctl --user enable --now "
+            f"{self.unit_name}",
+        ]
+        return self
+
+    def validate(self):
+        checks = []
+        total = 0
+        self._probe_environment()
+
+        # 1. User exists (5)
+        if _user_exists(self.username):
+            checks.append(ValidationCheck(
+                name="user_exists", passed=True, points=5,
+                message=f"User '{self.username}' exists"))
+            total += 5
+        else:
+            checks.append(ValidationCheck(
+                name="user_exists", passed=False, points=0, max_points=5,
+                message=f"User '{self.username}' does not exist"))
+            # Everything else is scoped to that user, so stop here.
+            checks.append(ValidationCheck(
+                name="linger_enabled", passed=False, points=0, max_points=5,
+                message="Cannot check lingering without the user"))
+            checks.append(ValidationCheck(
+                name="unit_enabled", passed=False, points=0, max_points=8,
+                message="Cannot check the user service without the user"))
+            return ValidationResult(self.id, False, total, self.points, checks)
+
+        # 2. Lingering (5) — the bit that makes "at boot" actually true.
+        linger = execute_safe(['ls', f'/var/lib/systemd/linger/{self.username}'])
+        if linger.success:
+            checks.append(ValidationCheck(
+                name="linger_enabled", passed=True, points=5,
+                message=f"Lingering is enabled for '{self.username}'"))
+            total += 5
+        else:
+            checks.append(ValidationCheck(
+                name="linger_enabled", passed=False, points=0, max_points=5,
+                message=(f"Lingering is not enabled — the container will not "
+                         f"start until '{self.username}' logs in. "
+                         f"loginctl enable-linger {self.username}")))
+
+        # 3. An enabled user unit referencing the container (8).
+        home = f"/home/{self.username}"
+        unit_dir = f"{home}/.config/systemd/user"
+        listing = execute_safe(['ls', unit_dir])
+        unit_files = [f.strip() for f in (listing.stdout or '').splitlines()
+                      if f.strip().endswith(('.service', '.container'))]
+
+        if not unit_files:
+            checks.append(ValidationCheck(
+                name="unit_enabled", passed=False, points=0, max_points=8,
+                message=f"No systemd user unit found in {unit_dir}"))
+            return ValidationResult(self.id, False, total, self.points, checks)
+
+        # Does any of them mention the container?
+        referencing = []
+        for unit in unit_files:
+            body = execute_safe(['cat', f'{unit_dir}/{unit}'])
+            if body.success and self.container_name in (body.stdout or ''):
+                referencing.append(unit)
+
+        wants = execute_safe(['ls', f'{unit_dir}/default.target.wants'])
+        enabled_names = [f.strip() for f in (wants.stdout or '').splitlines()
+                         if f.strip()]
+
+        if referencing and any(u in enabled_names for u in referencing):
+            checks.append(ValidationCheck(
+                name="unit_enabled", passed=True, points=8,
+                message=f"User unit {referencing[0]} is enabled for boot"))
+            total += 8
+        elif referencing:
+            checks.append(ValidationCheck(
+                name="unit_enabled", passed=False, points=0, max_points=8,
+                message=(f"Unit {referencing[0]} exists but is not enabled — "
+                         f"systemctl --user enable {referencing[0]}")))
+        else:
+            checks.append(ValidationCheck(
+                name="unit_enabled", passed=False, points=0, max_points=8,
+                message=(f"Found unit(s) {', '.join(unit_files)} but none "
+                         f"reference container '{self.container_name}'")))
+
+        return ValidationResult(self.id, total >= 13, total, self.points, checks)
+
+
+@TaskRegistry.register("containers")
+class ContainerServicePortTask(_ContainerTask):
+    """Run a service inside a container and publish it on a host port."""
+
+    def __init__(self):
+        super().__init__(id="containers_service_006", category="containers",
+                         difficulty="exam", points=15)
+        self.requires_persistence = False
+        self.exam_tips = [
+            "podman run -d -p <host>:<container> ... publishes a port",
+            "Rootless containers cannot bind host ports below 1024",
+            "podman port <container> shows the published mapping",
+            "ss -tlnp confirms something is actually listening on the host",
+        ]
+
+    def generate(self, **params):
+        self._probe_environment()
+        self.container_name = params.get('container_name', 'httpsvc')
+        self.host_port = params.get('host_port', random.choice([8080, 8088, 8090]))
+        self.container_port = params.get('container_port', 80)
+        self.description = (
+            f"Run a service inside a container and publish it:\n"
+            f"  - Container name: {self.container_name}\n"
+            f"  - The service inside the container listens on port "
+            f"{self.container_port}\n"
+            f"  - Publish it on host port {self.host_port}\n"
+            f"  - The container must be running when checked"
+        ) + self._lab_note()
+        self.hints = [
+            f"podman run -d --name {self.container_name} "
+            f"-p {self.host_port}:{self.container_port} <image>",
+            f"podman port {self.container_name}",
+            f"ss -tlnp | grep {self.host_port}",
+            "Rootless containers cannot publish ports below 1024",
+        ]
+        return self
+
+    def validate(self):
+        checks = []
+        total = 0
+        self._probe_environment()
+
+        if self._skip_or_fail(checks, "port_published", 15,
+                              f"cannot check container '{self.container_name}'"):
+            return ValidationResult(self.id, True, 0, 0, checks)
+
+        result = execute_safe(['podman', 'ps', '--format',
+                               '{{.Names}}|{{.Ports}}'])
+        line = None
+        for row in (result.stdout or '').splitlines():
+            if row.split('|')[0].strip() == self.container_name:
+                line = row
+                break
+
+        if not line:
+            checks.append(ValidationCheck(
+                name="container_running", passed=False, points=0, max_points=7,
+                message=f"No running container named '{self.container_name}'"))
+            checks.append(ValidationCheck(
+                name="port_published", passed=False, points=0, max_points=8,
+                message="Container is not running, so no port is published"))
+            return ValidationResult(self.id, False, 0, self.points, checks)
+
+        checks.append(ValidationCheck(
+            name="container_running", passed=True, points=7,
+            message=f"Container '{self.container_name}' is running"))
+        total += 7
+
+        ports = line.split('|', 1)[1] if '|' in line else ''
+        if f":{self.host_port}" in ports and str(self.container_port) in ports:
+            checks.append(ValidationCheck(
+                name="port_published", passed=True, points=8,
+                message=f"Port {self.host_port} -> {self.container_port} published"))
+            total += 8
+        else:
+            checks.append(ValidationCheck(
+                name="port_published", passed=False, points=0, max_points=8,
+                message=(f"Expected {self.host_port}->{self.container_port}, "
+                         f"container publishes: {ports.strip() or 'nothing'}")))
+
+        return ValidationResult(self.id, total >= 15, total, self.points, checks)
+
+
+@TaskRegistry.register("containers")
+class SkopeoInspectRemoteTask(_ContainerTask):
+    """Use skopeo to inspect a remote image without pulling it."""
+
+    def __init__(self):
+        super().__init__(id="containers_skopeo_007", category="containers",
+                         difficulty="medium", points=10)
+        self.requires_persistence = True
+        self.required_packages = ['podman', 'skopeo']
+        self.exam_tips = [
+            "skopeo inspect docker://<registry>/<image> reads remote metadata",
+            "No pull required, so it is fast and uses little disk",
+            "skopeo list-tags docker://<image> enumerates available tags",
+            "podman and skopeo are both named in the objective — know both",
+        ]
+
+    def generate(self, **params):
+        self._probe_environment()
+        self.report_path = params.get('report_path', '/root/skopeo-tags.txt')
+        self.image_ref = params.get('image_ref',
+                                    f'{DEFAULT_REGISTRY}/ubi9/ubi-minimal')
+        self.description = (
+            f"Inspect a container image without downloading it:\n"
+            f"  - Image: {self.image_ref}\n"
+            f"  - Use skopeo (not podman pull)\n"
+            f"  - Save the inspection output to {self.report_path}"
+        ) + self._lab_note()
+        self.hints = [
+            f"skopeo inspect docker://{self.image_ref}",
+            f"skopeo inspect docker://{self.image_ref} > {self.report_path}",
+            "skopeo needs the docker:// transport prefix",
+        ]
+        return self
+
+    def validate(self):
+        checks = []
+        total = 0
+
+        if not execute_safe(['test', '-f', self.report_path]).success:
+            checks.append(ValidationCheck(
+                name="report_exists", passed=False, points=0, max_points=10,
+                message=f"{self.report_path} does not exist"))
+            return ValidationResult(self.id, False, 0, self.points, checks)
+
+        checks.append(ValidationCheck(
+            name="report_exists", passed=True, points=4,
+            message=f"{self.report_path} exists"))
+        total += 4
+
+        body = execute_safe(['cat', self.report_path])
+        content = (body.stdout or '') if body.success else ''
+        # skopeo inspect emits JSON with these keys; grading the shape rather
+        # than exact bytes keeps it valid across skopeo versions.
+        markers = ['Digest', 'RepoTags', 'Architecture', 'Layers']
+        hits = [m for m in markers if m in content]
+
+        if len(hits) >= 2:
+            checks.append(ValidationCheck(
+                name="report_is_inspection", passed=True, points=6,
+                message=f"File contains skopeo inspection output ({', '.join(hits)})"))
+            total += 6
+        else:
+            checks.append(ValidationCheck(
+                name="report_is_inspection", passed=False, points=0, max_points=6,
+                message=("File does not look like skopeo inspect output — "
+                         "expected JSON with Digest/RepoTags/Architecture")))
+
+        return ValidationResult(self.id, total >= 10, total, self.points, checks)
+
+
+@TaskRegistry.register("containers")
+class ContainerLifecycleTask(_ContainerTask):
+    """Basic lifecycle: a container that exists but must be left stopped."""
+
+    def __init__(self):
+        super().__init__(id="containers_lifecycle_008", category="containers",
+                         difficulty="easy", points=8)
+        self.requires_persistence = False
+        self.exam_tips = [
+            "podman stop <name> leaves the container defined but not running",
+            "podman ps -a shows stopped containers; podman ps alone does not",
+            "'Exited' and 'Created' are different states — read the question",
+        ]
+
+    def generate(self, **params):
+        self._probe_environment()
+        self.container_name = params.get('container_name', 'idlesvc')
+        self.description = (
+            f"Manage a container's lifecycle:\n"
+            f"  - Create a container named {self.container_name}\n"
+            f"  - Start it, then stop it again\n"
+            f"  - Leave it defined on the system but NOT running"
+        ) + self._lab_note()
+        self.hints = [
+            f"podman run -d --name {self.container_name} <image> sleep infinity",
+            f"podman stop {self.container_name}",
+            f"podman ps -a  — it should be listed with a non-running state",
+        ]
+        return self
+
+    def validate(self):
+        checks = []
+        total = 0
+        self._probe_environment()
+
+        if self._skip_or_fail(checks, "container_stopped", 8,
+                              f"cannot check container '{self.container_name}'"):
+            return ValidationResult(self.id, True, 0, 0, checks)
+
+        result = execute_safe(['podman', 'ps', '-a', '--format',
+                               '{{.Names}}|{{.State}}'])
+        state = None
+        for row in (result.stdout or '').splitlines():
+            parts = row.split('|')
+            if parts and parts[0].strip() == self.container_name:
+                state = parts[1].strip().lower() if len(parts) > 1 else ''
+                break
+
+        if state is None:
+            checks.append(ValidationCheck(
+                name="container_exists", passed=False, points=0, max_points=4,
+                message=f"No container named '{self.container_name}'"))
+            checks.append(ValidationCheck(
+                name="container_stopped", passed=False, points=0, max_points=4,
+                message="Container does not exist"))
+            return ValidationResult(self.id, False, 0, self.points, checks)
+
+        checks.append(ValidationCheck(
+            name="container_exists", passed=True, points=4,
+            message=f"Container '{self.container_name}' is defined"))
+        total += 4
+
+        if state in ('exited', 'stopped', 'created', 'configured'):
+            checks.append(ValidationCheck(
+                name="container_stopped", passed=True, points=4,
+                message=f"Container is not running (state: {state})"))
+            total += 4
+        else:
+            checks.append(ValidationCheck(
+                name="container_stopped", passed=False, points=0, max_points=4,
+                message=f"Container is still running (state: {state})"))
+
+        return ValidationResult(self.id, total >= 8, total, self.points, checks)

--- a/tasks/partitioning.py
+++ b/tasks/partitioning.py
@@ -49,7 +49,14 @@ def _partition_dev(device, number):
 
 @TaskRegistry.register("partitioning")
 class CreateMBRPartitionTask(BaseTask):
-    """Create an MBR (msdos) partition using fdisk or parted."""
+    """Create an MBR (msdos) partition using fdisk or parted.
+
+    v9 only. The RHEL 9 objective reads "List, create, delete partitions on
+    MBR and GPT disks"; RHEL 10 narrowed it to "List, create, and delete
+    partitions on GPT disks", so this is off-syllabus for v10.
+    """
+
+    exam_versions = (9,)
 
     disk_slots = 1
 

--- a/tasks/registry.py
+++ b/tasks/registry.py
@@ -91,14 +91,50 @@ class TaskRegistry:
         return sum(len(tasks) for tasks in cls._tasks.values())
 
     @classmethod
+    def in_scope(cls, task_class, version=None):
+        """True if this task belongs to the exam version being simulated.
+
+        Two gates: the category (settings.VERSION_EXCLUDED_CATEGORIES) and
+        the task's own `exam_versions`. A task out of scope must never be
+        drawn — grading someone against a syllabus their exam does not use is
+        worse than having fewer tasks.
+        """
+        version = version if version is not None else settings.get_exam_version()
+        allowed = getattr(task_class, 'exam_versions', None)
+        if allowed is not None and version not in allowed:
+            return False
+        category = getattr(task_class, 'category', None)
+        if category is None:
+            # Category is set on the instance, not the class, for most tasks.
+            try:
+                category = task_class().category
+            except Exception:
+                return True
+        return settings.category_in_scope(category, version)
+
+    @classmethod
+    def categories_in_scope(cls, version=None):
+        """Registered categories that this exam version actually tests."""
+        return [c for c in cls._tasks
+                if settings.category_in_scope(c, version)]
+
+    @classmethod
     def get_random_task(cls, category=None, difficulty=None, skip_reboot=False):
         if category:
+            if not settings.category_in_scope(category):
+                return None
             task_classes = cls._tasks.get(category, [])
         else:
             task_classes = []
-            for cat_tasks in cls._tasks.values():
-                task_classes.extend(cat_tasks)
+            for cat in cls.categories_in_scope():
+                task_classes.extend(cls._tasks.get(cat, []))
 
+        if not task_classes:
+            return None
+
+        # Drop tasks the active exam version does not cover (e.g. MBR
+        # partitioning, which v10 removed).
+        task_classes = [tc for tc in task_classes if cls.in_scope(tc)]
         if not task_classes:
             return None
 
@@ -180,9 +216,10 @@ class TaskRegistry:
         max_attempts = count * 10
 
         if categories:
-            available_categories = [c for c in categories if c in cls._tasks]
+            available_categories = [c for c in categories if c in cls._tasks
+                                    and settings.category_in_scope(c)]
         else:
-            available_categories = list(cls._tasks.keys())
+            available_categories = cls.categories_in_scope()
 
         if not available_categories:
             return []
@@ -230,7 +267,8 @@ class TaskRegistry:
             disk_budget = max(disk_budget, 3)  # floor: exam start ensures >=3 loops
 
         # Distribute tasks across domains weighted by domain weight
-        from config.exam_objectives import EXAM_OBJECTIVES
+        from config.exam_objectives import get_objectives
+        EXAM_OBJECTIVES = get_objectives()
         total_weight = sum(d["weight"] for d in EXAM_OBJECTIVES.values())
 
         domain_counts = {}

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -6,6 +6,8 @@ import pytest
 import sys
 from unittest.mock import patch, MagicMock
 
+from config import settings
+
 
 pytestmark = pytest.mark.e2e
 
@@ -19,6 +21,11 @@ def _args(**overrides):
         list_categories=False, quick=None, exam=False, learn=None,
         practice=None, adaptive=False,
         export_code=False, import_code=None, import_mode='replace',
+        # Real values, not MagicMocks: main() feeds these to
+        # settings.set_exam_version() and the task panel, both of which
+        # validate their input rather than accepting anything truthy.
+        exam_version=settings.DEFAULT_EXAM_VERSION,
+        gui=None, gui_bind='127.0.0.1',
     )
     defaults.update(overrides)
     return MagicMock(**defaults)

--- a/tests/unit/test_content.py
+++ b/tests/unit/test_content.py
@@ -20,10 +20,22 @@ class TestContentRegistry:
         assert ContentRegistry._initialized is True
 
     def test_all_domains_have_categories(self):
+        """Every domain a version actually tests must have study content.
+
+        Checked per version, because the domain set differs: v9 has a
+        Containers domain that v10 dropped.
+        """
         ContentRegistry.initialize()
-        for domain_num in settings.EXAM_DOMAINS:
-            cats = ContentRegistry.get_categories_for_domain(domain_num)
-            assert len(cats) >= 1, f"Domain {domain_num} has no categories"
+        original = settings.get_exam_version()
+        try:
+            for version in settings.SUPPORTED_EXAM_VERSIONS:
+                settings.set_exam_version(version)
+                for domain_num in settings.exam_domains(version):
+                    cats = ContentRegistry.get_categories_for_domain(domain_num)
+                    assert len(cats) >= 1, (
+                        f"v{version} domain {domain_num} has no categories")
+        finally:
+            settings.set_exam_version(original)
 
     def test_get_topic_returns_dict(self):
         ContentRegistry.initialize()
@@ -40,12 +52,24 @@ class TestContentRegistry:
         assert topic is None
 
     def test_get_categories_for_domain_matches_settings(self):
+        """Content categories must be reachable from their domain — for the
+        version that actually tests them. A v9-only category like containers
+        is legitimately absent from v10's domain list."""
         ContentRegistry.initialize()
-        for cat, domain in settings.CATEGORY_TO_DOMAIN.items():
-            domain_cats = ContentRegistry.get_categories_for_domain(domain)
-            # Not all settings categories may have content, but content categories
-            # should be a subset of settings
-            if cat in ContentRegistry.get_all_categories():
-                assert cat in domain_cats, (
-                    f"{cat} (domain {domain}) missing from ContentRegistry"
-                )
+        original = settings.get_exam_version()
+        try:
+            for version in settings.SUPPORTED_EXAM_VERSIONS:
+                settings.set_exam_version(version)
+                for cat, domain in settings.CATEGORY_TO_DOMAIN.items():
+                    if not settings.category_in_scope(cat, version):
+                        continue
+                    domain_cats = ContentRegistry.get_categories_for_domain(domain)
+                    # Not all settings categories may have content, but content
+                    # categories should be a subset of settings
+                    if cat in ContentRegistry.get_all_categories():
+                        assert cat in domain_cats, (
+                            f"v{version}: {cat} (domain {domain}) missing "
+                            f"from ContentRegistry"
+                        )
+        finally:
+            settings.set_exam_version(original)

--- a/tests/unit/test_exam_version.py
+++ b/tests/unit/test_exam_version.py
@@ -1,0 +1,186 @@
+"""
+Tests for EX200 v9 / v10 mode.
+
+The two exams are not the same syllabus, and the difference is asymmetric:
+
+    v9 only   Manage containers, MBR partition tables
+    v10 only  Flatpak, systemd timer units
+
+Drawing an out-of-scope task means grading a candidate against objectives
+their exam does not contain, so the filtering is the part that matters most
+here.
+"""
+
+import pytest
+
+from config import settings
+from config.exam_objectives import get_objectives, get_domain_name
+from tasks.registry import TaskRegistry
+
+
+@pytest.fixture(autouse=True)
+def _restore_version():
+    original = settings.get_exam_version()
+    yield
+    settings.set_exam_version(original)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def _registry():
+    TaskRegistry.initialize()
+
+
+# ── version switching ───────────────────────────────────────────────────────
+
+def test_default_is_the_current_exam():
+    assert settings.DEFAULT_EXAM_VERSION == 10
+
+
+def test_set_and_get_round_trip():
+    settings.set_exam_version(9)
+    assert settings.get_exam_version() == 9
+    settings.set_exam_version(10)
+    assert settings.get_exam_version() == 10
+
+
+def test_string_version_accepted():
+    """--exam-version comes off a CLI, so '9' must work as well as 9."""
+    settings.set_exam_version('9')
+    assert settings.get_exam_version() == 9
+
+
+@pytest.mark.parametrize('bad', [8, 11, 0, -1, 'eleven'])
+def test_unsupported_version_rejected(bad):
+    """Falling back silently would grade against the wrong syllabus."""
+    with pytest.raises((ValueError, TypeError)):
+        settings.set_exam_version(bad)
+
+
+# ── category scope ──────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize('category,in_v9,in_v10', [
+    ('containers', True, False),      # dropped in v10
+    ('flatpak', False, True),         # introduced in v10
+    ('systemd_timers', False, True),  # v9 scheduling is at/cron only
+    ('lvm', True, True),
+    ('selinux', True, True),
+])
+def test_category_scope_per_version(category, in_v9, in_v10):
+    assert settings.category_in_scope(category, 9) is in_v9
+    assert settings.category_in_scope(category, 10) is in_v10
+
+
+def test_registry_reports_only_in_scope_categories():
+    settings.set_exam_version(9)
+    v9 = set(TaskRegistry.categories_in_scope())
+    settings.set_exam_version(10)
+    v10 = set(TaskRegistry.categories_in_scope())
+
+    assert 'containers' in v9 and 'containers' not in v10
+    assert 'flatpak' in v10 and 'flatpak' not in v9
+    assert 'systemd_timers' in v10 and 'systemd_timers' not in v9
+
+
+def test_out_of_scope_category_yields_no_task():
+    settings.set_exam_version(10)
+    assert TaskRegistry.get_random_task(category='containers') is None
+    settings.set_exam_version(9)
+    assert TaskRegistry.get_random_task(category='flatpak') is None
+
+
+# ── task-level scope (MBR) ──────────────────────────────────────────────────
+
+def test_mbr_partitioning_is_v9_only():
+    """v10's objective is "partitions on GPT disks" — MBR was dropped, so the
+    task must not be drawn even though `partitioning` is in scope for both."""
+    from tasks.partitioning import CreateMBRPartitionTask
+
+    assert TaskRegistry.in_scope(CreateMBRPartitionTask, 9) is True
+    assert TaskRegistry.in_scope(CreateMBRPartitionTask, 10) is False
+
+
+def test_partitioning_category_stays_in_scope_for_both():
+    assert settings.category_in_scope('partitioning', 9)
+    assert settings.category_in_scope('partitioning', 10)
+
+
+# ── domains and objectives ──────────────────────────────────────────────────
+
+def test_containers_domain_exists_only_in_v9():
+    assert 9 in settings.exam_domains(9)
+    assert 9 not in settings.exam_domains(10)
+
+
+def test_objectives_differ_by_version():
+    v9, v10 = get_objectives(9), get_objectives(10)
+    assert 9 in v9 and 9 not in v10
+    assert get_domain_name(9, version=9) == 'Containers'
+
+
+@pytest.mark.parametrize('version', [9, 10])
+def test_weights_sum_to_100(version):
+    """Domain weights drive exam composition; drift means a lopsided exam."""
+    assert sum(d['weight'] for d in get_objectives(version).values()) == 100
+
+
+def test_v9_objectives_carry_the_version_specific_bullets():
+    text = ' '.join(
+        obj for domain in get_objectives(9).values()
+        for obj in domain['objectives']).lower()
+    assert 'mbr' in text
+    assert 'set-gid' in text
+    assert 'skopeo' in text or 'podman' in text
+    assert 'flatpak' not in text
+
+
+def test_v10_objectives_carry_flatpak_and_not_containers():
+    text = ' '.join(
+        obj for domain in get_objectives(10).values()
+        for obj in domain['objectives']).lower()
+    assert 'flatpak' in text
+    assert 'podman' not in text and 'skopeo' not in text
+
+
+# ── generated exams ─────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize('version', [9, 10])
+def test_generated_exam_never_leaks_out_of_scope_tasks(version):
+    settings.set_exam_version(version)
+    tasks = TaskRegistry.generate_exam(20, disk_budget=4)
+
+    assert tasks, "no tasks generated"
+    leaked = [t.category for t in tasks
+              if not settings.category_in_scope(t.category, version)]
+    assert not leaked, f"v{version} exam contained out-of-scope: {leaked}"
+
+
+def test_v9_exam_can_include_containers():
+    settings.set_exam_version(9)
+    # Domain balancing is randomised; sample a few exams rather than assume
+    # one draw covers domain 9.
+    seen = set()
+    for _ in range(3):
+        seen.update(t.category for t in
+                    TaskRegistry.generate_exam(20, disk_budget=4))
+    assert 'containers' in seen
+
+
+def test_v10_exam_never_includes_containers():
+    settings.set_exam_version(10)
+    seen = set()
+    for _ in range(3):
+        seen.update(t.category for t in
+                    TaskRegistry.generate_exam(20, disk_budget=4))
+    assert 'containers' not in seen
+
+
+# ── preflight packages ──────────────────────────────────────────────────────
+
+def test_podman_required_only_for_v9():
+    from core import preflight
+
+    assert 'podman' in preflight.required_packages(9)
+    assert 'podman' not in preflight.required_packages(10)
+    # Shared requirements survive in both.
+    assert 'httpd' in preflight.required_packages(9)
+    assert 'httpd' in preflight.required_packages(10)

--- a/validators/safe_executor.py
+++ b/validators/safe_executor.py
@@ -310,6 +310,42 @@ class SafeCommandExecutor:
                     f"Only read-only operations permitted."
                 )
 
+        # Containers: inspection only. The candidate's containers, images,
+        # volumes and generated systemd units are all things we look at and
+        # never touch — `podman rm` on a graded container would destroy the
+        # very state the check is about.
+        elif base_cmd == 'podman':
+            if len(command) < 2:
+                return
+            subcommand = command[1]
+            read_only_ops = ['ps', 'images', 'image', 'inspect', 'container',
+                             'volume', 'port', 'info', 'version', 'healthcheck',
+                             'diff', 'top', 'logs', 'mount', 'stats', 'history',
+                             'search', 'pod', 'network', 'system']
+            if subcommand not in read_only_ops:
+                raise SecurityError(
+                    f"podman subcommand '{subcommand}' is not allowed. "
+                    f"Only read-only operations permitted."
+                )
+            # Sub-subcommands that mutate (podman image rm, volume prune, ...)
+            mutating = {'rm', 'rmi', 'prune', 'create', 'remove', 'import',
+                        'load', 'pull', 'push', 'build', 'tag', 'untag',
+                        'export', 'save', 'reset'}
+            if len(command) > 2 and command[2] in mutating:
+                raise SecurityError(
+                    f"podman {subcommand} {command[2]} modifies state and is "
+                    f"not allowed"
+                )
+
+        elif base_cmd == 'skopeo':
+            if len(command) < 2:
+                return
+            if command[1] not in ['inspect', 'list-tags']:
+                raise SecurityError(
+                    f"skopeo subcommand '{command[1]}' is not allowed. "
+                    f"Only inspect/list-tags permitted."
+                )
+
         # Ensure rpm is read-only
         elif base_cmd == 'rpm':
             cmd_str = ' '.join(command)


### PR DESCRIPTION
`--exam-version 9|10`, default 10.

## The delta is not symmetric

Taken from Red Hat's two objective pages, not from memory:

| | v9 (RHEL 9) | v10 (RHEL 10) |
|---|---|---|
| **Manage containers** — podman/skopeo, run a service in a container, systemd auto-start, persistent storage | own section | **removed** |
| **Flatpak** repos + packages | — | **new** |
| **systemd timer units** for scheduling | — (at/cron only) | added |
| Partition tables | MBR **and** GPT | GPT only |
| set-GID collaboration directories | present | **removed** |
| "Diagnose routine SELinux policy violations" | explicit | **removed** |
| Wording | superuser access, Red Hat Network | privileged access, Red Hat CDN |

v9 *removes* less than it *adds* — which is why this is bigger than "turn off a couple of categories".

## Mechanism

One task catalogue, filtered per version, on two gates:

- **Whole categories** — `settings.VERSION_EXCLUDED_CATEGORIES`
- **Individual tasks** — an `exam_versions` attribute on the class, used for MBR partitioning, where the `partitioning` category is in scope for both versions but that one task is v9-only

Both enforced in `TaskRegistry.in_scope()`. An out-of-scope task is never drawn: being graded against objectives your exam doesn't contain is worse than a smaller pool.

Note this fixes a **pre-existing v10 accuracy bug** — `CreateMBRPartitionTask` was being generated in a simulator labelled v10, which dropped MBR.

## New: tasks/containers.py

8 tasks covering all seven v9 container objectives — pull from a registry, inspect an image, skopeo remote inspect, run/stop lifecycle, a service published on a host port, persistent storage with the `:Z` relabel, and a rootless container started at boot by a systemd user unit with lingering.

Two things make this category unlike the rest of the simulator, and both are handled explicitly:

**It needs an image, and everything else here works offline.** Tasks probe for podman and a cached image at generation time, say so in the task text when either is missing, and **skip** the affected checks rather than failing them. Someone who did the work correctly must never lose points because the lab had no registry access.

**Rootless is the exam-realistic default.** The systemd task grades a user unit under `~/.config/systemd/user` *plus* lingering — without lingering the container doesn't start until that user logs in, which is the detail people miss. The storage task grades the `container_file_t` label that `:Z` produces, and skips that check when SELinux isn't enforcing.

`podman` and `skopeo` are added to the validation allowlist **restricted to inspection subcommands** — `safe_executor` blocks `rm`, `run`, `stop`, `prune`, `pull`, `image rm`, `volume prune`, `skopeo copy`. A check can never destroy the container it's grading. Tested both directions.

## Also

- Objectives and domain weights are per version behind `get_objectives()`; v9 gains a Containers domain at 10%. Weights sum to 100 in both (asserted).
- Learn mode, the content registry and exam generation all follow the active version. This also un-orphans `core/content/domain_9_containers.py`, which was reachable in Learn mode while nothing could ever test it.
- `preflight` only asks for podman/skopeo on v9.

## Counts

| | tasks | categories | domains |
|---|---|---|---|
| v9 | 187 | 24 | 9 |
| v10 | 191 | 25 | 8 |

200 task classes total.

## Tests

**400 passed, 1 failed.** 28 new tests in `tests/unit/test_exam_version.py` cover version switching, per-version category scope, the MBR task gate, objective/weight integrity, and that generated exams for both versions never leak an out-of-scope task.

Two existing tests needed updating rather than fixing: `test_cli`'s args stub handed a `MagicMock` to `set_exam_version()` (which validates its input rather than accepting anything truthy), and the content tests assumed one global domain set. Both are now version-aware.

The one failure is `test_generates_correct_count`. **It fails on unmodified `master` too** — it needs root to create `/var/lib/rhcsa-simulator`, and only passes in a full-suite run because of test ordering. Worth knowing that a green suite currently masks it; unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cp8gGc1CQ3UjdopTWsUmSd