### PR TITLE
Fix broken exam task panel from a bad merge conflict resolution

### DIFF
--- a/core/task_gui.py
+++ b/core/task_gui.py
@@ -492,11 +492,23 @@ def start_for_session(session, controller=None, port=DEFAULT_PORT,
         return (None, [])
 
 
-def start_for_session(session, port=DEFAULT_PORT, bind='0.0.0.0'):
-    """Start a panel backed by a live session exposing a `.tasks` list.
+class _TaskListSession:
+    """Minimal `.tasks` provider so start_for_tasks() can reuse
+    start_for_session() for a plain task list — quick/practice/adaptive/learn
+    have no ExamSession, just the tasks themselves."""
+
+    def __init__(self, get_tasks):
+        self._get_tasks = get_tasks
+
+    @property
+    def tasks(self):
+        return self._get_tasks()
+
+
+def start_for_tasks(get_tasks, port=DEFAULT_PORT, bind='0.0.0.0'):
+    """Start a panel backed by a callable returning the current task list.
     Never raises."""
-    return start_for_tasks(lambda: getattr(session, 'tasks', []),
-                            port=port, bind=bind)
+    return start_for_session(_TaskListSession(get_tasks), port=port, bind=bind)
 
 
 def open_panel(tasks, port, bind='0.0.0.0'):

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -182,4 +182,4 @@ class TestCLIDispatch:
                 adaptive=False,
             )
             main()
-            mock_quick.assert_called_once_with("all", gui_port=8080, gui_bind='0.0.0.0')
+            mock_quick.assert_called_once_with("all", gui_port=None, gui_bind='127.0.0.1')


### PR DESCRIPTION
## Summary
- **This is a real bug currently on `master`, not just a test failure.** Merging #87 (panel submit/results/disputes — adds `controller=` to `TaskPanel`/`start_for_session` plus an auth token) together with #88 (panel-by-default everywhere — adds `start_for_tasks()`/`open_panel()`/`close_panel()`) left **two definitions of `start_for_session()`** in `core/task_gui.py`. The second (2-arg) one silently overwrote the richer 4-arg one that `core/exam.py` actually calls with `controller=self.controller`.
- Net effect: **every real `--exam` launch currently raises `TypeError: start_for_session() got an unexpected keyword argument 'controller'`** the moment it tries to start the task panel. The stale duplicate also called a `start_for_tasks()` that no longer existed, which broke `open_panel()`/`close_panel()` too — so quick/practice/adaptive/learn panels were broken the same way.
- Fix: remove the duplicate/dead `start_for_session`, and reintroduce `start_for_tasks()` as a thin wrapper around the *one* real `start_for_session()` (via a minimal `_TaskListSession` shim) so plain-task-list callers share the exact same panel implementation `exam.py` uses instead of a second parallel one.
- Also fixes a `test_quick_flag` assertion left over from the same merge that expected the wrong `gui`/`gui_bind` fixture defaults (it was asserting stale hardcoded values instead of the fixture's actual `gui=None, gui_bind='127.0.0.1'`).

## Test plan
- [x] `pytest`: 411 passed, 0 failed (previously 7 failing on `master` at `ec54726`, including `test_start_for_session_never_raises`).
- [x] `python3 -m py_compile core/task_gui.py`.
- [ ] Manual: `rhcsa-simulator --exam` on a real box no longer throws when the panel starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DPog6hy3KDM1wBN4pc3HZ