### PR TITLE
Task panel: submit, results, disputes and lab reset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,19 @@ python3 -m pytest -v            # Verbose output
   collapsed task list that opens in place, Revisit/Done ticks, countdown.
   (The real exam's is a native app; we serve ours over HTTP to a browser
   because that needs nothing installed and works on a headless VM. Don't
-  describe the exam's own window as a browser.) Advisory only — it must
-  never influence grading, which stays driven by real system state. Stdlib
-  `http.server`, no external assets. It must also never mutate the box:
-  notably it reports on firewalld but never opens a port, because firewall
-  tasks are graded.
+  describe the exam's own window as a browser.) Stdlib `http.server`, no
+  external assets.
+- The panel also **drives the session** — submit for grading, per-check
+  results, file a dispute, reset the lab — through named actions in
+  `core/panel_control.py`. Never add a general command channel. **Every
+  request is authenticated** with a per-session token: the panel binds
+  0.0.0.0 by default, so reachability is not authorisation. Reset
+  additionally refuses during a running exam. Validation is only ever
+  *requested* by the panel; it runs on the main exam thread, so there is one
+  grader whichever way it was triggered. Ticks still never influence
+  grading, which stays driven by real system state. The panel must not
+  otherwise mutate the box — notably it reports on firewalld but never opens
+  a port, because firewall tasks are graded.
 - `tasks/` — Task definitions (188 tasks, 25 categories, 8 domains)
 - `validators/` — Safe read-only system validators for each task type
 - `utils/` — AI feedback, progress reports, device detection

--- a/README.md
+++ b/README.md
@@ -223,9 +223,27 @@ firewalld would corrupt what their validators grade.
 ssh -L 8080:127.0.0.1:8080 root@<exam-vm>   # then browse to 127.0.0.1:8080
 ```
 
-The ticks are your own bookkeeping. Grading is unchanged: it still runs against
-real system state when you return to the terminal, so ticking "done" earns
-nothing on its own.
+The ticks are your own bookkeeping — they earn nothing on their own.
+
+**The panel also drives the session:**
+
+- **Submit for grading** — runs the real validators, same as pressing Enter in
+  the terminal. Whichever you use, grading happens once, on the exam host.
+- **Results** — score, pass/fail, and every check with its message and points,
+  per task.
+- **Dispute a result** — tick the checks you think are wrong, say why, and
+  file it. The report is written to `data/disputes/` **first**, so the evidence
+  survives even if submitting fails. If a GitHub issue is opened, the AI
+  reviewer posts its verdict as a comment *there* — verdicts do not come back
+  into the panel.
+- **Reset lab environment** — clears practice mounts, loop devices and
+  leftover task artifacts. Refused while an exam is in progress.
+
+**The URL contains a session token** (`?t=…`) and every request must carry it.
+That is not decoration: the panel binds `0.0.0.0` so a headless VM can be read
+from your laptop, and once it can reset the lab and open GitHub issues,
+"whoever can reach the port" stops being an acceptable authorisation rule. A
+fresh token is minted per exam. `--gui-bind 127.0.0.1` restricts it further.
 
 ### Terminal menu
 

--- a/core/exam.py
+++ b/core/exam.py
@@ -44,6 +44,11 @@ class ExamSession:
         self.gui_port = gui_port
         self.gui_bind = gui_bind
         self.panel = None
+        self.controller = None
+        # Shared with the browser panel so both views agree on where the
+        # session is: in_progress -> validating -> complete.
+        self.panel_status = 'in_progress'
+        self.panel_results = None
         self.timer_enabled = timer_enabled
         self.duration_minutes = duration_minutes or settings.DEFAULT_EXAM_DURATION
         self.reboot_simulation = reboot_simulation if reboot_simulation is not None else settings.REBOOT_SIMULATION
@@ -151,9 +156,12 @@ class ExamSession:
         if not self.gui_port:
             return
         from core import task_gui
+        from core.panel_control import PanelController
         task_gui.clear_marks()
+        self.controller = PanelController(self)
         self.panel, urls = task_gui.start_for_session(
-            self, port=self.gui_port, bind=self.gui_bind)
+            self, controller=self.controller,
+            port=self.gui_port, bind=self.gui_bind)
         if not urls:
             print(fmt.warning(
                 f"\nTask panel could not start on port {self.gui_port} "
@@ -434,6 +442,16 @@ class ExamSession:
 
         passed = percentage >= (settings.EXAM_PASS_THRESHOLD * 100)
 
+        # Publish to the panel before printing, so the browser view updates
+        # while the terminal report is still scrolling past.
+        try:
+            from core.panel_control import serialize_results
+            self.panel_results = serialize_results(
+                self.tasks, validation_results, total_score, max_score, passed)
+            self.panel_status = 'complete'
+        except Exception as e:
+            logger.debug("could not publish results to panel: %s", e)
+
         # Display final report
         duration = (self.end_time - self.start_time).total_seconds()
         self._display_final_report(
@@ -603,6 +621,49 @@ def _select_reboot_simulation():
             print(fmt.error("Invalid selection"))
 
 
+def _wait_for_submit(session):
+    """Block until the candidate submits, from the terminal or the panel.
+
+    input() cannot be interrupted, so it runs on its own thread and both
+    paths converge on one Event. Grading itself always happens back here on
+    the main thread — the panel only ever requests it, so there is exactly
+    one grader no matter which button was pressed.
+    """
+    import threading
+
+    done = threading.Event()
+    prompt = "\nPress Enter when you're ready to validate your work"
+    controller = getattr(session, 'controller', None)
+    if controller is not None:
+        prompt += " (or press Submit in the task panel)"
+    prompt += "..."
+
+    # Ctrl-C and EOF must still abort the exam. input() now runs off the main
+    # thread, so its exception cannot propagate on its own — capture it and
+    # re-raise here, or a candidate pressing Ctrl-C would be graded instead of
+    # quitting.
+    raised = {}
+
+    def _await_enter():
+        try:
+            input(prompt)
+        except BaseException as exc:        # EOFError, KeyboardInterrupt
+            raised['exc'] = exc
+        done.set()
+
+    reader = threading.Thread(target=_await_enter, daemon=True)
+    reader.start()
+
+    while not done.is_set():
+        if controller is not None and controller.submit_requested.is_set():
+            print(fmt.info("\nSubmitted from the task panel — validating..."))
+            return
+        done.wait(0.3)
+
+    if 'exc' in raised:
+        raise raised['exc']
+
+
 def run_exam_mode(gui_port=None, gui_bind='0.0.0.0'):
     """Run exam mode (convenience function)."""
     task_count = _select_exam_task_count()
@@ -615,7 +676,7 @@ def run_exam_mode(gui_port=None, gui_bind='0.0.0.0'):
         session._stop_task_panel()
         return None
 
-    input("\nPress Enter when you're ready to validate your work...")
+    _wait_for_submit(session)
 
     try:
         # No teardown on any exit path — the environment persists for review

--- a/core/panel_control.py
+++ b/core/panel_control.py
@@ -1,0 +1,224 @@
+"""
+Actions the browser task panel can perform on a live exam session.
+
+The panel used to be a read-only view of the question sheet. It now drives
+the session — submit for grading, dispute a check, reset the lab — and this
+module is the whole of what it is allowed to do. There is deliberately no
+general command channel: the panel calls named methods here, nothing else.
+
+THREADING
+---------
+Requests arrive on HTTP worker threads. Validation runs real commands and
+mutates session state, so it must not happen there — request_validate()
+only sets an Event, and the main exam thread (which is otherwise blocked
+waiting for the candidate to press Enter) picks it up and does the work.
+That keeps a single grader, whichever way the submit was triggered.
+
+Reset is the opposite case: it is fast enough to run inline, but it is
+destructive, so it refuses while an exam is in progress unless the caller
+confirms.
+"""
+
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+
+class PanelController:
+    """Bridge between the HTTP panel and an ExamSession."""
+
+    def __init__(self, session):
+        self.session = session
+        # Set by the panel, consumed by the main exam thread.
+        self.submit_requested = threading.Event()
+        self._dispute_lock = threading.Lock()
+
+    # ── grading ─────────────────────────────────────────────────────────
+
+    def request_validate(self):
+        """Ask the main thread to grade the exam. Idempotent."""
+        status = getattr(self.session, 'panel_status', 'in_progress')
+        if status in ('validating', 'complete'):
+            return {'queued': False, 'status': status,
+                    'message': 'Already submitted'}
+        self.session.panel_status = 'validating'
+        self.submit_requested.set()
+        logger.info("panel requested validation")
+        return {'queued': True, 'status': 'validating'}
+
+    # ── disputes ────────────────────────────────────────────────────────
+
+    def file_dispute(self, task_id, check_names, argument, submit=True):
+        """Raise a checker dispute for one task.
+
+        The local report is written before any network call and is kept even
+        if submitting fails, so evidence is never lost to a flaky connection.
+        The AI reviewer's verdict comes back as a comment on the GitHub
+        issue — it does not flow back into the simulator, so the caller gets
+        the issue URL to follow.
+        """
+        from core import dispute
+
+        if not task_id:
+            return {'ok': False, 'error': 'task_id is required'}
+
+        record = self._result_for(task_id)
+        if not record:
+            return {'ok': False,
+                    'error': f'No graded result for {task_id} to dispute. '
+                             f'Submit the exam first.'}
+
+        wanted = set(check_names or [])
+        disputed = [c for c in record.get('checks', [])
+                    if not wanted or c.get('name') in wanted]
+        if not disputed:
+            return {'ok': False, 'error': 'No matching checks to dispute'}
+
+        with self._dispute_lock:
+            try:
+                evidence = dispute.collect_evidence(record.get('category', ''))
+                body = dispute.build_report(record, disputed, argument, evidence)
+                path = dispute.save_report(record, body)
+            except Exception as e:
+                logger.warning("dispute report failed: %s", e)
+                return {'ok': False, 'error': f'Could not build report: {e}'}
+
+            result = {'ok': True, 'saved_to': path, 'submitted': False,
+                      'issue_url': None}
+
+            if not submit:
+                result['message'] = ('Saved locally. Not submitted — no GitHub '
+                                     'issue was opened.')
+                return result
+
+            if not dispute.gh_available():
+                result['message'] = (
+                    'Saved locally. The GitHub CLI (gh) is not available or '
+                    'not authenticated, so no issue was opened. The report is '
+                    'complete and can be filed later.')
+                return result
+
+            try:
+                ok, info = dispute.submit_issue(record, path)
+            except Exception as e:
+                logger.warning("dispute submit failed: %s", e)
+                ok, info = False, str(e)
+
+            result['submitted'] = bool(ok)
+            if ok:
+                result['issue_url'] = info
+                result['message'] = (
+                    'Issue opened. The AI reviewer posts its verdict as a '
+                    'comment there — it does not appear in the simulator.')
+            else:
+                result['message'] = (
+                    f'Saved locally, but submitting failed: {info}. The '
+                    f'evidence is preserved at {path}.')
+            return result
+
+    def list_disputes(self):
+        """Reports filed on this box, newest first.
+
+        Disputes are otherwise fire-and-forget — there is no command to list
+        what you have filed — so the panel showing them is the only place
+        that gap is closed. Verdicts still live on GitHub.
+        """
+        import os
+        from core import dispute
+
+        entries = []
+        try:
+            names = sorted(os.listdir(dispute.DISPUTE_DIR), reverse=True)
+        except OSError:
+            names = []
+        for name in names:
+            if not name.endswith('.md'):
+                continue
+            path = os.path.join(dispute.DISPUTE_DIR, name)
+            try:
+                stamp = os.path.getmtime(path)
+            except OSError:
+                stamp = 0
+            entries.append({'file': name, 'path': path, 'mtime': stamp})
+        return {'disputes': entries, 'dir': dispute.DISPUTE_DIR}
+
+    # ── lab reset ───────────────────────────────────────────────────────
+
+    def reset_lab(self, confirm=False):
+        """Return the box to a clean practice state.
+
+        Destructive, so it is gated twice: the caller must pass confirm, and
+        it refuses outright during a running exam — resetting mid-exam would
+        delete the very state the candidate is being graded on, and a stray
+        request must not be able to do that.
+        """
+        status = getattr(self.session, 'panel_status', 'in_progress')
+        if status == 'in_progress' and getattr(self.session, 'tasks', None):
+            return {'ok': False,
+                    'error': 'An exam is in progress. Submit it first — '
+                             'resetting now would destroy the work being '
+                             'graded.'}
+        if not confirm:
+            return {'ok': False, 'error': 'confirmation required'}
+
+        from core import task_env
+        try:
+            task_env.session_reset(verbose=False)
+        except Exception as e:
+            logger.warning("panel lab reset failed: %s", e)
+            return {'ok': False, 'error': str(e)}
+        logger.info("panel reset the lab environment")
+        return {'ok': True,
+                'message': 'Lab environment reset: practice mounts, loop '
+                           'devices and leftover task artifacts cleared.'}
+
+    # ── helpers ─────────────────────────────────────────────────────────
+
+    def _result_for(self, task_id):
+        for record in (getattr(self.session, 'panel_results', None) or {}).get(
+                'tasks', []):
+            if record.get('task_id') == task_id:
+                return record
+        return None
+
+
+def serialize_results(tasks, validation_results, score, max_score, passed):
+    """Flatten graded results into something the panel can render.
+
+    Deliberately the same shape core/dispute.py expects for a task record, so
+    a dispute raised from the panel carries exactly what one raised from the
+    terminal does.
+    """
+    records = []
+    for task, result in zip(tasks, validation_results or []):
+        records.append({
+            'task_id': getattr(task, 'id', ''),
+            'category': getattr(task, 'category', ''),
+            'difficulty': getattr(task, 'difficulty', ''),
+            'description': getattr(task, 'description', ''),
+            'domain': getattr(task, 'exam_domain', 0),
+            'score': getattr(result, 'score', 0),
+            'max_score': getattr(result, 'max_score', 0),
+            'passed': bool(getattr(result, 'passed', False)),
+            'checks': [
+                {
+                    'name': getattr(c, 'name', ''),
+                    'passed': bool(getattr(c, 'passed', False)),
+                    'points': getattr(c, 'points', 0),
+                    'max_points': getattr(c, 'max_points',
+                                          getattr(c, 'points', 0)),
+                    'message': getattr(c, 'message', ''),
+                }
+                for c in (getattr(result, 'checks', None) or [])
+            ],
+        })
+
+    percentage = (score / max_score * 100) if max_score else 0
+    return {
+        'score': score,
+        'max_score': max_score,
+        'percentage': round(percentage, 1),
+        'passed': bool(passed),
+        'tasks': records,
+    }

--- a/core/task_gui.py
+++ b/core/task_gui.py
@@ -42,8 +42,24 @@ panel must never become a way to score points.
 DESIGN
 ------
 - Stdlib only (http.server + json), consistent with the rest of the project.
-- Read-mostly. The panel shows state and records ticks; it never validates,
-  never mutates the system, and never touches task state the grader reads.
+- The panel drives the session: submit for grading, read the per-check
+  results, dispute a check, reset the lab. Those are real actions on a real
+  box, which is why every request is authenticated (see below) — an earlier
+  version of this panel was read-only and could afford not to be.
+
+AUTHENTICATION
+--------------
+A random token is minted per session and embedded in the URL the exam
+prints. Every request must carry it, as ?t= or an X-Panel-Token header;
+anything else gets 403. This exists because the panel binds 0.0.0.0 by
+default so a headless exam VM can be read from a laptop — and once the
+panel can reset the lab or file a GitHub issue, "anyone who can reach the
+port" is no longer an acceptable authorisation rule. The token is compared
+with secrets.compare_digest.
+
+Reset is additionally guarded server-side: it refuses while an exam is
+running unless the caller passes confirm=True, so a stray request cannot
+wipe a session in progress.
 - Marks live server-side so the view survives a page reload and is shared
   across windows (laptop and phone show the same ticks).
 - The page holds no state worth losing: it polls /api/state and re-renders.
@@ -53,6 +69,7 @@ DESIGN
 
 import json
 import logging
+import secrets
 import socket
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -244,6 +261,17 @@ def _local_addresses(port):
     return urls
 
 
+def _json_body(handler):
+    """Parse a JSON request body. Returns {} on anything unreadable."""
+    try:
+        length = int(handler.headers.get('Content-Length') or 0)
+        if length <= 0:
+            return {}
+        return json.loads(handler.rfile.read(length) or b'{}')
+    except (ValueError, TypeError, OSError):
+        return {}
+
+
 class _Handler(BaseHTTPRequestHandler):
     server_version = 'RHCSATaskPanel/1.0'
 
@@ -264,8 +292,47 @@ class _Handler(BaseHTTPRequestHandler):
         except (BrokenPipeError, ConnectionResetError):
             pass  # browser navigated away mid-response
 
+    def _authorized(self):
+        """Every request must carry the session token.
+
+        The panel binds 0.0.0.0 so a headless VM can be read from a laptop.
+        Now that it can submit for grading, file a GitHub issue and reset the
+        lab, "can reach the port" is not an acceptable authorisation rule.
+        """
+        expected = getattr(self.server, 'token', None)
+        if not expected:
+            return True                      # token disabled (tests)
+        supplied = self.headers.get('X-Panel-Token') or ''
+        if not supplied and '?' in self.path:
+            from urllib.parse import parse_qs, urlparse
+            supplied = (parse_qs(urlparse(self.path).query).get('t') or [''])[0]
+        return secrets.compare_digest(str(supplied), str(expected))
+
+    def _deny(self):
+        self._send(403, '{"error":"invalid or missing panel token"}',
+                   'application/json')
+
+    def _action(self, name, *args, **kwargs):
+        """Call a controller method, returning (status_code, payload).
+
+        A panel wired without a controller (or to one missing this action)
+        answers 501 rather than pretending the action happened.
+        """
+        controller = getattr(self.server, 'controller', None)
+        fn = getattr(controller, name, None) if controller else None
+        if fn is None:
+            return 501, {'error': f'{name} is not available in this session'}
+        try:
+            return 200, fn(*args, **kwargs)
+        except Exception as e:                        # controller bugs
+            logger.warning("panel action %s failed: %s", name, e)
+            return 500, {'error': str(e)}
+
     def do_GET(self):
         path = self.path.split('?', 1)[0].rstrip('/') or '/'
+        if not self._authorized():
+            return self._deny()
+
         if path == '/':
             self._send(200, PAGE_HTML, 'text/html; charset=utf-8')
         elif path == '/api/state':
@@ -277,39 +344,70 @@ class _Handler(BaseHTTPRequestHandler):
                          'done_count': 0, 'revisit_count': 0,
                          'remaining_seconds': None, 'error': 'state unavailable'}
             self._send(200, json.dumps(state), 'application/json')
+        elif path == '/api/disputes':
+            code, payload = self._action('list_disputes')
+            self._send(code, json.dumps(payload), 'application/json')
         else:
             self._send(404, '{"error":"not found"}', 'application/json')
 
     def do_POST(self):
         path = self.path.split('?', 1)[0].rstrip('/') or '/'
-        if path != '/api/mark':
+        if not self._authorized():
+            return self._deny()
+
+        if path == '/api/mark':
+            payload = _json_body(self)
+            try:
+                state = set_mark(payload.get('id'), payload.get('field'),
+                                 bool(payload.get('value')))
+            except ValueError:
+                self._send(400, '{"error":"unknown mark"}', 'application/json')
+                return
+            self._send(200, json.dumps({'id': payload.get('id'),
+                                        'marks': state}), 'application/json')
+
+        elif path == '/api/validate':
+            # Submit for grading. The controller queues it for the main
+            # thread — validators run real commands and touch shared session
+            # state, so they must not run on an HTTP worker thread.
+            code, payload = self._action('request_validate')
+            self._send(code, json.dumps(payload), 'application/json')
+
+        elif path == '/api/dispute':
+            body = _json_body(self)
+            code, payload = self._action(
+                'file_dispute',
+                task_id=body.get('task_id'),
+                check_names=body.get('checks') or [],
+                argument=body.get('argument') or '',
+                submit=bool(body.get('submit', True)),
+            )
+            self._send(code, json.dumps(payload), 'application/json')
+
+        elif path == '/api/reset-lab':
+            body = _json_body(self)
+            code, payload = self._action('reset_lab',
+                                         confirm=bool(body.get('confirm')))
+            self._send(code, json.dumps(payload), 'application/json')
+
+        else:
             self._send(404, '{"error":"not found"}', 'application/json')
-            return
-        try:
-            length = int(self.headers.get('Content-Length') or 0)
-            payload = json.loads(self.rfile.read(length) or b'{}')
-            task_id = payload.get('id')
-            field = payload.get('field')
-            value = bool(payload.get('value'))
-        except (ValueError, TypeError, OSError):
-            self._send(400, '{"error":"bad request"}', 'application/json')
-            return
-        try:
-            state = set_mark(task_id, field, value)
-        except ValueError:
-            self._send(400, '{"error":"unknown mark"}', 'application/json')
-            return
-        self._send(200, json.dumps({'id': task_id, 'marks': state}),
-                   'application/json')
 
 
 class TaskPanel:
     """Background HTTP server showing the current exam's task sheet."""
 
-    def __init__(self, state_provider, port=DEFAULT_PORT, bind='0.0.0.0'):
+    def __init__(self, state_provider, controller=None, port=DEFAULT_PORT,
+                 bind='0.0.0.0', token=None):
         self.state_provider = state_provider
+        # Optional: object exposing request_validate / file_dispute /
+        # reset_lab / list_disputes. Without it those endpoints answer 501.
+        self.controller = controller
         self.port = port
         self.bind = bind
+        # Pass token='' to disable auth (tests only). Otherwise every request
+        # must present this value.
+        self.token = secrets.token_urlsafe(16) if token is None else token
         self._httpd = None
         self._thread = None
 
@@ -329,6 +427,8 @@ class TaskPanel:
                            self.bind, self.port, e)
             return []
         httpd.state_provider = self.state_provider
+        httpd.controller = self.controller
+        httpd.token = self.token
         httpd.daemon_threads = True
         self._httpd = httpd
         self._thread = threading.Thread(target=httpd.serve_forever,
@@ -337,12 +437,20 @@ class TaskPanel:
         return self.urls()
 
     def urls(self):
+        """Reachable URLs, each carrying the session token.
+
+        The token is in the URL rather than a separate secret to type,
+        because an exam candidate should be able to click once and start.
+        """
         if not self.running:
             return []
         port = self._httpd.server_address[1]
+        suffix = ('?t=%s' % self.token) if self.token else ''
         if self.bind in ('127.0.0.1', 'localhost'):
-            return ['http://127.0.0.1:%d/' % port]
-        return _local_addresses(port)
+            bases = ['http://127.0.0.1:%d/' % port]
+        else:
+            bases = _local_addresses(port)
+        return [b + suffix for b in bases]
 
     def stop(self):
         if not self.running:
@@ -357,7 +465,8 @@ class TaskPanel:
             self._thread = None
 
 
-def start_for_session(session, port=DEFAULT_PORT, bind='0.0.0.0'):
+def start_for_session(session, controller=None, port=DEFAULT_PORT,
+                      bind='0.0.0.0'):
     """Start a panel backed by a live ExamSession. Never raises."""
     def provider():
         remaining = None
@@ -366,10 +475,16 @@ def start_for_session(session, port=DEFAULT_PORT, bind='0.0.0.0'):
             remaining = exam_clock.remaining_seconds()
         except Exception:
             pass
-        return build_state(getattr(session, 'tasks', []), remaining)
+        state = build_state(getattr(session, 'tasks', []), remaining)
+        # Grading state lives on the session so the panel and the terminal
+        # always agree about what has been submitted and what it scored.
+        state['status'] = getattr(session, 'panel_status', 'in_progress')
+        state['results'] = getattr(session, 'panel_results', None)
+        state['can_control'] = controller is not None
+        return state
 
     try:
-        panel = TaskPanel(provider, port=port, bind=bind)
+        panel = TaskPanel(provider, controller=controller, port=port, bind=bind)
         urls = panel.start()
         return (panel, urls) if urls else (None, [])
     except Exception as e:
@@ -548,6 +663,66 @@ PAGE_HTML = """<!doctype html>
   kbd { font:inherit; font-size:11px; padding:1.5px 6px; border-radius:5px;
         background:var(--panel2); border:1px solid var(--edge2); color:var(--dim); }
 
+  /* actions + results */
+  .actions { display:flex; flex-direction:column; gap:8px; }
+  .btn {
+    font:inherit; font-size:13.5px; padding:10px 14px; border-radius:10px;
+    border:1px solid var(--edge2); background:var(--panel); color:var(--ink);
+    cursor:pointer; text-align:center; transition:background .12s,border-color .12s;
+  }
+  .btn:hover:not(:disabled) { border-color:var(--accent); background:var(--panel2); }
+  .btn:disabled { opacity:.45; cursor:default; }
+  .btn.primary { background:var(--accent); border-color:var(--accent); color:#fff; }
+  .btn.primary:hover:not(:disabled) { filter:brightness(1.08); background:var(--accent); }
+  .btn.danger { color:var(--crit); border-color:color-mix(in srgb,var(--crit) 45%,transparent); }
+  .btn.danger:hover:not(:disabled) { background:color-mix(in srgb,var(--crit) 12%,transparent);
+                                     border-color:var(--crit); }
+
+  .banner {
+    border-radius:12px; padding:13px 16px; margin-bottom:14px; font-size:14px;
+    border:1px solid var(--edge); background:var(--panel);
+  }
+  .banner.ok { border-color:var(--done); background:color-mix(in srgb,var(--done) 12%,transparent); }
+  .banner.bad { border-color:var(--crit); background:color-mix(in srgb,var(--crit) 12%,transparent); }
+  .banner.busy { border-color:var(--accent); background:color-mix(in srgb,var(--accent) 12%,transparent); }
+  .banner b { display:block; font-size:16px; margin-bottom:3px; }
+
+  .scoreline { display:flex; align-items:baseline; gap:12px; margin-bottom:14px; }
+  .scorebig { font-size:30px; font-weight:660; font-variant-numeric:tabular-nums; }
+  .verdict { font-size:14px; font-weight:600; padding:3px 12px; border-radius:99px; }
+  .verdict.pass { color:var(--done); background:color-mix(in srgb,var(--done) 15%,transparent); }
+  .verdict.fail { color:var(--crit); background:color-mix(in srgb,var(--crit) 15%,transparent); }
+
+  .check { display:flex; gap:10px; padding:7px 0; font-size:14px;
+           border-top:1px solid var(--edge); }
+  .check:first-child { border-top:0; }
+  .check .mark { width:16px; flex:0 0 16px; font-weight:700; }
+  .check.ok .mark { color:var(--done); }
+  .check.no .mark { color:var(--crit); }
+  .check .msg { flex:1; }
+  .check .pts { color:var(--faint); font-variant-numeric:tabular-nums; font-size:12.5px; }
+
+  /* dialog */
+  .scrim { position:fixed; inset:0; background:rgba(0,0,0,.55); display:grid;
+           place-items:center; padding:20px; z-index:20; }
+  .dialog {
+    background:var(--panel); border:1px solid var(--edge2); border-radius:14px;
+    padding:22px 24px; max-width:620px; width:100%; max-height:86vh; overflow:auto;
+  }
+  .dialog h3 { margin:0 0 6px; font-size:17px; }
+  .dialog p { color:var(--dim); font-size:13.5px; margin:0 0 14px; }
+  .dialog label.row { display:flex; gap:9px; align-items:flex-start; padding:7px 0;
+                      font-size:13.5px; cursor:pointer; }
+  textarea {
+    width:100%; min-height:110px; font:inherit; font-size:14px; padding:11px 13px;
+    border-radius:10px; border:1px solid var(--edge2); background:var(--panel2);
+    color:var(--ink); resize:vertical;
+  }
+  textarea:focus { outline:2px solid var(--accent); outline-offset:1px; }
+  .dialog .foot { display:flex; gap:9px; justify-content:flex-end; margin-top:16px; }
+  .note { font-size:12.5px; color:var(--faint); line-height:1.55; margin-top:10px; }
+  .note code { font-family:ui-monospace,Menlo,monospace; font-size:11.5px; }
+
   .empty { padding:80px 0; text-align:center; color:var(--faint); }
   .empty b { display:block; font-size:16px; color:var(--dim); margin-bottom:6px;
              font-weight:550; }
@@ -582,15 +757,22 @@ PAGE_HTML = """<!doctype html>
         <div class="stat"><b id="nleft">0</b><span>left</span></div>
       </div>
     </div>
+    <div class="actions">
+      <button class="btn primary" id="submit">Submit for grading</button>
+      <button class="btn danger" id="resetlab">Reset lab environment</button>
+    </div>
+
     <div class="side-foot">
-      <div class="side-note">Ticks here are your own notes. Grading runs
-        against real system state when you return to the terminal.</div>
+      <div class="side-note">Ticks are your own notes — they do not affect
+        grading. Submitting runs the real validators against this system.</div>
       <button id="theme"><span id="themeicon">&#9789;</span><span id="themetext">Dark</span></button>
     </div>
   </aside>
 
   <main>
+    <div id="banner"></div>
     <div class="topbar" id="topbar"></div>
+    <div id="results"></div>
     <div id="list">
       <div class="empty"><b>Waiting for an exam to start</b>
         Start one in the terminal &mdash; this panel follows it.</div>
@@ -598,15 +780,41 @@ PAGE_HTML = """<!doctype html>
     <div class="keys" id="keys"></div>
   </main>
 </div>
+<div id="modal"></div>
 
 <script>
 (function () {
   var state = { tasks: [] };
   var open = {};             // task id -> drawer expanded
+  var openResult = {};       // task id -> result drawer expanded
   var sel = 0;               // keyboard cursor, 0-based
   var localRemaining = null; // ticks locally between polls
+  var busy = false;          // an action is in flight
+  var flash = null;          // {kind, title, body} shown as a banner
 
   var $ = function (id) { return document.getElementById(id); };
+
+  // The session token arrives in the URL the exam printed. Keep it out of
+  // later requests' query strings by sending it as a header instead.
+  var TOKEN = (new URLSearchParams(location.search)).get('t') || '';
+
+  function api(path, opts) {
+    opts = opts || {};
+    opts.headers = Object.assign({'Content-Type': 'application/json'},
+                                 opts.headers || {});
+    if (TOKEN) opts.headers['X-Panel-Token'] = TOKEN;
+    return fetch(path, opts).then(function (r) {
+      return r.json().catch(function () { return {}; }).then(function (body) {
+        if (!r.ok) throw new Error(body.error || ('HTTP ' + r.status));
+        return body;
+      });
+    });
+  }
+
+  function setFlash(kind, title, body) {
+    flash = { kind: kind, title: title, body: body || '' };
+    render();
+  }
 
   // ── theme ───────────────────────────────────────────────────────────
   // Follows the OS until the viewer picks one, then remembers the choice.
@@ -663,6 +871,70 @@ PAGE_HTML = """<!doctype html>
                             : localRemaining <= 900 ? ' warn' : '');
   }
 
+  function renderBanner() {
+    var el = $('banner');
+    if (flash) {
+      el.innerHTML = '<div class="banner ' + flash.kind + '"><b>'
+        + esc(flash.title) + '</b>' + esc(flash.body) + '</div>';
+      return;
+    }
+    if (state.status === 'validating') {
+      el.innerHTML = '<div class="banner busy"><b>Validating…</b>'
+        + 'Running the checks against this system. Watch the terminal for '
+        + 'progress; results appear here when it finishes.</div>';
+      return;
+    }
+    el.innerHTML = '';
+  }
+
+  function renderResults() {
+    var el = $('results');
+    var r = state.results;
+    if (!r) { el.innerHTML = ''; return; }
+
+    var head = ''
+      + '<div class="scoreline">'
+      +   '<span class="scorebig">' + r.score + ' / ' + r.max_score + '</span>'
+      +   '<span class="verdict ' + (r.passed ? 'pass' : 'fail') + '">'
+      +     (r.passed ? 'PASS' : 'FAIL') + ' \u00b7 ' + r.percentage + '%</span>'
+      + '</div>'
+      + '<div class="keys" style="margin:0 0 12px">Open a task to see every '
+      +   'check and dispute a result you think is wrong.</div>';
+
+    var rows = (r.tasks || []).map(function (t, i) {
+      var isOpen = !!openResult[t.task_id];
+      var checks = (t.checks || []).map(function (c) {
+        return '<div class="check ' + (c.passed ? 'ok' : 'no') + '">'
+          + '<span class="mark">' + (c.passed ? '\u2713' : '\u2717') + '</span>'
+          + '<span class="msg">' + esc(c.message || c.name) + '</span>'
+          + '<span class="pts">' + c.points + '/' + c.max_points + '</span>'
+          + '</div>';
+      }).join('');
+
+      return ''
+        + '<div class="item' + (isOpen ? ' open' : '') + '" data-r="' + i + '">'
+        +   '<div class="row" data-act="rtoggle">'
+        +     '<span class="chev"></span>'
+        +     '<span class="label">Task ' + (i + 1 < 10 ? '0' : '') + (i + 1) + '</span>'
+        +     '<span class="cat">' + esc(t.category) + '</span>'
+        +     '<span class="rowpts">' + t.score + '/' + t.max_score + ' pts</span>'
+        +     '<span class="verdict ' + (t.passed ? 'pass' : 'fail') + '">'
+        +       (t.passed ? 'PASS' : 'FAIL') + '</span>'
+        +   '</div>'
+        +   '<div class="drawer">'
+        +     '<div class="desc mono">' + esc(t.description) + '</div>'
+        +     '<div style="margin-top:14px">' + checks + '</div>'
+        +     '<div class="nav">'
+        +       '<button class="btn" data-act="dispute" data-task="'
+        +         esc(t.task_id) + '">Dispute this result</button>'
+        +     '</div>'
+        +   '</div>'
+        + '</div>';
+    }).join('');
+
+    el.innerHTML = head + rows;
+  }
+
   function render() {
     var ts = state.tasks || [];
     var done = state.done_count || 0;
@@ -670,6 +942,29 @@ PAGE_HTML = """<!doctype html>
     $('nrev').textContent = state.revisit_count || 0;
     $('nleft').textContent = Math.max(0, ts.length - done);
     $('progfill').style.width = ts.length ? (done / ts.length * 100) + '%' : '0%';
+
+    renderBanner();
+    renderResults();
+
+    var graded = state.status === 'complete';
+    var sb = $('submit');
+    if (sb) {
+      sb.disabled = busy || graded || state.status === 'validating' || !ts.length
+                    || !state.can_control;
+      sb.textContent = graded ? 'Graded' :
+        (state.status === 'validating' ? 'Validating\u2026' : 'Submit for grading');
+    }
+    var rb = $('resetlab');
+    if (rb) rb.disabled = busy || !state.can_control;
+
+    if (graded) {
+      // Results carry the task text and are numbered the same way, so
+      // keeping the question sheet below them just showed everything twice.
+      $('topbar').innerHTML = '';
+      $('keys').innerHTML = '';
+      $('list').innerHTML = '';
+      return;
+    }
 
     if (!ts.length) {
       $('topbar').innerHTML = '';
@@ -733,11 +1028,10 @@ PAGE_HTML = """<!doctype html>
     state.done_count = ts.filter(function (x) { return x.done; }).length;
     state.revisit_count = ts.filter(function (x) { return x.revisit; }).length;
     render();
-    fetch('/api/mark', {
+    api('/api/mark', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: t.id, field: field, value: value })
-    }).catch(function () { /* panel is advisory; ignore */ });
+    }).catch(function () { /* marks are advisory; ignore */ });
   }
 
   function toggle(i) {
@@ -756,8 +1050,113 @@ PAGE_HTML = """<!doctype html>
     if (el) el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
   }
 
+  // ── actions ─────────────────────────────────────────────────────────
+
+  function submitForGrading() {
+    if (busy) return;
+    if (!confirm('Submit for grading?\\n\\nThe validators will run against '
+                 + 'this system now. You cannot un-submit.')) return;
+    busy = true;
+    render();
+    api('/api/validate', { method: 'POST' })
+      .then(function (res) {
+        state.status = res.status || 'validating';
+        setFlash('busy', 'Submitted',
+                 'Grading is running on the exam host. Results appear here '
+                 + 'when it finishes.');
+      })
+      .catch(function (e) { setFlash('bad', 'Could not submit', e.message); })
+      .then(function () { busy = false; render(); });
+  }
+
+  function resetLab() {
+    if (busy) return;
+    if (!confirm('Reset the lab environment?\\n\\nThis clears practice mounts, '
+                 + 'loop devices and leftover task artifacts. It is refused '
+                 + 'while an exam is in progress.')) return;
+    busy = true;
+    render();
+    api('/api/reset-lab', { method: 'POST',
+                            body: JSON.stringify({ confirm: true }) })
+      .then(function (res) {
+        if (res.ok) setFlash('ok', 'Lab reset', res.message || '');
+        else setFlash('bad', 'Reset refused', res.error || '');
+      })
+      .catch(function (e) { setFlash('bad', 'Reset failed', e.message); })
+      .then(function () { busy = false; render(); });
+  }
+
+  function closeModal() { $('modal').innerHTML = ''; }
+
+  function openDispute(taskId) {
+    var r = state.results || {};
+    var task = (r.tasks || []).filter(function (t) {
+      return t.task_id === taskId; })[0];
+    if (!task) return;
+
+    var rows = (task.checks || []).map(function (c, i) {
+      return '<label class="row"><input type="checkbox" data-check="'
+        + esc(c.name) + '"' + (c.passed ? '' : ' checked') + '>'
+        + '<span>' + (c.passed ? '\u2713' : '\u2717') + ' '
+        + esc(c.message || c.name) + '</span></label>';
+    }).join('');
+
+    $('modal').innerHTML = ''
+      + '<div class="scrim" data-act="scrim"><div class="dialog">'
+      +   '<h3>Dispute a checker result</h3>'
+      +   '<p>' + esc(task.task_id) + ' \u00b7 scored ' + task.score + '/'
+      +     task.max_score + '. Tick the checks you believe are wrong.</p>'
+      +   rows
+      +   '<p style="margin:14px 0 6px">Why is the checker wrong? Be specific '
+      +     '\u2014 the reviewer reads this against the captured evidence.</p>'
+      +   '<textarea id="disputearg" placeholder="e.g. The check greps for '
+      +     'ext4 but the task asked for xfs, so a correct answer fails."></textarea>'
+      +   '<label class="row" style="margin-top:10px">'
+      +     '<input type="checkbox" id="disputesubmit" checked>'
+      +     '<span>Open a GitHub issue as well as saving locally</span></label>'
+      +   '<div class="note">The report is written to <code>data/disputes/</code> '
+      +     'first, so the evidence survives even if submitting fails. If an '
+      +     'issue is opened, the AI reviewer posts its verdict as a comment '
+      +     'there \u2014 it does not come back into this panel.</div>'
+      +   '<div class="foot">'
+      +     '<button class="btn" data-act="cancel">Cancel</button>'
+      +     '<button class="btn primary" data-act="filedispute" data-task="'
+      +       esc(taskId) + '">File dispute</button>'
+      +   '</div>'
+      + '</div></div>';
+  }
+
+  function fileDispute(taskId) {
+    var boxes = document.querySelectorAll('[data-check]');
+    var checks = [];
+    for (var i = 0; i < boxes.length; i++) {
+      if (boxes[i].checked) checks.push(boxes[i].getAttribute('data-check'));
+    }
+    var argument = ($('disputearg') || {}).value || '';
+    var submit = ($('disputesubmit') || {}).checked;
+
+    if (!checks.length) { alert('Tick at least one check to dispute.'); return; }
+    if (!argument.trim()) { alert('Explain why the checker is wrong.'); return; }
+
+    busy = true;
+    closeModal();
+    render();
+    api('/api/dispute', {
+      method: 'POST',
+      body: JSON.stringify({ task_id: taskId, checks: checks,
+                             argument: argument, submit: submit })
+    }).then(function (res) {
+      if (!res.ok) { setFlash('bad', 'Dispute not filed', res.error || ''); return; }
+      var body = 'Saved to ' + res.saved_to + '. ' + (res.message || '');
+      if (res.issue_url) body += ' ' + res.issue_url;
+      setFlash(res.submitted ? 'ok' : 'busy', 'Dispute filed', body);
+    }).catch(function (e) {
+      setFlash('bad', 'Dispute failed', e.message);
+    }).then(function () { busy = false; render(); });
+  }
+
   function poll() {
-    fetch('/api/state').then(function (r) { return r.json(); }).then(function (s) {
+    api('/api/state').then(function (s) {
       state = s;
       if (typeof s.remaining_seconds === 'number') localRemaining = s.remaining_seconds;
       else if (s.remaining_seconds === null) localRemaining = null;
@@ -767,6 +1166,33 @@ PAGE_HTML = """<!doctype html>
   }
 
   document.addEventListener('click', function (e) {
+    if (e.target.id === 'submit') { submitForGrading(); return; }
+    if (e.target.id === 'resetlab') { resetLab(); return; }
+
+    var act = e.target.getAttribute && e.target.getAttribute('data-act');
+    if (act === 'cancel' || act === 'scrim') {
+      if (act === 'scrim' && e.target !== e.currentTarget
+          && !e.target.classList.contains('scrim')) return;
+      closeModal();
+      return;
+    }
+    if (act === 'filedispute') {
+      fileDispute(e.target.getAttribute('data-task'));
+      return;
+    }
+    if (act === 'dispute') {
+      openDispute(e.target.getAttribute('data-task'));
+      return;
+    }
+
+    var rhost = e.target.closest('[data-r]');
+    if (rhost && e.target.closest('[data-act="rtoggle"]')) {
+      var ri = parseInt(rhost.getAttribute('data-r'), 10);
+      var rt = ((state.results || {}).tasks || [])[ri];
+      if (rt) { openResult[rt.task_id] = !openResult[rt.task_id]; render(); }
+      return;
+    }
+
     if (e.target.id === 'toggleall') {
       var ts = state.tasks || [];
       var anyOpen = ts.some(function (t) { return open[t.id]; });
@@ -791,6 +1217,10 @@ PAGE_HTML = """<!doctype html>
   });
 
   document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') { closeModal(); return; }
+    // Never steal keys while the candidate is typing their dispute.
+    if (e.target && (e.target.tagName === 'TEXTAREA'
+                     || e.target.tagName === 'INPUT')) return;
     if (e.metaKey || e.ctrlKey || e.altKey) return;
     var t = (state.tasks || [])[sel];
     var k = e.key;

--- a/tests/unit/test_task_gui.py
+++ b/tests/unit/test_task_gui.py
@@ -43,26 +43,69 @@ def tasks():
     ]
 
 
+TOKEN = 'test-token-abc123'
+
+
+class FakeController:
+    """Records what the panel asked for, without doing any of it."""
+
+    def __init__(self):
+        self.calls = []
+        self.reset_allowed = True
+
+    def request_validate(self):
+        self.calls.append(('request_validate',))
+        return {'queued': True, 'status': 'validating'}
+
+    def file_dispute(self, task_id, check_names, argument, submit=True):
+        self.calls.append(('file_dispute', task_id, tuple(check_names),
+                           argument, submit))
+        return {'saved_to': f'/var/lib/disputes/{task_id}.md',
+                'submitted': submit, 'issue_url': 'https://example/issues/1'}
+
+    def reset_lab(self, confirm=False):
+        self.calls.append(('reset_lab', confirm))
+        if not confirm:
+            return {'ok': False, 'error': 'confirmation required'}
+        return {'ok': True, 'message': 'lab reset'}
+
+    def list_disputes(self):
+        self.calls.append(('list_disputes',))
+        return {'disputes': []}
+
+
 @pytest.fixture
-def panel(tasks):
-    """A live panel on an ephemeral loopback port."""
+def controller():
+    return FakeController()
+
+
+@pytest.fixture
+def panel(tasks, controller):
+    """A live panel on an ephemeral loopback port, with auth enabled."""
     p = task_gui.TaskPanel(lambda: task_gui.build_state(tasks, 3600),
-                           port=0, bind='127.0.0.1')
+                           controller=controller, port=0, bind='127.0.0.1',
+                           token=TOKEN)
     urls = p.start()
     assert urls, "panel failed to bind"
-    yield p, urls[0].rstrip('/')
+    base = urls[0].split('?')[0].rstrip('/')
+    yield p, base
     p.stop()
 
 
-def _get(base, path):
-    with urllib.request.urlopen(base + path, timeout=5) as r:
+def _get(base, path, token=TOKEN):
+    headers = {'X-Panel-Token': token} if token is not None else {}
+    req = urllib.request.Request(base + path, headers=headers)
+    with urllib.request.urlopen(req, timeout=5) as r:
         return r.status, r.read().decode()
 
 
-def _post(base, path, payload):
+def _post(base, path, payload, token=TOKEN):
+    headers = {'Content-Type': 'application/json'}
+    if token is not None:
+        headers['X-Panel-Token'] = token
     req = urllib.request.Request(
         base + path, data=json.dumps(payload).encode(),
-        headers={'Content-Type': 'application/json'}, method='POST')
+        headers=headers, method='POST')
     with urllib.request.urlopen(req, timeout=5) as r:
         return r.status, json.loads(r.read().decode())
 
@@ -202,10 +245,11 @@ def test_unknown_route_is_404(panel):
     assert e.value.code == 404
 
 
-def test_panel_serves_no_shell_or_validation_route(panel):
-    """The panel is read-mostly by design: exam questions and ticks only."""
+def test_panel_exposes_no_shell_route(panel):
+    """The panel drives the session through named actions only — there is no
+    general command channel, and never should be."""
     _, base = panel
-    for path in ('/api/validate', '/api/exec', '/api/grade', '/shell'):
+    for path in ('/api/exec', '/api/run', '/api/command', '/shell'):
         with pytest.raises(urllib.error.HTTPError) as e:
             _get(base, path)
         assert e.value.code == 404, path
@@ -218,10 +262,10 @@ def test_state_provider_failure_degrades_instead_of_500(tasks):
     def boom():
         raise RuntimeError("session went away")
 
-    p = task_gui.TaskPanel(boom, port=0, bind='127.0.0.1')
+    p = task_gui.TaskPanel(boom, port=0, bind='127.0.0.1', token='')
     urls = p.start()
     try:
-        status, body = _get(urls[0].rstrip('/'), '/api/state')
+        status, body = _get(urls[0].rstrip('/'), '/api/state', token=None)
         assert status == 200
         assert json.loads(body)['tasks'] == []
     finally:
@@ -230,12 +274,12 @@ def test_state_provider_failure_degrades_instead_of_500(tasks):
 
 def test_port_already_in_use_returns_no_urls(tasks):
     first = task_gui.TaskPanel(lambda: task_gui.build_state(tasks),
-                               port=0, bind='127.0.0.1')
+                               port=0, bind='127.0.0.1', token='')
     assert first.start()
     port = first._httpd.server_address[1]
     try:
         second = task_gui.TaskPanel(lambda: task_gui.build_state(tasks),
-                                    port=port, bind='127.0.0.1')
+                                    port=port, bind='127.0.0.1', token='')
         assert second.start() == [], "should fail quietly, not raise"
         assert second.running is False
     finally:
@@ -244,7 +288,7 @@ def test_port_already_in_use_returns_no_urls(tasks):
 
 def test_stop_is_idempotent(tasks):
     p = task_gui.TaskPanel(lambda: task_gui.build_state(tasks),
-                           port=0, bind='127.0.0.1')
+                           port=0, bind='127.0.0.1', token='')
     p.start()
     p.stop()
     p.stop()
@@ -259,10 +303,13 @@ def test_start_for_session_never_raises():
 
     panel, urls = task_gui.start_for_session(BadSession(), port=0,
                                              bind='127.0.0.1')
+    if panel:
+        panel.token = panel.token  # keep the generated token for the request
     try:
         # It binds fine; the failure only shows up per-request, degraded.
         if urls:
-            status, body = _get(urls[0].rstrip('/'), '/api/state')
+            base = urls[0].split('?')[0].rstrip('/')
+            status, body = _get(base, '/api/state', token=panel.token)
             assert status == 200
             assert json.loads(body)['tasks'] == []
     finally:
@@ -391,3 +438,107 @@ def test_theme_toggle_present_and_overrides_the_os_preference(panel):
     # The OS preference must not beat an explicit choice.
     assert ':root:not([data-theme])' in body
     assert 'localStorage' in body
+
+
+# ── authentication ──────────────────────────────────────────────────────────
+
+def test_requests_without_the_token_are_refused(panel):
+    """The panel binds 0.0.0.0 by default and can now reset the lab and file
+    GitHub issues — reachability is not authorisation."""
+    _, base = panel
+    for path in ('/', '/api/state'):
+        with pytest.raises(urllib.error.HTTPError) as e:
+            _get(base, path, token=None)
+        assert e.value.code == 403, path
+
+
+def test_wrong_token_refused(panel):
+    _, base = panel
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _get(base, '/api/state', token='not-the-token')
+    assert e.value.code == 403
+
+
+def test_control_endpoints_require_the_token(panel, controller):
+    _, base = panel
+    for path, body in [('/api/validate', {}),
+                       ('/api/reset-lab', {'confirm': True}),
+                       ('/api/dispute', {'task_id': 'x', 'argument': 'y'})]:
+        with pytest.raises(urllib.error.HTTPError) as e:
+            _post(base, path, body, token=None)
+        assert e.value.code == 403, path
+    assert controller.calls == [], "an unauthorised request reached the controller"
+
+
+def test_token_accepted_in_the_query_string(panel):
+    """The URL the exam prints carries ?t=, so a plain browser GET works."""
+    _, base = panel
+    status, _ = _get(base + f'/api/state?t={TOKEN}', '', token=None)
+    assert status == 200
+
+
+def test_urls_carry_the_token(tasks, controller):
+    p = task_gui.TaskPanel(lambda: task_gui.build_state(tasks),
+                           controller=controller, port=0, bind='127.0.0.1')
+    try:
+        urls = p.start()
+        assert urls and all('?t=' in u for u in urls)
+        assert len(p.token) >= 16
+    finally:
+        p.stop()
+
+
+# ── control actions ─────────────────────────────────────────────────────────
+
+def test_submit_queues_validation(panel, controller):
+    _, base = panel
+    status, body = _post(base, '/api/validate', {})
+    assert status == 200
+    assert body['queued'] is True
+    assert ('request_validate',) in controller.calls
+
+
+def test_reset_requires_confirmation(panel, controller):
+    """Destructive, and reachable over the network — it must not fire on a
+    bare request."""
+    _, base = panel
+    _, body = _post(base, '/api/reset-lab', {})
+    assert body['ok'] is False
+    assert 'confirm' in body['error'].lower()
+
+    _, body = _post(base, '/api/reset-lab', {'confirm': True})
+    assert body['ok'] is True
+
+
+def test_dispute_passes_checks_and_argument_through(panel, controller):
+    _, base = panel
+    _, body = _post(base, '/api/dispute', {
+        'task_id': 'lvm_001', 'checks': ['size_correct'],
+        'argument': 'the check greps for the wrong fs', 'submit': False})
+    assert body['saved_to'].endswith('lvm_001.md')
+    call = [c for c in controller.calls if c[0] == 'file_dispute'][0]
+    assert call[1] == 'lvm_001'
+    assert call[2] == ('size_correct',)
+    assert call[4] is False
+
+
+def test_actions_report_501_without_a_controller(tasks):
+    """A panel with no controller must say so rather than pretend it acted."""
+    p = task_gui.TaskPanel(lambda: task_gui.build_state(tasks),
+                           port=0, bind='127.0.0.1', token='')
+    try:
+        p.start()
+        base = p.urls()[0].split('?')[0].rstrip('/')
+        with pytest.raises(urllib.error.HTTPError) as e:
+            _post(base, '/api/validate', {}, token=None)
+        assert e.value.code == 501
+    finally:
+        p.stop()
+
+
+def test_page_exposes_the_control_ui(panel):
+    _, base = panel
+    _, body = _get(base, '/')
+    for marker in ('id="submit"', 'id="resetlab"', 'data-act="dispute"',
+                   'X-Panel-Token'):
+        assert marker in body, marker


### PR DESCRIPTION
The panel showed the question sheet and nothing else. It can now drive the session, which is the point of having it open beside your terminals.

- **Submit for grading** from the panel or the terminal.
- **Results** — score, verdict, and every check with its message and points, per task.
- **Dispute a result** — tick the checks you believe are wrong, say why, file it.
- **Reset lab environment.**

## ⚠️ This changes the panel's security posture — please read

The panel was read-only, which is why it could afford to be unauthenticated on a listener that **binds `0.0.0.0` by default** (so a headless exam VM can be read from your laptop). Now that it can reset the lab and open GitHub issues, "whoever can reach the port" is not an acceptable authorisation rule — anyone on the LAN could have wiped an exam mid-session.

So every request now carries a **per-session token**, minted at panel start, embedded in the printed URL, compared with `secrets.compare_digest`. Requests without it get 403 and **never reach the controller** (asserted by test, not just by inspection).

Reset is gated twice on top of that: the caller must confirm, *and* it refuses outright while an exam is in progress, because resetting then would delete the state being graded.

The panel calls named actions in the new `core/panel_control.py` and nothing else. There is deliberately no general command channel, and a test asserts `/api/exec` and friends stay 404. If you'd rather the default bind were loopback now that it's a control surface, say so — one line.

## Threading

`request_validate()` only sets an Event; the main exam thread does the grading. That means one grader whichever button was pressed, and validators never run on an HTTP worker thread where they'd race the terminal.

**A regression this surfaced:** `input()` now runs on a reader thread so a panel submit can interrupt the wait — which meant `KeyboardInterrupt` stopped propagating, and **Ctrl-C at the submit prompt would have graded the exam instead of quitting it.** The exception is now captured and re-raised on the main thread. The existing `test_session_teardown` test caught this, which is a good argument for it existing.

## Disputes

Matching how disputes actually work: the report is written to `data/disputes/` **before any network call**, so evidence survives a failed submit. If an issue is opened, the AI reviewer's verdict arrives as a comment *there* and does not flow back into the simulator — the UI says so explicitly and surfaces the issue URL, rather than leaving someone waiting for a result that will never appear in the panel.

There's also a `/api/disputes` endpoint listing reports filed on the box, which partly closes the "no way to see what you've filed" gap. Verdicts still live on GitHub.

## Verification

Driven in a real browser against a seeded session, not just asserted in tests: results render, a drawer shows per-check pass/fail with points, the dispute dialog pre-ticks the failed checks and leaves passing ones alone, and filing one reports the local path and the issue URL.

That also caught a bug tests wouldn't have: `\n` escapes in the JS were being consumed by the Python string before reaching the browser, producing a `SyntaxError` that blanked the whole page. Fixed, and it's why the page is now checked by loading it rather than only by asserting on markup.

Tests: **382 passed, 1 failed** — `test_generates_correct_count`, which fails on unmodified `master` too (needs root for `/var/lib/rhcsa-simulator`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cp8gGc1CQ3UjdopTWsUmSd