### PR TITLE
Claude workflows: reaction lifecycle, private whitelist, self-serve triggering

### DIFF
--- a/.github/scripts/react.sh
+++ b/.github/scripts/react.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Maintain ONE "current state" emoji reaction from the Actions bot on an issue
+# or PR, so the Claude workflows visibly signal where a run is:
+#
+#   seen     👀  gate accepted the trigger, run is queued
+#   running  🚀  Claude is actually working it
+#   success  🎉  finished cleanly (PR opened / review posted)
+#   paused   😕  stopped on the usage limit, auto-resume scheduled
+#   failure  👎  real (non-limit) failure, or auto-resume gave up
+#
+# Each call removes whatever lifecycle reaction the bot left before and adds
+# the new one, so exactly one bot reaction is on the item at a time. Human
+# reactions (and the bot's own reaction on a specific comment) are untouched.
+#
+# Usage: react.sh <issue-or-pr-number> <seen|running|success|paused|failure>
+# Env:   GH_TOKEN (required), GITHUB_REPOSITORY (auto-set by Actions)
+set -euo pipefail
+
+num="${1:?issue/PR number required}"
+state="${2:?state required}"
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
+
+case "$state" in
+  seen)    want=eyes ;;
+  running) want=rocket ;;
+  success) want=hooray ;;
+  paused)  want=confused ;;
+  failure) want='-1' ;;
+  *) echo "react.sh: unknown state '$state'" >&2; exit 2 ;;
+esac
+
+bot='github-actions[bot]'
+lifecycle='eyes rocket hooray confused -1'
+
+# Drop stale lifecycle reactions from the bot (keep the one we're about to set
+# if it's already there).
+while read -r id content; do
+  [ -n "${id:-}" ] || continue
+  case " $lifecycle " in *" $content "*) : ;; *) continue ;; esac
+  [ "$content" = "$want" ] && continue
+  gh api --method DELETE "repos/$repo/issues/$num/reactions/$id" >/dev/null 2>&1 || true
+done < <(gh api --paginate "repos/$repo/issues/$num/reactions" \
+           --jq ".[] | select(.user.login == \"$bot\") | \"\(.id) \(.content)\"" 2>/dev/null || true)
+
+gh api --method POST "repos/$repo/issues/$num/reactions" -f content="$want" >/dev/null
+echo "react: #$num -> $state ($want)"

--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -5,11 +5,19 @@ name: Claude issue worker
 # the issue, implements the change across the repo, runs the tests, and opens a
 # PR that closes the issue.
 #
-# Two ways to trigger it — RESTRICTED TO THE REPO OWNER (TroggoMan). Anyone
-# may open issues, but only the owner can hand one to Claude (the
-# checker-dispute workflow is separate and stays fully automatic):
-#   * Add the  claude  label to an issue, OR
-#   * Comment  @claude  on an issue.
+# Ways to trigger it:
+#   * The owner (TroggoMan) adds the  claude  label to any issue, OR
+#   * The owner comments  @claude  on an issue, OR
+#   * A WHITELISTED user opens an issue that carries a trigger label
+#     (bug / enhancement — the issue forms apply these automatically).
+#     See ISSUE_TRIGGER_WHITELIST / ISSUE_TRIGGER_LABELS below; edit those
+#     lists to change who and which labels qualify.
+#
+# Whichever path fires, the triggering comment (or the issue itself) gets an
+# 👀 reaction immediately so it's obvious the run was picked up — that ack
+# does NOT wait behind the shared Claude usage-budget queue.
+#
+# The checker-dispute workflow is separate and stays fully automatic.
 #
 # NOTE: label/mention-triggered workflows run from the DEFAULT branch, so this
 # file must be merged to the default branch before the trigger will fire.
@@ -30,11 +38,15 @@ on:
   issue_comment:
     types: [created]
 
-# Serialize all Claude runs (fresh + resumes) — they share one subscription
-# budget, so parallel runs would just trip the limit for each other.
-concurrency:
-  group: claude-work
-  cancel-in-progress: false
+env:
+  # GitHub usernames pre-authorised to hand Claude a fresh issue just by
+  # opening it with a trigger label. The repo owner is included so their own
+  # bug reports auto-start too; remove a name to revoke that.
+  ISSUE_TRIGGER_WHITELIST: '["TroggoMan","KirMozor"]'
+  # Labels that, on a whitelisted user's issue, hand it to Claude. The issue
+  # forms apply "bug" (bug report, lab setup) and "enhancement" (feature
+  # request) on their own. "claude" stays owner-only and is handled separately.
+  ISSUE_TRIGGER_LABELS: '["bug","enhancement"]'
 
 permissions:
   contents: write
@@ -44,16 +56,86 @@ permissions:
   id-token: write
 
 jobs:
+  # Decide whether this event should start a Claude run. Kept in one place so
+  # the ack and the worker can't drift apart. Event fields are read through
+  # env (never inlined into the script) so a crafted comment body can't inject
+  # shell.
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.check.outputs.go }}
+    steps:
+      - id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          ACTOR: ${{ github.actor }}
+          LABEL: ${{ github.event.label.name }}
+          IS_PR: ${{ github.event.issue.pull_request != null }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          WHITELIST: ${{ env.ISSUE_TRIGGER_WHITELIST }}
+          TRIGGER_LABELS: ${{ env.ISSUE_TRIGGER_LABELS }}
+          OWNER: TroggoMan
+        run: |
+          set -euo pipefail
+          go=false
+
+          # Owner comments @claude on an issue (not a PR — claude-pr-review.yml
+          # owns that side).
+          if [ "$EVENT_NAME" = "issue_comment" ] \
+             && [ "$IS_PR" != "true" ] \
+             && [ "$ACTOR" = "$OWNER" ] \
+             && printf '%s' "$COMMENT_BODY" | grep -qF '@claude'; then
+            go=true
+          fi
+
+          if [ "$EVENT_NAME" = "issues" ] && [ "$ACTION" = "labeled" ]; then
+            # Owner hands an issue over with the `claude` label.
+            if [ "$LABEL" = "claude" ] && [ "$ACTOR" = "$OWNER" ]; then
+              go=true
+            fi
+            # Whitelisted author + a trigger label on their issue.
+            if printf '%s' "$TRIGGER_LABELS" | jq -e --arg l "$LABEL" 'any(.[]; . == $l)' >/dev/null \
+               && printf '%s' "$WHITELIST" | jq -e --arg u "$ISSUE_AUTHOR" 'any(.[]; . == $u)' >/dev/null; then
+              go=true
+            fi
+          fi
+
+          echo "go=$go" >> "$GITHUB_OUTPUT"
+          echo "gate: go=$go (event=$EVENT_NAME action=${ACTION:-} label=${LABEL:-} actor=$ACTOR author=${ISSUE_AUTHOR:-})"
+
+  # Immediate, visible acknowledgement. Separate from `work` and deliberately
+  # NOT in the claude-work concurrency group, so the reaction lands right away
+  # even when another Claude run is holding the budget queue.
+  react:
+    needs: gate
+    if: needs.gate.outputs.go == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add an 👀 reaction to the trigger
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            gh api --method POST "repos/$REPO/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
+          else
+            gh api --method POST "repos/$REPO/issues/${{ github.event.issue.number }}/reactions" -f content=eyes
+          fi
+
   work:
-    # Owner-only: strangers may open issues, but only TroggoMan can trigger a
-    # Claude run (via the "claude" label or an @claude comment). Ignore comments
-    # on pull requests (issue_comment fires for both).
-    if: >-
-      github.actor == 'TroggoMan' &&
-      (
-        (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude') ||
-        (github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.comment.body, '@claude'))
-      )
+    needs: gate
+    if: needs.gate.outputs.go == 'true'
+    # Serialize the actual Claude runs (fresh + resumes + sweeps) — they share
+    # one subscription budget, so parallel runs would just trip the limit for
+    # each other. Only this job joins the queue; gate/react run immediately.
+    concurrency:
+      group: claude-work
+      cancel-in-progress: false
     uses: ./.github/workflows/claude-worker.yml
     with:
       issue_number: ${{ github.event.issue.number }}

--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -10,12 +10,15 @@ name: Claude issue worker
 #   * The owner comments  @claude  on an issue, OR
 #   * A WHITELISTED user opens an issue that carries a trigger label
 #     (bug / enhancement — the issue forms apply these automatically).
-#     See ISSUE_TRIGGER_WHITELIST / ISSUE_TRIGGER_LABELS below; edit those
-#     lists to change who and which labels qualify.
 #
-# Whichever path fires, the triggering comment (or the issue itself) gets an
-# 👀 reaction immediately so it's obvious the run was picked up — that ack
-# does NOT wait behind the shared Claude usage-budget queue.
+# The whitelist is the repo secret  CLAUDE_ISSUE_WHITELIST  — a JSON array of
+# GitHub usernames, e.g.  ["TroggoMan","KirMozor"]  — so it isn't visible in
+# this file or its history. Edit it under Settings → Secrets and variables →
+# Actions, or:  gh secret set CLAUDE_ISSUE_WHITELIST --body '["a","b"]'
+# The trigger labels are not sensitive and stay in ISSUE_TRIGGER_LABELS below.
+#
+# Reactions track the run on the issue (and the triggering comment gets 👀):
+#   👀 seen/queued   🚀 running   🎉 done   😕 paused (usage limit)   👎 failed
 #
 # The checker-dispute workflow is separate and stays fully automatic.
 #
@@ -39,10 +42,6 @@ on:
     types: [created]
 
 env:
-  # GitHub usernames pre-authorised to hand Claude a fresh issue just by
-  # opening it with a trigger label. The repo owner is included so their own
-  # bug reports auto-start too; remove a name to revoke that.
-  ISSUE_TRIGGER_WHITELIST: '["TroggoMan","KirMozor"]'
   # Labels that, on a whitelisted user's issue, hand it to Claude. The issue
   # forms apply "bug" (bug report, lab setup) and "enhancement" (feature
   # request) on their own. "claude" stays owner-only and is handled separately.
@@ -74,7 +73,7 @@ jobs:
           IS_PR: ${{ github.event.issue.pull_request != null }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
-          WHITELIST: ${{ env.ISSUE_TRIGGER_WHITELIST }}
+          WHITELIST: ${{ secrets.CLAUDE_ISSUE_WHITELIST }}
           TRIGGER_LABELS: ${{ env.ISSUE_TRIGGER_LABELS }}
           OWNER: TroggoMan
         run: |
@@ -95,9 +94,15 @@ jobs:
             if [ "$LABEL" = "claude" ] && [ "$ACTOR" = "$OWNER" ]; then
               go=true
             fi
-            # Whitelisted author + a trigger label on their issue.
+            # Whitelisted author + a trigger label on their issue. Tolerate an
+            # unset/malformed secret by treating the whitelist as empty.
+            wl="${WHITELIST:-[]}"
+            printf '%s' "$wl" | jq -e 'type == "array"' >/dev/null 2>&1 || {
+              echo "::warning::CLAUDE_ISSUE_WHITELIST is not a JSON array; treating as empty"
+              wl='[]'
+            }
             if printf '%s' "$TRIGGER_LABELS" | jq -e --arg l "$LABEL" 'any(.[]; . == $l)' >/dev/null \
-               && printf '%s' "$WHITELIST" | jq -e --arg u "$ISSUE_AUTHOR" 'any(.[]; . == $u)' >/dev/null; then
+               && printf '%s' "$wl" | jq -e --arg u "$ISSUE_AUTHOR" 'any(.[]; . == $u)' >/dev/null; then
               go=true
             fi
           fi
@@ -106,33 +111,35 @@ jobs:
           echo "gate: go=$go (event=$EVENT_NAME action=${ACTION:-} label=${LABEL:-} actor=$ACTOR author=${ISSUE_AUTHOR:-})"
 
   # Immediate, visible acknowledgement. Separate from `work` and deliberately
-  # NOT in the claude-work concurrency group, so the reaction lands right away
-  # even when another Claude run is holding the budget queue.
-  react:
+  # NOT in the claude-work concurrency group, so 👀 lands right away even when
+  # another Claude run is holding the budget queue. `work` waits on this so the
+  # reaction order stays seen -> running.
+  ack:
     needs: gate
     if: needs.gate.outputs.go == 'true'
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
-      - name: Add an 👀 reaction to the trigger
+      - uses: actions/checkout@v5
+      - name: React 👀 seen
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/react.sh "${{ github.event.issue.number }}" seen
+      - name: Also 👀 the triggering comment
+        if: github.event_name == 'issue_comment'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            gh api --method POST "repos/$REPO/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
-          else
-            gh api --method POST "repos/$REPO/issues/${{ github.event.issue.number }}/reactions" -f content=eyes
-          fi
+        run: gh api --method POST "repos/$REPO/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
 
   work:
-    needs: gate
-    if: needs.gate.outputs.go == 'true'
+    needs: [gate, ack]
+    if: >-
+      !cancelled() && needs.gate.outputs.go == 'true'
     # Serialize the actual Claude runs (fresh + resumes + sweeps) — they share
     # one subscription budget, so parallel runs would just trip the limit for
-    # each other. Only this job joins the queue; gate/react run immediately.
+    # each other. Only this job joins the queue; gate/ack run immediately.
     concurrency:
       group: claude-work
       cancel-in-progress: false

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -14,6 +14,9 @@ name: Claude PR review
 # and contents:read — a prompt-injection in the PR can at worst produce a
 # misleading review comment, it cannot touch the repo.
 #
+# Reactions track the run on the PR (and the triggering comment gets 👀):
+#   👀 seen/queued   🚀 running   🎉 review posted   👎 failed
+#
 # NOTE: comment-triggered workflows run from the DEFAULT branch, so this file
 # must be merged to master before the trigger will fire.
 #
@@ -26,15 +29,6 @@ on:
   issue_comment:
     types: [created]
 
-# Share the one Claude subscription budget with the issue worker / resumer /
-# sweeper so runs serialize instead of tripping each other's usage limit. A
-# review queued behind a long issue run can be dropped if another Claude run
-# arrives before it starts (see claude-sweep.yml) — if that happens, just
-# comment @claude again.
-concurrency:
-  group: claude-work
-  cancel-in-progress: false
-
 permissions:
   contents: read
   pull-requests: write
@@ -43,15 +37,46 @@ permissions:
   id-token: write
 
 jobs:
-  review:
-    # Owner-only, PR comments only (issue_comment fires for issues and PRs;
-    # the issue side is handled by claude-issue.yml), and only when the
-    # comment actually mentions @claude.
+  # Immediate 👀 — not in the claude-work concurrency group, so it lands even
+  # while another Claude run holds the budget queue. `review` waits on this so
+  # the reaction order stays seen -> running.
+  ack:
     if: >-
       github.actor == 'TroggoMan' &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: React 👀 seen
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/react.sh "${{ github.event.issue.number }}" seen
+      - name: Also 👀 the triggering comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: gh api --method POST "repos/$REPO/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
+
+  review:
+    needs: ack
+    # Same guard as `ack` (issue_comment fires for issues and PRs; the issue
+    # side is claude-issue.yml). `!cancelled()` lets this run even if the ack
+    # job hiccups.
+    if: >-
+      !cancelled() &&
+      github.actor == 'TroggoMan' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    # Share the one Claude subscription budget with the issue worker / resumer
+    # / sweeper so runs serialize instead of tripping each other's usage limit.
+    # A review queued behind a long issue run can be dropped if another Claude
+    # run arrives before it starts (see claude-sweep.yml) — if that happens,
+    # just comment @claude again.
+    concurrency:
+      group: claude-work
+      cancel-in-progress: false
     steps:
       - name: Check out the base repo
         uses: actions/checkout@v5
@@ -64,6 +89,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr checkout ${{ github.event.issue.number }}
+
+      - name: React 🚀 running
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/react.sh "${{ github.event.issue.number }}" running
 
       - name: AI review of the PR
         uses: anthropics/claude-code-action@v1
@@ -116,3 +146,14 @@ jobs:
             merge. Your output is the review comment only.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: React with the outcome
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            bash .github/scripts/react.sh "${{ github.event.issue.number }}" success
+          else
+            bash .github/scripts/react.sh "${{ github.event.issue.number }}" failure
+          fi

--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -44,6 +44,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: React 🚀 running
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/react.sh "${{ inputs.issue_number }}" running
+
       # Remove the pending label up front so the next scheduler tick doesn't
       # start a duplicate resume while this one is still running. If we hit
       # the limit again, the save step below re-adds it with fresh state.
@@ -122,6 +127,7 @@ jobs:
         run: python3 .github/scripts/claude_usage_limit.py "${{ steps.claude.outputs.execution_file }}"
 
       - name: Save progress and schedule auto-resume
+        id: save
         if: steps.limit.outputs.rate_limited == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -177,6 +183,19 @@ jobs:
             --color FBCA04 || true
           gh issue edit "$ISSUE" --add-label claude-resume-pending
           echo "Paused. Resume scheduled after $RESET_HUMAN."
+
+      - name: React with the outcome
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ steps.claude.outcome }}" = "success" ]; then
+            bash .github/scripts/react.sh "${{ inputs.issue_number }}" success
+          elif [ "${{ steps.limit.outputs.rate_limited }}" = "true" ] && [ "${{ steps.save.outcome }}" = "success" ]; then
+            bash .github/scripts/react.sh "${{ inputs.issue_number }}" paused
+          else
+            bash .github/scripts/react.sh "${{ inputs.issue_number }}" failure
+          fi
 
       - name: Fail on real (non-limit) errors
         if: steps.claude.outcome == 'failure' && steps.limit.outputs.rate_limited != 'true'


### PR DESCRIPTION
Builds on #109. Three things.

## 1. Full reaction lifecycle

`.github/scripts/react.sh <number> <state>` keeps **one** bot reaction on the issue/PR at a time (lists existing, drops the stale one, adds the new):

| state | emoji | when |
|---|---|---|
| `seen` | 👀 | gate accepted the trigger, run is queued |
| `running` | 🚀 | Claude is actually working it |
| `success` | 🎉 | PR opened / review posted |
| `paused` | 😕 | stopped on the usage limit, auto-resume scheduled |
| `failure` | 👎 | real (non-limit) failure, or auto-resume gave up |

- **`claude-issue.yml`** — the old `react` job is now `ack`: sets 👀 on the issue *and* 👀 on the triggering comment. `work` waits on `ack` so the order is always seen → running.
- **`claude-worker.yml`** — 🚀 right after checkout; a final `always()` step reads the `claude` / `limit` / `save` step outcomes and picks 🎉 / 😕 / 👎. Because `resume` and `sweep` both call this reusable workflow, they get the lifecycle too.
- **`claude-pr-review.yml`** — restructured to match: `ack` job outside the `claude-work` concurrency group (so 👀 is instant), `review` job carries the concurrency at job level, plus 🚀 and an outcome step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)