### PR TITLE
Make the task panel the default in every mode, not just exam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,11 @@ python3 -m pytest -v            # Verbose output
 
 - `rhcsa_simulator.py` — Main entry point
 - `core/` — Engine: task manager, exam loop, SM-2 spaced repetition, ResultsDB
-- `core/task_gui.py` — task panel, **on by default for exam mode**
-  (`--no-gui` opts out), mirroring how the real exam presents questions: a
+- `core/task_gui.py` — task panel, **on by default in every mode** (exam,
+  quick, practice, adaptive, and learn's "Practice this topic"); `--no-gui`
+  opts out, and a panel that fails to bind falls back to the terminal sheet
+  automatically. `open_panel()`/`close_panel()` are the shared lifecycle
+  every mode uses. Mirrors how the real exam presents questions: a
   collapsed task list that opens in place, Revisit/Done ticks, countdown.
   (The real exam's is a native app; we serve ours over HTTP to a browser
   because that needs nothing installed and works on a headless VM. Don't

--- a/core/adaptive.py
+++ b/core/adaptive.py
@@ -21,9 +21,15 @@ logger = logging.getLogger(__name__)
 class AdaptiveMode:
     """SM-2 driven adaptive practice session."""
 
-    def __init__(self):
+    def __init__(self, gui_port=None, gui_bind='0.0.0.0'):
         self.db = get_results_db()
         self.tasks_per_session = 5
+        # Task panel — same window every other mode uses, on by default;
+        # None (--no-gui) falls back to the terminal only.
+        self.gui_port = gui_port
+        self.gui_bind = gui_bind
+        self.tasks = []
+        self.panel = None
 
     def start(self):
         """Start an adaptive practice session."""
@@ -68,6 +74,10 @@ class AdaptiveMode:
         if not confirm_action("Ready to start?", default=True):
             return
 
+        self.tasks = tasks
+        from core import task_gui
+        self.panel = task_gui.open_panel(self.tasks, self.gui_port, self.gui_bind)
+
         # Reset the box to a clean, practice-ready state (fresh loop disks +
         # remove leftover artifacts) just like exam mode does at start, and
         # offer to install any packages the drawn tasks rely on.
@@ -86,6 +96,8 @@ class AdaptiveMode:
             # However the session ends (finished, quit, or Ctrl-C), leave a
             # clean box — reverse any still-active setup and remove artifacts.
             task_env.session_teardown(tasks)
+            task_gui.close_panel(self.panel)
+            self.panel = None
 
         # Show session summary
         if results:
@@ -354,7 +366,7 @@ class AdaptiveMode:
         input("Press Enter to return to menu...")
 
 
-def run_adaptive_mode():
+def run_adaptive_mode(gui_port=None, gui_bind='0.0.0.0'):
     """Run adaptive mode (convenience function)."""
-    mode = AdaptiveMode()
+    mode = AdaptiveMode(gui_port=gui_port, gui_bind=gui_bind)
     mode.start()

--- a/core/exam.py
+++ b/core/exam.py
@@ -148,55 +148,13 @@ class ExamSession:
         """Serve the task sheet to a window beside the candidate's terminals.
         Best-effort: a panel that won't start must never prevent an exam from
         running."""
-        if not self.gui_port:
-            return
         from core import task_gui
-        task_gui.clear_marks()
-        self.panel, urls = task_gui.start_for_session(
-            self, port=self.gui_port, bind=self.gui_bind)
-        if not urls:
-            print(fmt.warning(
-                f"\nTask panel could not start on port {self.gui_port} "
-                f"(in use?). Continuing without it — the task sheet below is "
-                f"the same content."))
-            return
-        print()
-        print(fmt.success("Task panel running — open it beside your terminals:"))
-        for url in urls:
-            print(fmt.bold(f"    {url}"))
-        if self.gui_bind not in ('127.0.0.1', 'localhost'):
-            print(fmt.dim("  (Unauthenticated and reachable from your LAN. It "
-                          "serves exam questions only — no shell, no control "
-                          "of this box.)"))
-            # A stock RHEL/Alma box has firewalld up with nothing open, so
-            # the LAN URL above simply won't connect from a laptop. Say so
-            # rather than letting the candidate debug it mid-exam. We never
-            # open the port ourselves — this simulator grades firewall tasks,
-            # and editing firewalld here would corrupt what they check.
-            try:
-                from core import task_gui
-                if task_gui.firewall_blocks(self.gui_port):
-                    print(fmt.warning(
-                        f"  firewalld is blocking port {self.gui_port}, so only "
-                        f"the 127.0.0.1 URL will work from this box."))
-                    print(fmt.dim(
-                        f"    Reach it from another machine either by "
-                        f"forwarding it over SSH (leaves the firewall alone):\n"
-                        f"      ssh -L {self.gui_port}:127.0.0.1:"
-                        f"{self.gui_port} root@<this-box>\n"
-                        f"    or by opening the port yourself. Note that this "
-                        f"exam may contain firewall tasks, so the simulator "
-                        f"will not change firewalld for you."))
-            except Exception:
-                pass
+        self.panel = task_gui.open_panel(self.tasks, self.gui_port, self.gui_bind)
 
     def _stop_task_panel(self):
-        if self.panel:
-            try:
-                self.panel.stop()
-            except Exception:
-                pass
-            self.panel = None
+        from core import task_gui
+        task_gui.close_panel(self.panel)
+        self.panel = None
 
     def _provision_devices(self):
         """Assign a distinct practice device to each whole-disk task so an LVM

--- a/core/learn.py
+++ b/core/learn.py
@@ -14,8 +14,13 @@ logger = logging.getLogger(__name__)
 class LearnMode:
     """Domain-based learn mode with SM-2 indicators and practice integration."""
 
-    def __init__(self):
+    def __init__(self, gui_port=None, gui_bind='0.0.0.0'):
         self._db = None
+        # Task panel — same window every other mode uses, on by default;
+        # None (--no-gui) falls back to the terminal only. Only relevant
+        # once a "Practice this topic" jump generates a task list.
+        self.gui_port = gui_port
+        self.gui_bind = gui_bind
 
     @property
     def db(self):
@@ -260,14 +265,20 @@ class LearnMode:
                 return
 
             from core.practice import PracticeSession
+            from core import task_gui
 
-            session = PracticeSession()
+            session = PracticeSession(gui_port=self.gui_port, gui_bind=self.gui_bind)
             session.category = category
             session.difficulty = "exam"
             session.task_count = len(tasks)
+            session.tasks = tasks
 
-            for i, task in enumerate(tasks, 1):
-                session._run_practice_task(task, i, len(tasks))
+            session.panel = task_gui.open_panel(tasks, self.gui_port, self.gui_bind)
+            try:
+                for i, task in enumerate(tasks, 1):
+                    session._run_practice_task(task, i, len(tasks))
+            finally:
+                task_gui.close_panel(session.panel)
         except ImportError as e:
             logger.warning(f"Could not launch practice: {e}")
             print(fmt.warning("Practice mode not available."))
@@ -278,13 +289,13 @@ class LearnMode:
             input("Press Enter to continue...")
 
 
-def run_learn_mode(category=None):
+def run_learn_mode(category=None, gui_port=None, gui_bind='0.0.0.0'):
     """Run learn mode (convenience function).
 
     Args:
         category: Optional category to jump directly to
     """
-    mode = LearnMode()
+    mode = LearnMode(gui_port=gui_port, gui_bind=gui_bind)
     if category:
         mode._display_topic(category)
     else:

--- a/core/practice.py
+++ b/core/practice.py
@@ -26,11 +26,17 @@ logger = logging.getLogger(__name__)
 class PracticeSession:
     """Practice mode session with ResultsDB tracking."""
 
-    def __init__(self):
+    def __init__(self, gui_port=None, gui_bind='0.0.0.0'):
         self.category = None
         self.difficulty = None  # None => prompt in start(); set explicitly to skip prompt
         self.task_count = settings.DEFAULT_PRACTICE_TASKS
         self.skip_reboot = False
+        # Task panel — same window every other mode uses, on by default;
+        # None (--no-gui) falls back to the terminal only.
+        self.gui_port = gui_port
+        self.gui_bind = gui_bind
+        self.tasks = []
+        self.panel = None
 
     def start(self):
         """Start practice session."""
@@ -95,6 +101,10 @@ class PracticeSession:
 
         print(fmt.info(f"\nStarting session…"))
 
+        self.tasks = tasks
+        from core import task_gui
+        self.panel = task_gui.open_panel(self.tasks, self.gui_port, self.gui_bind)
+
         # Reset the box to a clean, practice-ready state (fresh loop disks +
         # remove leftover artifacts) exactly like exam mode does at start, and
         # offer to install any packages the drawn tasks rely on.
@@ -112,6 +122,8 @@ class PracticeSession:
             # However the session ends (finished, quit, or Ctrl-C), leave a
             # clean box — reverse any still-active setup and remove artifacts.
             task_env.session_teardown(tasks)
+            task_gui.close_panel(self.panel)
+            self.panel = None
 
     def _select_category(self):
         """Select practice category."""
@@ -375,7 +387,7 @@ class PracticeSession:
         print()
 
 
-def run_practice_mode():
+def run_practice_mode(gui_port=None, gui_bind='0.0.0.0'):
     """Run practice mode (convenience function)."""
-    session = PracticeSession()
+    session = PracticeSession(gui_port=gui_port, gui_bind=gui_bind)
     session.start()

--- a/core/task_gui.py
+++ b/core/task_gui.py
@@ -357,8 +357,9 @@ class TaskPanel:
             self._thread = None
 
 
-def start_for_session(session, port=DEFAULT_PORT, bind='0.0.0.0'):
-    """Start a panel backed by a live ExamSession. Never raises."""
+def start_for_tasks(get_tasks, port=DEFAULT_PORT, bind='0.0.0.0'):
+    """Start a panel backed by a callable returning the current task list.
+    Never raises."""
     def provider():
         remaining = None
         try:
@@ -366,7 +367,7 @@ def start_for_session(session, port=DEFAULT_PORT, bind='0.0.0.0'):
             remaining = exam_clock.remaining_seconds()
         except Exception:
             pass
-        return build_state(getattr(session, 'tasks', []), remaining)
+        return build_state(get_tasks(), remaining)
 
     try:
         panel = TaskPanel(provider, port=port, bind=bind)
@@ -375,6 +376,71 @@ def start_for_session(session, port=DEFAULT_PORT, bind='0.0.0.0'):
     except Exception as e:
         logger.warning("task panel failed to start: %s", e)
         return (None, [])
+
+
+def start_for_session(session, port=DEFAULT_PORT, bind='0.0.0.0'):
+    """Start a panel backed by a live session exposing a `.tasks` list.
+    Never raises."""
+    return start_for_tasks(lambda: getattr(session, 'tasks', []),
+                            port=port, bind=bind)
+
+
+def open_panel(tasks, port, bind='0.0.0.0'):
+    """Start the task panel for a session's task list and print how to reach
+    it. Shared by every mode (exam/quick/practice/adaptive/learn) so the
+    panel is the same default experience everywhere, with the terminal as
+    the automatic fallback: a panel that won't start must never stop a
+    session, it just prints a warning and the caller carries on without it.
+    Returns the running TaskPanel, or None if disabled or it failed to bind.
+    """
+    if not port:
+        return None
+    from utils import formatters as fmt
+    clear_marks()
+    panel, urls = start_for_tasks(lambda: tasks, port=port, bind=bind)
+    if not urls:
+        print(fmt.warning(
+            f"\nTask panel could not start on port {port} (in use?). "
+            f"Continuing in the terminal — the task text below is the same "
+            f"content."))
+        return None
+    print()
+    print(fmt.success("Task panel running — open it beside your terminals:"))
+    for url in urls:
+        print(fmt.bold(f"    {url}"))
+    if bind not in ('127.0.0.1', 'localhost'):
+        print(fmt.dim("  (Unauthenticated and reachable from your LAN. It "
+                      "serves the task sheet only — no shell, no control "
+                      "of this box.)"))
+        # A stock RHEL/Alma box has firewalld up with nothing open, so the
+        # LAN URL above simply won't connect from a laptop. Say so rather
+        # than letting the candidate debug it mid-session. We never open the
+        # port ourselves — this simulator grades firewall tasks, and editing
+        # firewalld here would corrupt what they check.
+        try:
+            if firewall_blocks(port):
+                print(fmt.warning(
+                    f"  firewalld is blocking port {port}, so only the "
+                    f"127.0.0.1 URL will work from this box."))
+                print(fmt.dim(
+                    f"    Reach it from another machine either by "
+                    f"forwarding it over SSH (leaves the firewall alone):\n"
+                    f"      ssh -L {port}:127.0.0.1:{port} root@<this-box>\n"
+                    f"    or by opening the port yourself. Note that this "
+                    f"session may include firewall tasks, so the simulator "
+                    f"will not change firewalld for you."))
+        except Exception:
+            pass
+    return panel
+
+
+def close_panel(panel):
+    """Stop a panel started by open_panel(), best-effort."""
+    if panel:
+        try:
+            panel.stop()
+        except Exception:
+            pass
 
 
 PAGE_HTML = """<!doctype html>

--- a/rhcsa_simulator.py
+++ b/rhcsa_simulator.py
@@ -27,9 +27,9 @@ def parse_args():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Quick Start Examples:
-  %(prog)s --quick              5 random tasks
+  %(prog)s --quick              5 random tasks (task panel in a window)
   %(prog)s --quick lvm          5 LVM tasks
-  %(prog)s --exam               Full mock exam (task panel in a window)
+  %(prog)s --exam               Full mock exam
   %(prog)s --exam --no-gui      Same, terminal only
   %(prog)s --learn              Domain-based study mode
   %(prog)s --practice lvm       Practice LVM category
@@ -56,20 +56,22 @@ Quick Start Examples:
     parser.add_argument('--import-mode', choices=['replace', 'merge'],
                         default='replace',
                         help='How --import-code applies (default: replace)')
-    # The task panel is ON for exam mode by default: the real exam puts its
+    # The task panel is ON by default in every mode: the real exam puts its
     # questions in a window of their own, so that is the honest default for a
     # simulator. (We serve ours to a browser; Red Hat's is a native app. The
-    # window is the point, not the technology.) --no-gui opts out. Both flags
-    # write the same dest, so whichever comes last wins.
+    # window is the point, not the technology.) --no-gui opts out; if the
+    # panel can't bind (e.g. port in use) it falls back to the terminal sheet
+    # automatically. Both flags write the same dest, so whichever comes last
+    # wins.
     from core.task_gui import DEFAULT_PORT as GUI_PORT
     parser.add_argument('--gui', nargs='?', const=GUI_PORT, type=int,
                         default=GUI_PORT, metavar='PORT',
-                        help=f'Port for the exam task panel (default '
-                             f'{GUI_PORT}). The panel is on by default for '
-                             f'--exam; pass a port only to move it.')
+                        help=f'Port for the task panel (default {GUI_PORT}). '
+                             f'On by default in every mode; pass a port only '
+                             f'to move it.')
     parser.add_argument('--no-gui', dest='gui', action='store_const', const=None,
-                        help='Run the exam in the terminal only, with no '
-                             'task panel window')
+                        help='Run in the terminal only, with no task panel '
+                             'window')
     parser.add_argument('--gui-bind', default='0.0.0.0', metavar='ADDR',
                         help='Address the task panel listens on '
                              '(default 0.0.0.0, so a headless exam VM can be '
@@ -81,9 +83,10 @@ Quick Start Examples:
     return parser.parse_args()
 
 
-def run_quick_practice(category=None):
+def run_quick_practice(category=None, gui_port=None, gui_bind='0.0.0.0'):
     """Run quick practice - a short session (4-20 tasks) with ResultsDB tracking."""
     from tasks.registry import TaskRegistry
+    from core import task_gui
     from core.validator import get_validator
     from core.results_db import get_results_db
     from core import task_env
@@ -128,6 +131,8 @@ def run_quick_practice(category=None):
     # changes are reverted ONCE, at the end of the session (finally below).
     print(fmt.dim("Preparing a clean practice environment..."))
     task_env.prepare_session(tasks)
+
+    panel = task_gui.open_panel(tasks, gui_port, gui_bind)
 
     try:
         for i, task in enumerate(tasks, 1):
@@ -213,6 +218,7 @@ def run_quick_practice(category=None):
         # However the session ends (finished, quit, or Ctrl-C), leave a clean
         # box — reverse all faults/preconditions and remove artifacts.
         task_env.session_teardown(tasks)
+        task_gui.close_panel(panel)
 
     # Summary
     print()
@@ -349,7 +355,7 @@ def main():
 
     # CLI quick modes
     if args.quick:
-        run_quick_practice(args.quick)
+        run_quick_practice(args.quick, gui_port=args.gui, gui_bind=args.gui_bind)
         return 0
 
     if args.exam:
@@ -363,13 +369,13 @@ def main():
             from tasks.registry import TaskRegistry
             TaskRegistry.initialize()
             if args.learn in TaskRegistry.get_all_categories():
-                run_learn_mode(category=args.learn)
+                run_learn_mode(category=args.learn, gui_port=args.gui, gui_bind=args.gui_bind)
             else:
                 print(f"Unknown category: {args.learn}")
                 print("Use --list-categories to see available categories")
                 return 1
         else:
-            run_learn_mode()
+            run_learn_mode(gui_port=args.gui, gui_bind=args.gui_bind)
         return 0
 
     if args.practice:
@@ -377,7 +383,7 @@ def main():
         TaskRegistry.initialize()
         if args.practice in TaskRegistry.get_all_categories():
             from core.practice import PracticeSession
-            session = PracticeSession()
+            session = PracticeSession(gui_port=args.gui, gui_bind=args.gui_bind)
             session.category = args.practice
             session.difficulty = 'exam'
             session.start()
@@ -389,7 +395,7 @@ def main():
 
     if args.adaptive:
         from core.adaptive import run_adaptive_mode
-        run_adaptive_mode()
+        run_adaptive_mode(gui_port=args.gui, gui_bind=args.gui_bind)
         return 0
 
     # Note if a previous session's environment is still in place (expected —
@@ -421,10 +427,10 @@ def main():
             choice = menu.display_main_menu()
 
             if choice == 'learn':
-                run_learn_mode()
+                run_learn_mode(gui_port=args.gui, gui_bind=args.gui_bind)
 
             elif choice == 'quick_practice':
-                run_quick_practice()
+                run_quick_practice(gui_port=args.gui, gui_bind=args.gui_bind)
                 input("\nPress Enter to return to menu...")
 
             elif choice == 'exam':
@@ -432,11 +438,11 @@ def main():
                 input("\nPress Enter to return to menu...")
 
             elif choice == 'practice':
-                run_practice_mode()
+                run_practice_mode(gui_port=args.gui, gui_bind=args.gui_bind)
                 input("\nPress Enter to return to menu...")
 
             elif choice == 'adaptive':
-                run_adaptive_mode()
+                run_adaptive_mode(gui_port=args.gui, gui_bind=args.gui_bind)
 
             elif choice == 'boot_rescue':
                 from core import boot_rescue

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -19,6 +19,7 @@ def _args(**overrides):
         list_categories=False, quick=None, exam=False, learn=None,
         practice=None, adaptive=False,
         export_code=False, import_code=None, import_mode='replace',
+        gui=8080, gui_bind='0.0.0.0',
     )
     defaults.update(overrides)
     return MagicMock(**defaults)
@@ -175,4 +176,4 @@ class TestCLIDispatch:
                 adaptive=False,
             )
             main()
-            mock_quick.assert_called_once_with("all")
+            mock_quick.assert_called_once_with("all", gui_port=8080, gui_bind='0.0.0.0')


### PR DESCRIPTION
## Summary
- The browser task panel (`--gui`, on by default / `--no-gui` opts out) previously only appeared in exam mode. It now opens the same way for quick practice, practice mode, adaptive mode, and learn mode's "Practice this topic" jump.
- If the panel can't bind (port in use, etc.) every mode falls back to the terminal task sheet automatically, exactly like exam mode already did — the panel is never load-bearing.
- Extracted the panel start/print/firewall-warning logic that used to live only in `ExamSession` into shared `task_gui.open_panel()` / `task_gui.close_panel()` helpers so all modes share one implementation instead of duplicating it.

## Test plan
- [x] `pytest` full suite: 372 passed, 1 pre-existing failure unrelated to this change (`test_generates_correct_count` needs root to create `/var/lib/rhcsa-simulator`; fails identically on `master`).
- [x] `python3 -m py_compile` on all touched files.
- [ ] Manual smoke test on a real RHEL/Rocky VM as root: `--quick`, `--practice`, `--adaptive`, and learn mode's practice jump each open the panel URL; `--no-gui` suppresses it in all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DPog6hy3KDM1wBN4pc3HZ