### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,97 @@
+name: Bug report
+description: A task, checker, or the simulator itself is doing something wrong.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing this — real bug reports from candidates are how the
+        task catalog gets more exam-accurate over time.
+
+        **If a specific check just scored you wrong on a task you believe you
+        completed correctly**, use the built-in dispute flow instead of this
+        form: in **Result History**, open the task and press **`d`**. It
+        automatically captures live evidence (`ls -Z`, `getfacl`, `lsblk -f`,
+        etc.) and an AI reviewer inspects the exact validator line — that gets
+        looked at faster and with better evidence than a manual report can.
+        Only use this form for disputes if the in-app flow isn't available to
+        you (e.g. `gh` isn't set up and you have no browser).
+
+  - type: dropdown
+    id: where
+    attributes:
+      label: Where did you encounter this?
+      description: Which mode were you in when you hit the bug?
+      options:
+        - Mock Exam (--exam / task panel)
+        - Quick Practice (--quick)
+        - Practice Mode (--practice CATEGORY)
+        - Adaptive Mode (--adaptive, SM-2 spaced repetition)
+        - Learn Mode (--learn)
+        - Result History (reviewing or disputing a past result)
+        - Setup menu (practice disks, Reset Machine, NFS server, link second machine)
+        - Boot Rescue Lab
+        - Installation (install.sh)
+        - Something else / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: task_id
+    attributes:
+      label: Task ID / category (if known)
+      description: >-
+        Shown in the task detail view or Result History. Run
+        `rhcsa-simulator --list-categories` if you only know the category
+        name. Leave blank if this isn't about a specific task.
+      placeholder: e.g. sudo_002, or "users_groups"
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened?
+      description: Be as specific as you can — exact commands, exact output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps if possible, from a fresh session/reset.
+      placeholder: |
+        1. sudo rhcsa-simulator --practice users_groups
+        2. Complete the task by doing X
+        3. Validate — see wrong result
+
+  - type: textarea
+    id: validation_output
+    attributes:
+      label: Validation output / error message
+      description: Paste terminal output. It'll be rendered as a code block automatically.
+      render: shell
+
+  - type: input
+    id: environment
+    attributes:
+      label: OS / environment
+      description: OS + version, and whether it's a VM you can throw away.
+      placeholder: e.g. Rocky Linux 10.2, VirtualBox VM
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I'm on the latest version (`git pull` before reproducing)
+          required: false
+        - label: I searched existing issues and this isn't a duplicate
+          required: false

--- a/.github/ISSUE_TEMPLATE/02-checker-dispute.yml
+++ b/.github/ISSUE_TEMPLATE/02-checker-dispute.yml
@@ -1,0 +1,83 @@
+name: Checker dispute (manual)
+description: >-
+  A validator scored you wrong on a task, and the in-app dispute flow isn't
+  available to you.
+title: "[Dispute]: "
+labels: ["checker-dispute"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Use this only as a fallback.** The built-in flow — **Result
+        History**, open the task, press **`d`** — automatically captures live
+        system-state evidence and points the AI reviewer at the exact
+        `validate()` line, which gets your dispute a much faster and better-
+        evidenced review. Use this manual form only if `gh` isn't set up on
+        your box and you have no browser to use the pre-filled issue link the
+        app prints instead.
+
+  - type: dropdown
+    id: where
+    attributes:
+      label: Where did you encounter this?
+      options:
+        - Mock Exam (--exam / task panel)
+        - Quick Practice (--quick)
+        - Practice Mode (--practice CATEGORY)
+        - Adaptive Mode (--adaptive, SM-2 spaced repetition)
+        - Result History (reviewing a past result)
+        - Something else / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: task_id
+    attributes:
+      label: Task ID
+      description: Shown in the task detail view or Result History.
+      placeholder: e.g. sudo_002
+    validations:
+      required: true
+
+  - type: input
+    id: score
+    attributes:
+      label: Score you received
+      placeholder: e.g. 3/10 points (30%) - FAIL
+
+  - type: input
+    id: checker_source
+    attributes:
+      label: Checker source (if you know it)
+      description: File, class, and validate() line — makes the review much faster.
+      placeholder: e.g. tasks/users_groups.py -> ConfigureSudoTask.validate() around line 586
+
+  - type: textarea
+    id: disputed_checks
+    attributes:
+      label: Which check(s) do you believe are wrong?
+      description: Copy the exact line(s) from the validation output.
+      placeholder: "✗ [0/2pt] User 'operator84' does not exist"
+    validations:
+      required: true
+
+  - type: textarea
+    id: argument
+    attributes:
+      label: Why do you believe the checker is wrong?
+      description: What did you actually do, and why should it have passed (or not passed)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence — live command output
+      description: >-
+        Paste whatever read-only output backs up your argument (`getent
+        passwd`, `ls -Z`, `getfacl`, `systemctl status`, the contents of a
+        config file, etc.). This stands in for what the in-app tool would
+        have captured automatically.
+      render: shell
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/03-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature-request.yml
@@ -1,0 +1,55 @@
+name: Feature request
+description: Suggest a new task, mode, or capability.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Task-catalog gaps are especially useful — "EX200 v10 covers X and
+        there's no task for it" is exactly the kind of report that improves
+        exam coverage.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's missing, or what problem does this solve?
+      description: >-
+        E.g. a domain/category with too few tasks, an EX200 objective bullet
+        with no coverage, a workflow the simulator makes awkward.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to see?
+      description: Be as concrete as you can — an example task, a command, a menu option.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: where
+    attributes:
+      label: Where would this fit? (if applicable)
+      options:
+        - Mock Exam (--exam / task panel)
+        - Quick Practice (--quick)
+        - Practice Mode (--practice CATEGORY)
+        - Adaptive Mode (--adaptive, SM-2 spaced repetition)
+        - Learn Mode (--learn)
+        - Setup menu
+        - Boot Rescue Lab
+        - Not tied to a specific mode
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Optional — anything you tried as a workaround.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to Red Hat's official EX200 objectives, prior discussion, etc.

--- a/.github/ISSUE_TEMPLATE/04-lab-setup.yml
+++ b/.github/ISSUE_TEMPLATE/04-lab-setup.yml
@@ -1,0 +1,60 @@
+name: Installation / lab setup problem
+description: install.sh, the exam task panel, practice disks, or the Boot Rescue Lab isn't working.
+title: "[Setup]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For task-specific problems (a checker or a task's starting state is
+        wrong), use **Bug report** instead — this template is for getting the
+        simulator itself running.
+
+  - type: dropdown
+    id: step
+    attributes:
+      label: Which step is failing?
+      options:
+        - install.sh (initial install)
+        - Launching the simulator (sudo rhcsa-simulator ...)
+        - Exam task panel (--gui / browser window)
+        - Practice disks (Setup menu, loop devices)
+        - Reset Machine
+        - Configure remote NFS server
+        - Link second lab machine / Boot Rescue Lab
+        - Progress snapshot (export/import code)
+        - Something else
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: OS / environment
+      description: OS + version, VM or bare metal, hypervisor if relevant.
+      placeholder: e.g. Rocky Linux 10.2, fresh VirtualBox VM, minimal install
+    validations:
+      required: true
+
+  - type: input
+    id: command
+    attributes:
+      label: Exact command you ran
+      placeholder: e.g. sudo ./install.sh --yes
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Full output / error message
+      description: The more complete the better — don't trim unless it's genuinely huge.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you already tried?
+      description: >-
+        Check the README's Troubleshooting section and Package & service
+        requirements table first — link or mention what you already checked.

--- a/.github/ISSUE_TEMPLATE/05-question.yml
+++ b/.github/ISSUE_TEMPLATE/05-question.yml
@@ -1,0 +1,32 @@
+name: Question
+description: Something is unclear, or you're not sure if it's a bug.
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: dropdown
+    id: where
+    attributes:
+      label: What are you asking about?
+      options:
+        - Mock Exam (--exam / task panel)
+        - Quick Practice (--quick)
+        - Practice Mode (--practice CATEGORY)
+        - Adaptive Mode (--adaptive, SM-2 spaced repetition)
+        - Learn Mode (--learn)
+        - Setup / installation
+        - Boot Rescue Lab
+        - Progress snapshots (export/import code)
+        - Something else / general
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Anything that helps answer it — what you've tried, what you expected, relevant output.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Checker dispute (in-app — preferred)
+    url: https://github.com/TroggoMan/rhcsa-simulator#disputing-a-validator-result-ai-checker-disputes
+    about: >-
+      Think a specific check scored you wrong? File it from Result History
+      (press d on a task) instead of opening an issue — it auto-captures
+      evidence and gets a much faster, better-informed review.
+  - name: Troubleshooting section (README)
+    url: https://github.com/TroggoMan/rhcsa-simulator#troubleshooting
+    about: Check here first for install/launch problems — several common ones are already documented.


### PR DESCRIPTION
## Summary
- Adds 5 issue forms (bug report, checker dispute, feature request, lab/install setup, question) + a config.yml disabling blank issues.
- Built from patterns in closed issues (#42, #66, #76, #91) — most reports were informal bug descriptions or auto-generated checker disputes.
- Every template that makes sense to asks **where** the candidate was (Mock Exam, Quick Practice, Practice Mode, Adaptive Mode, Learn Mode, Setup, Boot Rescue Lab) since that context was consistently missing from past reports.
- Checker dispute template steers people to the in-app `d` flow first (auto-captures evidence) and is a manual fallback mirroring its structure for when `gh`/browser access isn't available.

## Test plan
- [ ] Open "New issue" on GitHub and confirm all 5 templates + the config render correctly